### PR TITLE
Open Kerchunk refs as Virtual Dataset

### DIFF
--- a/virtualizarr/kerchunk.py
+++ b/virtualizarr/kerchunk.py
@@ -38,6 +38,7 @@ class FileType(AutoName):
     tiff = auto()
     fits = auto()
     zarr = auto()
+    kerchunk = auto()
 
 
 class NumpyEncoder(json.JSONEncoder):
@@ -117,7 +118,6 @@ def _automatically_determine_filetype(
     fpath = _fsspec_openfile_from_filepath(
         filepath=filepath, reader_options=reader_options
     )
-
     if file_extension == ".nc":
         # based off of: https://github.com/TomNicholas/VirtualiZarr/pull/43#discussion_r1543415167
         magic = fpath.read()

--- a/virtualizarr/utils.py
+++ b/virtualizarr/utils.py
@@ -41,7 +41,10 @@ def _fsspec_openfile_from_filepath(
     protocol = universal_filepath.protocol
 
     if protocol == "":
-        fpath = fsspec.open(filepath, "rb").open()
+        # import pdb; pdb.set_trace()
+        fpath = fsspec.open(universal_filepath, "rb")
+        if universal_filepath.is_file():
+            fpath = fpath.open()
 
     elif protocol in ["s3"]:
         s3_anon_defaults = {"key": "", "secret": "", "anon": True}
@@ -53,8 +56,9 @@ def _fsspec_openfile_from_filepath(
 
             # using dict merge operator to add in defaults if keys are not specified
             storage_options = s3_anon_defaults | storage_options
-
-        fpath = fsspec.filesystem(protocol, **storage_options).open(filepath)
+        fpath = fsspec.filesystem(protocol, **storage_options)
+        if universal_filepath.is_file():
+            fpath = fpath.open(filepath)
 
     else:
         raise NotImplementedError(

--- a/virtualizarr/utils.py
+++ b/virtualizarr/utils.py
@@ -41,7 +41,6 @@ def _fsspec_openfile_from_filepath(
     protocol = universal_filepath.protocol
 
     if protocol == "":
-        # import pdb; pdb.set_trace()
         fpath = fsspec.open(universal_filepath, "rb")
         if universal_filepath.is_file():
             fpath = fpath.open()


### PR DESCRIPTION
- [x] Closes https://github.com/TomNicholas/VirtualiZarr/issues/118
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `changelog.md`
- [ ] New functions/methods are listed in `api.rst`

Start of PR to address https://github.com/TomNicholas/VirtualiZarr/issues/118.

Lots of open questions! 
- How should we read `.parquet`files into `KerchunkStoreRefs` to pass into **dataset_from_kerchunk_refs**
- RT'ing json seems to loose `_ARRAY_DIMENSIONS`

Would love some feedback @jsignell!