### PR TITLE
Add dunder version to top-level __init__.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,11 +61,7 @@ requires = [
 ]
 
 [tool.setuptools_scm]
-write_to = "virtualizarr/_version.py"
-write_to_template = '''
-# Do not change! Do not track in version control!
-__version__ = "{version}"
-'''
+fallback_version = "9999"
 
 [tool.setuptools.packages.find]
 exclude = ["docs", "tests", "tests.*", "docs.*"]

--- a/virtualizarr/__init__.py
+++ b/virtualizarr/__init__.py
@@ -1,3 +1,12 @@
 from .manifests import ChunkManifest, ManifestArray  # type: ignore # noqa
 from .xarray import VirtualiZarrDatasetAccessor  # type: ignore # noqa
 from .xarray import open_virtual_dataset  # noqa: F401
+
+from importlib.metadata import version as _version
+
+try:
+    __version__ = _version("virtualizarr")
+except Exception:
+    # Local copy or not installed with setuptools.
+    # Disable minimum version checks on downstream libraries.
+    __version__ = "9999"


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

This PR makes the following work:

```
python -c "import virtualizarr; print(virtualizarr.__version__)"
```

Welcome any feedback, in particular if there's a reason to use setuptools_scm's `write_to` rather than `importlib.metadata`.
- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
