### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,9 +51,9 @@ jobs:
   test-built-dist:
     needs: build-artifacts
     runs-on: ubuntu-latest
-    # environment: # TODO: Have a VirtualiZarr maintainer create a test-release environment
-    #   name: test-release
-    #   url: https://test.pypi.org/p/virtualizarr
+    environment:
+      name: test-release
+      url: https://test.pypi.org/p/virtualizarr
     permissions:
       id-token: write # this permission is mandatory for trusted publishing
     steps:
@@ -87,9 +87,9 @@ jobs:
     needs: test-built-dist
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
-    # environment: # TODO: Have a VirtualiZarr maintainer create a release environment
-    #   name: release
-    #   url: https://pypi.org/p/virtualizarr
+    environment:
+      name: release
+      url: https://pypi.org/p/virtualizarr
     permissions:
       id-token: write # this permission is mandatory for trusted publishing
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,18 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install setuptools setuptools-scm wheel twine check-manifest
-      - name: Build tarball and wheels
-        run: |
           git clean -xdf
           git restore -SW .
+      # This step is only necessary for testing purposes and for TestPyPI
+      - name: Fix up version string for TestPyPI
+        if: ${{ !startsWith(github.ref, 'refs/tags') }}
+        run: |
+          # Change setuptools-scm local_scheme to "no-local-version" so the
+          # local part of the version isn't included, making the version string
+          # compatible with PyPI.
+          sed --in-place "s/guess-next-dev/no-local-version/g" pyproject.toml
+      - name: Build tarball and wheels
+        run: |
           python -m build --sdist --wheel .
       - name: Check built artifacts
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,103 @@
+name: Build distribution
+on:
+  release:
+    types:
+      - published
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build-artifacts:
+    runs-on: ubuntu-latest
+    if: github.repository == 'zarr-developers/VirtualiZarr'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        name: Install Python
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install setuptools setuptools-scm wheel twine check-manifest
+
+      - name: Build tarball and wheels
+        run: |
+          git clean -xdf
+          git restore -SW .
+          python -m build --sdist --wheel .
+
+      - name: Check built artifacts
+        run: |
+          python -m twine check dist/*
+          python -m pip check
+          pwd
+          if [ -f dist/virtualizarr-unknown.tar.gz ]; then
+            echo "❌ INVALID VERSION NUMBER"
+            exit 1xxw
+          else
+            echo "✅ Looks good"
+          fi
+      - uses: actions/upload-artifact@v4
+        with:
+          name: releases
+          path: dist
+
+  test-built-dist:
+    needs: build-artifacts
+    runs-on: ubuntu-latest
+    # environment: # TODO: Have a VirtualiZarr maintainer create a test-release environment
+    #   name: test-release
+    #   url: https://test.pypi.org/p/virtualizarr
+    permissions:
+      id-token: write # this permission is mandatory for trusted publishing
+    steps:
+      - uses: actions/setup-python@v5
+        name: Install Python
+        with:
+          python-version: "3.12"
+      - uses: actions/download-artifact@v4
+        with:
+          name: releases
+          path: dist
+      - name: List contents of built dist
+        run: |
+          ls -ltrh
+          ls -ltrh dist
+
+      - name: Verify the built dist/wheel is valid
+        if: github.event_name == 'push'
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install dist/virtualizarr*.whl
+          python -c "import virtualizarr; print(virtualizarr.__version__)"
+
+      - name: Publish package to TestPyPI
+        uses: pypa/gh-action-pypi-publish@v1.8.14
+        with:
+          repository_url: https://test.pypi.org/legacy/
+          verbose: true
+
+  upload-to-pypi:
+    needs: test-built-dist
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    # environment: # TODO: Have a VirtualiZarr maintainer create a release environment
+    #   name: release
+    #   url: https://pypi.org/p/virtualizarr
+    permissions:
+      id-token: write # this permission is mandatory for trusted publishing
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: releases
+          path: dist
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.8.14
+        with:
+          verbose: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build-artifacts:
     runs-on: ubuntu-latest
@@ -16,30 +19,26 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5.0.0
         name: Install Python
         with:
           python-version: "3.12"
-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install setuptools setuptools-scm wheel twine check-manifest
-
       - name: Build tarball and wheels
         run: |
           git clean -xdf
           git restore -SW .
           python -m build --sdist --wheel .
-
       - name: Check built artifacts
         run: |
-          python -m twine check dist/*
-          python -m pip check
+          python -m twine check --strict dist/*
           pwd
           if [ -f dist/virtualizarr-unknown.tar.gz ]; then
             echo "❌ INVALID VERSION NUMBER"
-            exit 1xxw
+            exit 1
           else
             echo "✅ Looks good"
           fi
@@ -55,9 +54,9 @@ jobs:
       name: test-release
       url: https://test.pypi.org/p/virtualizarr
     permissions:
-      id-token: write # this permission is mandatory for trusted publishing
+      id-token: write
     steps:
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5.0.0
         name: Install Python
         with:
           python-version: "3.12"
@@ -69,19 +68,16 @@ jobs:
         run: |
           ls -ltrh
           ls -ltrh dist
-
       - name: Verify the built dist/wheel is valid
-        if: github.event_name == 'push'
         run: |
           python -m pip install --upgrade pip
           python -m pip install dist/virtualizarr*.whl
           python -c "import virtualizarr; print(virtualizarr.__version__)"
-
       - name: Publish package to TestPyPI
         uses: pypa/gh-action-pypi-publish@v1.8.14
         with:
-          repository_url: https://test.pypi.org/legacy/
-          verbose: true
+          repository-url: https://test.pypi.org/legacy/
+          # verbose: true
 
   upload-to-pypi:
     needs: test-built-dist
@@ -91,7 +87,7 @@ jobs:
       name: release
       url: https://pypi.org/p/virtualizarr
     permissions:
-      id-token: write # this permission is mandatory for trusted publishing
+      id-token: write
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -99,5 +95,3 @@ jobs:
           path: dist
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@v1.8.14
-        with:
-          verbose: true

--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,4 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 virtualizarr/_version.py
+docs/generated/

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,29 @@
+# Contributing
+
+## Contributing documentation
+
+### Build the documentation locally
+
+```bash
+mamba env create -f ci/doc.yml
+mamba activate docs
+cd docs # From project's root
+rm -rf generated
+make clean
+make html
+```
+
+### Access the documentation locally
+
+Open `docs/_build/html/index.html` in a web browser
+
+## Making a release
+
+1. Navigate to the [https://github.com/zarr-developers/virtualizarr/releases](https://github.com/zarr-developers/virtualizarr/releases) release page.
+2. Select draft a new release.
+3. Select 'Choose a tag', then 'create a new tag'
+4. Enter the name for the new tag following the [EffVer](https://jacobtomlinson.dev/effver/) versioning scheme (e.g., releasing v0.2.0 as the next release denotes that “some small effort may be required to make sure this version works for you”).
+4. Click 'Generate Release Notes' to draft notes based on merged pull requests.
+5. Edit the draft release notes for consistency.
+6. Publish the release.
+7. Navigate to the GitHub actions page and approve the deployment to run the PyPI release section in the `release` GitHub actions environment. This requires having privileges set in the [environment protection rules](https://github.com/zarr-developers/VirtualiZarr/settings/environments/3162544968/edit), which currently includes being part of the `virtualizarr-core-devs` GitHub team.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -26,4 +26,3 @@ Open `docs/_build/html/index.html` in a web browser
 4. Click 'Generate Release Notes' to draft notes based on merged pull requests.
 5. Edit the draft release notes for consistency.
 6. Publish the release.
-7. Navigate to the GitHub actions page and approve the deployment to run the PyPI release section in the `release` GitHub actions environment. This requires having privileges set in the [environment protection rules](https://github.com/zarr-developers/VirtualiZarr/settings/environments/3162544968/edit), which currently includes being part of the `virtualizarr-core-devs` GitHub team.

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,4 +83,5 @@ usage
 faq
 api
 releases
+contributing
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ requires = [
 ]
 
 [tool.setuptools_scm]
+local_scheme = "guess-next-dev"
 fallback_version = "9999"
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,11 +61,7 @@ requires = [
 ]
 
 [tool.setuptools_scm]
-write_to = "virtualizarr/_version.py"
-write_to_template = '''
-# Do not change! Do not track in version control!
-__version__ = "{version}"
-'''
+fallback_version = "9999"
 
 [tool.setuptools.packages.find]
 exclude = ["docs", "tests", "tests.*", "docs.*"]

--- a/virtualizarr/__init__.py
+++ b/virtualizarr/__init__.py
@@ -1,3 +1,12 @@
 from .manifests import ChunkManifest, ManifestArray  # type: ignore # noqa
 from .xarray import VirtualiZarrDatasetAccessor  # type: ignore # noqa
 from .xarray import open_virtual_dataset  # noqa: F401
+
+from importlib.metadata import version as _version
+
+try:
+    __version__ = _version("virtualizarr")
+except Exception:
+    # Local copy or not installed with setuptools.
+    # Disable minimum version checks on downstream libraries.
+    __version__ = "9999"


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

This PR adds a GitHub workflow to test distributions using TestPyPI and upload releases to PyPI. (Same as #134 but not off a fork to allow testing the workflow)


- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
