### PR TITLE
Replace np.NaN with np.nan in preparation for numpy 2.0

### DIFF
--- a/virtualizarr/tests/test_kerchunk.py
+++ b/virtualizarr/tests/test_kerchunk.py
@@ -40,7 +40,7 @@ def test_dataset_from_df_refs():
 
     assert da.data.zarray.compressor is None
     assert da.data.zarray.filters is None
-    assert da.data.zarray.fill_value is np.NaN
+    assert da.data.zarray.fill_value is np.nan
     assert da.data.zarray.order == "C"
 
     assert da.data.manifest.dict() == {
@@ -76,7 +76,7 @@ class TestAccessor:
                 chunks=(2, 3),
                 compressor=None,
                 filters=None,
-                fill_value=np.NaN,
+                fill_value=np.nan,
                 order="C",
             ),
         )
@@ -105,7 +105,7 @@ class TestAccessor:
                 chunks=(2, 3),
                 compressor=None,
                 filters=None,
-                fill_value=np.NaN,
+                fill_value=np.nan,
                 order="C",
             ),
         )
@@ -186,7 +186,7 @@ def test_kerchunk_roundtrip_in_memory_no_concat():
             chunks=(2, 2),
             compressor=None,
             filters=None,
-            fill_value=np.NaN,
+            fill_value=np.nan,
             order="C",
         ),
         chunkmanifest=manifest,

--- a/virtualizarr/tests/test_manifests/test_array.py
+++ b/virtualizarr/tests/test_manifests/test_array.py
@@ -46,7 +46,7 @@ class TestManifestArray:
         assert marr.chunks == (2, 3)
         assert marr.dtype == np.dtype("int64")
         assert marr.zarray.compressor is None
-        assert marr.zarray.fill_value is np.NaN
+        assert marr.zarray.fill_value is np.nan
         assert marr.zarray.filters is None
         assert marr.zarray.order == "C"
 

--- a/virtualizarr/tests/test_zarr.py
+++ b/virtualizarr/tests/test_zarr.py
@@ -15,7 +15,7 @@ def test_zarr_v3_roundtrip(tmpdir):
             chunks=(2, 3),
             compressor=None,
             filters=None,
-            fill_value=np.NaN,
+            fill_value=np.nan,
             order="C",
             zarr_format=3,
         ),

--- a/virtualizarr/zarr.py
+++ b/virtualizarr/zarr.py
@@ -43,7 +43,7 @@ class ZArray(BaseModel):
     chunks: tuple[int, ...]
     compressor: str | None = None
     dtype: np.dtype
-    fill_value: float | int | None = np.NaN  # float or int?
+    fill_value: float | int | None = np.nan  # float or int?
     filters: list[dict] | None = None
     order: Literal["C", "F"]
     shape: tuple[int, ...]
@@ -76,7 +76,7 @@ class ZArray(BaseModel):
         # coerce type of fill_value as kerchunk can be inconsistent with this
         fill_value = decoded_arr_refs_zarray["fill_value"]
         if fill_value is None or fill_value == "NaN":
-            fill_value = np.NaN
+            fill_value = np.nan
 
         return ZArray(
             chunks=tuple(decoded_arr_refs_zarray["chunks"]),
@@ -94,7 +94,7 @@ class ZArray(BaseModel):
 
         zarray_dict["dtype"] = encode_dtype(zarray_dict["dtype"])
 
-        if zarray_dict["fill_value"] is np.NaN:
+        if zarray_dict["fill_value"] is np.nan:
             zarray_dict["fill_value"] = None
 
         return zarray_dict
@@ -247,7 +247,7 @@ def metadata_from_zarr_json(filepath: Path) -> tuple[ZArray, list[str], dict]:
     chunk_shape = metadata["chunk_grid"]["configuration"]["chunk_shape"]
 
     if metadata["fill_value"] is None:
-        fill_value = np.NaN
+        fill_value = np.nan
     else:
         fill_value = metadata["fill_value"]
 


### PR DESCRIPTION
See https://numpy.org/devdocs/numpy_2_0_migration_guide.html#main-namespace

- [ ] ~~Closes #xxxx~~
- [ ] ~~Tests added~~
- [ ] ~~Changes are documented in `docs/releases.rst`~~
- [ ] ~~New functions/methods are listed in `api.rst`~~
