### PR TITLE
Mark tests which require network access

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Running Tests
         run: |
-          python -m pytest --cov=./ --cov-report=xml --verbose
+          python -m pytest --run-network-tests --cov=./ --cov-report=xml --verbose
 
       - name: Upload code coverage to Codecov
         uses: codecov/codecov-action@v3.1.4

--- a/virtualizarr/tests/__init__.py
+++ b/virtualizarr/tests/__init__.py
@@ -1,13 +1,38 @@
+import importlib
 import itertools
 
 import numpy as np
 import pytest
+from packaging.version import Version
 
 from virtualizarr.manifests import ChunkManifest, ManifestArray
 from virtualizarr.manifests.manifest import join
 from virtualizarr.zarr import ZArray, ceildiv
 
 network = pytest.mark.network
+
+
+def _importorskip(
+    modname: str, minversion: str | None = None
+) -> tuple[bool, pytest.MarkDecorator]:
+    try:
+        mod = importlib.import_module(modname)
+        has = True
+        if minversion is not None:
+            v = getattr(mod, "__version__", "999")
+            if Version(v) < Version(minversion):
+                raise ImportError("Minimum version not satisfied")
+    except ImportError:
+        has = False
+
+    reason = f"requires {modname}"
+    if minversion is not None:
+        reason += f">={minversion}"
+    func = pytest.mark.skipif(not has, reason=reason)
+    return has, func
+
+
+has_s3fs, requires_s3fs = _importorskip("s3fs")
 
 
 def create_manifestarray(

--- a/virtualizarr/tests/__init__.py
+++ b/virtualizarr/tests/__init__.py
@@ -1,10 +1,13 @@
 import itertools
 
 import numpy as np
+import pytest
 
 from virtualizarr.manifests import ChunkManifest, ManifestArray
 from virtualizarr.manifests.manifest import join
 from virtualizarr.zarr import ZArray, ceildiv
+
+network = pytest.mark.network
 
 
 def create_manifestarray(

--- a/virtualizarr/tests/conftest.py
+++ b/virtualizarr/tests/conftest.py
@@ -16,7 +16,7 @@ def pytest_runtest_setup(item):
     # based on https://stackoverflow.com/questions/47559524
     if "network" in item.keywords and not item.config.getoption("--run-network-tests"):
         pytest.skip(
-            "set --run-network-tests to run test requiring an internet connection"
+            "set --run-network-tests to run tests requiring an internet connection"
         )
 
 

--- a/virtualizarr/tests/conftest.py
+++ b/virtualizarr/tests/conftest.py
@@ -2,6 +2,24 @@ import pytest
 import xarray as xr
 
 
+def pytest_addoption(parser):
+    """Add command-line flags for pytest."""
+    parser.addoption("--run-flaky", action="store_true", help="runs flaky tests")
+    parser.addoption(
+        "--run-network-tests",
+        action="store_true",
+        help="runs tests requiring a network connection",
+    )
+
+
+def pytest_runtest_setup(item):
+    # based on https://stackoverflow.com/questions/47559524
+    if "network" in item.keywords and not item.config.getoption("--run-network-tests"):
+        pytest.skip(
+            "set --run-network-tests to run test requiring an internet connection"
+        )
+
+
 @pytest.fixture
 def netcdf4_file(tmpdir):
     # Set up example xarray dataset

--- a/virtualizarr/tests/test_xarray.py
+++ b/virtualizarr/tests/test_xarray.py
@@ -9,6 +9,7 @@ from xarray.core.indexes import Index
 
 from virtualizarr import open_virtual_dataset
 from virtualizarr.manifests import ChunkManifest, ManifestArray
+from virtualizarr.tests import network
 from virtualizarr.zarr import ZArray
 
 
@@ -273,19 +274,23 @@ class TestCombineUsingIndexes:
 pytest.importorskip("s3fs")
 
 
-@pytest.mark.parametrize(
-    "filetype", ["netcdf4", None], ids=["netcdf4 filetype", "None filetype"]
-)
-@pytest.mark.parametrize("indexes", [None, {}], ids=["None index", "empty dict index"])
-def test_anon_read_s3(filetype, indexes):
-    """Parameterized tests for empty vs supplied indexes and filetypes."""
-    # TODO: Switch away from this s3 url after minIO is implemented.
-    fpath = "s3://carbonplan-share/virtualizarr/local.nc"
-    vds = open_virtual_dataset(fpath, filetype=filetype, indexes=indexes)
+@network
+class TestReadFromS3:
+    @pytest.mark.parametrize(
+        "filetype", ["netcdf4", None], ids=["netcdf4 filetype", "None filetype"]
+    )
+    @pytest.mark.parametrize(
+        "indexes", [None, {}], ids=["None index", "empty dict index"]
+    )
+    def test_anon_read_s3(self, filetype, indexes):
+        """Parameterized tests for empty vs supplied indexes and filetypes."""
+        # TODO: Switch away from this s3 url after minIO is implemented.
+        fpath = "s3://carbonplan-share/virtualizarr/local.nc"
+        vds = open_virtual_dataset(fpath, filetype=filetype, indexes=indexes)
 
-    assert vds.dims == {"time": 2920, "lat": 25, "lon": 53}
-    for var in vds.variables:
-        assert isinstance(vds[var].data, ManifestArray), var
+        assert vds.dims == {"time": 2920, "lat": 25, "lon": 53}
+        for var in vds.variables:
+            assert isinstance(vds[var].data, ManifestArray), var
 
 
 class TestLoadVirtualDataset:

--- a/virtualizarr/tests/test_xarray.py
+++ b/virtualizarr/tests/test_xarray.py
@@ -271,9 +271,6 @@ class TestCombineUsingIndexes:
         assert combined_vds.xindexes["time"].to_pandas_index().is_monotonic_increasing
 
 
-pytest.importorskip("s3fs")
-
-
 @network
 @requires_s3fs
 class TestReadFromS3:

--- a/virtualizarr/tests/test_xarray.py
+++ b/virtualizarr/tests/test_xarray.py
@@ -9,7 +9,7 @@ from xarray.core.indexes import Index
 
 from virtualizarr import open_virtual_dataset
 from virtualizarr.manifests import ChunkManifest, ManifestArray
-from virtualizarr.tests import network
+from virtualizarr.tests import network, requires_s3fs
 from virtualizarr.zarr import ZArray
 
 
@@ -275,6 +275,7 @@ pytest.importorskip("s3fs")
 
 
 @network
+@requires_s3fs
 class TestReadFromS3:
     @pytest.mark.parametrize(
         "filetype", ["netcdf4", None], ids=["netcdf4 filetype", "None filetype"]


### PR DESCRIPTION
Implements @scottyhq's suggestion in https://github.com/zarr-developers/VirtualiZarr/pull/143#issuecomment-2174029069.

Makes the test suite run considerably faster locally by default because you don't have to wait for the tests that access S3 to complete.

- [ ] ~~Closes #xxxx~~
- [ ] ~~Tests added~~
- [ ] Changes are documented in `docs/releases.rst`
- [ ] ~~New functions/methods are listed in `api.rst`~~
