### PR TITLE
Use default version scheme for setuptools_scm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,8 @@ on:
       - published
   # push:
   #   branches: [ "main" ]
-  # pull_request:
-  #   branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
 
 permissions:
   contents: read
@@ -29,14 +29,6 @@ jobs:
           python -m pip install setuptools setuptools-scm wheel twine check-manifest
           git clean -xdf
           git restore -SW .
-      # This step is only necessary for testing purposes and for TestPyPI
-      - name: Fix up version string for TestPyPI
-        if: ${{ !startsWith(github.ref, 'refs/tags') }}
-        run: |
-          # Change setuptools-scm local_scheme to "no-local-version" so the
-          # local part of the version isn't included, making the version string
-          # compatible with PyPI.
-          sed --in-place "s/guess-next-dev/no-local-version/g" pyproject.toml
       - name: Build tarball and wheels
         run: |
           python -m build --sdist --wheel .
@@ -82,6 +74,7 @@ jobs:
           python -m pip install dist/virtualizarr*.whl
           python -c "import virtualizarr; print(virtualizarr.__version__)"
       - name: Publish package to TestPyPI
+        if: github.event_name == 'release'
         uses: pypa/gh-action-pypi-publish@v1.8.14
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,6 @@ requires = [
 ]
 
 [tool.setuptools_scm]
-local_scheme = "guess-next-dev"
 fallback_version = "9999"
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Including `local_scheme = "guess-next-dev"` in pyproject.toml caused the +unknown to be included in the distribution name. This PR removes that configuration and updates the release workflow to build the package on PRs, but only upload to TestPyPI for releases.

Relates to #13 
- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
