### PR TITLE
Ensure _ARRAY_DIMENSIONS get dropped from attrs

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -25,6 +25,8 @@ Deprecations
 Bug fixes
 ~~~~~~~~~
 
+- Ensure that `_ARRAY_DIMENSIONS` are dropped from variable `.attrs`. (:issue:`150`, :pull:`152`) 
+  By `Tom Nicholas <https://github.com/TomNicholas>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/virtualizarr/tests/test_xarray.py
+++ b/virtualizarr/tests/test_xarray.py
@@ -228,6 +228,12 @@ class TestConcat:
         assert result.data.zarray.zarr_format == zarray.zarr_format
 
 
+def test_open_virtual_dataset_attrs(netcdf4_file):
+    # regression test for GH issue #150
+    vds = open_virtual_dataset(netcdf4_file, indexes={})
+    assert "_ARRAY_DIMENSIONS" not in vds["air"].attrs
+
+
 class TestOpenVirtualDatasetIndexes:
     def test_no_indexes(self, netcdf4_file):
         vds = open_virtual_dataset(netcdf4_file, indexes={})

--- a/virtualizarr/tests/test_xarray.py
+++ b/virtualizarr/tests/test_xarray.py
@@ -228,10 +228,11 @@ class TestConcat:
         assert result.data.zarray.zarr_format == zarray.zarr_format
 
 
-def test_open_virtual_dataset_attrs(netcdf4_file):
-    # regression test for GH issue #150
-    vds = open_virtual_dataset(netcdf4_file, indexes={})
-    assert "_ARRAY_DIMENSIONS" not in vds["air"].attrs
+class TestOpenVirtualDatasetAttrs:
+    def test_drop_array_dimensions(self, netcdf4_file):
+        # regression test for GH issue #150
+        vds = open_virtual_dataset(netcdf4_file, indexes={})
+        assert "_ARRAY_DIMENSIONS" not in vds["air"].attrs
 
 
 class TestOpenVirtualDatasetIndexes:

--- a/virtualizarr/xarray.py
+++ b/virtualizarr/xarray.py
@@ -288,8 +288,12 @@ def variable_from_kerchunk_refs(
 
     arr_refs = kerchunk.extract_array_refs(refs, var_name)
     chunk_dict, zarray, zattrs = kerchunk.parse_array_refs(arr_refs)
+
     manifest = ChunkManifest._from_kerchunk_chunk_dict(chunk_dict)
-    dims = zattrs["_ARRAY_DIMENSIONS"]
+
+    # we want to remove the _ARRAY_DIMENSIONS from the final variables' .attrs
+    dims = zattrs.pop("_ARRAY_DIMENSIONS")
+
     varr = virtual_array_class(zarray=zarray, chunkmanifest=manifest)
 
     return xr.Variable(data=varr, dims=dims, attrs=zattrs)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #150
- [x] Tests added
- [x] Tests passing
- [x] Full type hint coverage
- [x] Changes are documented in `docs/releases.rst`
- [ ] ~~New functions/methods are listed in `api.rst`~~
- [ ] ~~New functionality has documentation~~
