### PR TITLE
Use a set to avoid duplicate var names from kerchunk

### DIFF
--- a/virtualizarr/kerchunk.py
+++ b/virtualizarr/kerchunk.py
@@ -165,8 +165,8 @@ def find_var_names(ds_reference_dict: KerchunkStoreRefs) -> list[str]:
     """Find the names of zarr variables in this store/group."""
 
     refs = ds_reference_dict["refs"]
-    found_var_names = [key.split("/")[0] for key in refs.keys() if "/" in key]
-    return found_var_names
+    found_var_names = {key.split("/")[0] for key in refs.keys() if "/" in key}
+    return list(found_var_names)
 
 
 def extract_array_refs(

--- a/virtualizarr/tests/test_kerchunk.py
+++ b/virtualizarr/tests/test_kerchunk.py
@@ -5,7 +5,7 @@ import ujson  # type: ignore
 import xarray as xr
 import xarray.testing as xrt
 
-from virtualizarr.kerchunk import FileType, _automatically_determine_filetype
+from virtualizarr.kerchunk import FileType, find_var_names, _automatically_determine_filetype, KerchunkStoreRefs
 from virtualizarr.manifests import ChunkManifest, ManifestArray
 from virtualizarr.xarray import dataset_from_kerchunk_refs
 
@@ -266,3 +266,14 @@ def test_FileType():
     assert "zarr" == FileType("zarr").name
     with pytest.raises(ValueError):
         FileType(None)
+
+
+def test_no_duplicates_find_var_names():
+    """Verify that we get a deduplicated list of var names"""
+    ref_dict = {
+        "refs": {
+            "x/something": {},
+            "x/otherthing": {}
+        }
+    }
+    assert len(find_var_names(ref_dict)) == 1


### PR DESCRIPTION
This PR uses a set comprehension rather than a list comprehension in `find_var_names` to drop all duplicate var names that happen to show up in the kerchunk reference dict.

- [x] Closes #178
- [x] Tests added
- [x] Tests passing
