### PR TITLE
Extend refspec support to [path] entries (without offset/length)

### DIFF
--- a/virtualizarr/manifests/manifest.py
+++ b/virtualizarr/manifests/manifest.py
@@ -299,6 +299,8 @@ class ChunkManifest:
     @classmethod
     def _from_kerchunk_chunk_dict(
         cls,
+        # The type hint requires `Dict` instead of `dict` due to
+        # the conflicting ChunkManifest.dict method.
         kerchunk_chunk_dict: Dict[ChunkKey, str | tuple[str] | tuple[str, int, int]],
     ) -> "ChunkManifest":
         chunk_entries: dict[ChunkKey, ChunkDictEntry] = {}

--- a/virtualizarr/manifests/manifest.py
+++ b/virtualizarr/manifests/manifest.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, NewType, Tuple, TypedDict, cast
 
 import numpy as np
 from pydantic import BaseModel, ConfigDict
+from upath import UPath
 
 from virtualizarr.types import ChunkKey
 
@@ -42,9 +43,14 @@ class ChunkEntry(BaseModel):
 
     @classmethod
     def from_kerchunk(
-        cls, path_and_byte_range_info: tuple[str, int, int]
+        cls, path_and_byte_range_info: tuple[str] | tuple[str, int, int]
     ) -> "ChunkEntry":
-        path, offset, length = path_and_byte_range_info
+        if len(path_and_byte_range_info) == 1:
+            path = path_and_byte_range_info[0]
+            offset = 0
+            length = UPath(path).stat().st_size
+        else:
+            path, offset, length = path_and_byte_range_info
         return ChunkEntry(path=path, offset=offset, length=length)
 
     def to_kerchunk(self) -> tuple[str, int, int]:


### PR DESCRIPTION
I'm trying to open a Zarr v2. I couldn't find a good obvious way to do this, so my attempt was:

```python
from kerchunk.zarr import ZarrToZarr
from virtualizarr.xarray import dataset_from_kerchunk_refs

ref = ZarrToZarr(url).translate()
ds = dataset_from_kerchunk_refs(ref)
```

This fails [here in unpacking](https://github.com/zarr-developers/VirtualiZarr/blob/f60707f86f6fa7415463c1a3e886eb134b84bdb0/virtualizarr/manifests/manifest.py#L39) because kerchunk produces reference entries of the form `[path]` instead of `[path, length, offset]`.

I was wondering if I could work around this by `stat`ing the chunks, and sure enough it worked! (See my second commit.)

I'd love to get some feedback on this, including if there's a better way to open v2 zarrs.

In preparation for my second commit I needed to clean up some types. To make things more precise and clean, I tell a minor lie: that the `[path, offset, length]` lists are tuples. This was done in the spirit of duck typing, and I'd argue is more semantically accurate. (Not to mention that tuples serialize to lists in JSON.)


<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
