### PR TITLE
Exclude empty `paths` on `ChunkDict` creation

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -18,6 +18,9 @@ Deprecations
 Bug fixes
 ~~~~~~~~~
 
+- Exclude empty chunks during `ChunkDict` construction. (:pull:`198`)
+  By `Gustavo Hidalgo <https://github.com/ghidalgo3>`_.
+
 Documentation
 ~~~~~~~~~~~~~
 

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -12,6 +12,9 @@ New Features
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
+- Serialize valid ZarrV3 metadata (for :pull:`193`).
+  By `Gustavo Hidalgo <https://github.com/ghidalgo3>`_.
+
 Deprecations
 ~~~~~~~~~~~~
 

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -12,9 +12,6 @@ New Features
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
-- Serialize valid ZarrV3 metadata (for :pull:`193`).
-  By `Gustavo Hidalgo <https://github.com/ghidalgo3>`_.
-
 Deprecations
 ~~~~~~~~~~~~
 

--- a/virtualizarr/manifests/manifest.py
+++ b/virtualizarr/manifests/manifest.py
@@ -364,16 +364,14 @@ def validate_chunk_keys(chunk_keys: Iterable[ChunkKey]):
             raise ValueError(f"Invalid format for chunk key: '{key}'")
 
     # Check if all keys have the same number of dimensions
-    keys = list(chunk_keys)
-    if len(keys) > 1:
-        first_key, *other_keys = keys
-        ndim = get_ndim_from_key(first_key)
-        for key in other_keys:
-            other_ndim = get_ndim_from_key(key)
-            if other_ndim != ndim:
-                raise ValueError(
-                    f"Inconsistent number of dimensions between chunk key {key} and {first_key}: {other_ndim} vs {ndim}"
-                )
+    first_key, *other_keys = list(chunk_keys)
+    ndim = get_ndim_from_key(first_key)
+    for key in other_keys:
+        other_ndim = get_ndim_from_key(key)
+        if other_ndim != ndim:
+            raise ValueError(
+                f"Inconsistent number of dimensions between chunk key {key} and {first_key}: {other_ndim} vs {ndim}"
+            )
 
 
 def get_chunk_grid_shape(chunk_keys: Iterable[ChunkKey]) -> tuple[int, ...]:

--- a/virtualizarr/manifests/manifest.py
+++ b/virtualizarr/manifests/manifest.py
@@ -252,7 +252,7 @@ class ChunkManifest:
                 [*coord_vectors, self._paths, self._offsets, self._lengths],
                 flags=("refs_ok",),
             )
-            if path.item()[0] != ""  # don't include entry if path='' (i.e. empty chunk)
+            if path.item() != ""  # don't include entry if path='' (i.e. empty chunk)
         }
 
         return cast(
@@ -364,14 +364,16 @@ def validate_chunk_keys(chunk_keys: Iterable[ChunkKey]):
             raise ValueError(f"Invalid format for chunk key: '{key}'")
 
     # Check if all keys have the same number of dimensions
-    first_key, *other_keys = list(chunk_keys)
-    ndim = get_ndim_from_key(first_key)
-    for key in other_keys:
-        other_ndim = get_ndim_from_key(key)
-        if other_ndim != ndim:
-            raise ValueError(
-                f"Inconsistent number of dimensions between chunk key {key} and {first_key}: {other_ndim} vs {ndim}"
-            )
+    keys = list(chunk_keys)
+    if len(keys) > 1:
+        first_key, *other_keys = keys
+        ndim = get_ndim_from_key(first_key)
+        for key in other_keys:
+            other_ndim = get_ndim_from_key(key)
+            if other_ndim != ndim:
+                raise ValueError(
+                    f"Inconsistent number of dimensions between chunk key {key} and {first_key}: {other_ndim} vs {ndim}"
+                )
 
 
 def get_chunk_grid_shape(chunk_keys: Iterable[ChunkKey]) -> tuple[int, ...]:

--- a/virtualizarr/tests/test_manifests/test_manifest.py
+++ b/virtualizarr/tests/test_manifests/test_manifest.py
@@ -51,6 +51,14 @@ class TestCreateManifest:
         with pytest.raises(ValueError, match="Inconsistent number of dimensions"):
             ChunkManifest(entries=chunks)
 
+    def test_empty_chunk_paths(self):
+        chunks = {
+            "0.0.0": {"path": "", "offset": 0, "length": 100},
+            "1.0.0": {"path": "s3://bucket/foo.nc", "offset": 100, "length": 100},
+        }
+        manifest = ChunkManifest(entries=chunks)
+        assert len(manifest.dict()) == 1
+
 
 class TestProperties:
     def test_chunk_grid_info(self):


### PR DESCRIPTION
This was discovered while experimenting with [GOES](https://planetarycomputer.microsoft.com/dataset/goes-cmi) data, kudos to @t-mcneely for discovering this. We think there's a small bug in the filter expression during `ChunkDict` creation. Ultimately this caused a problem when reading/writing kerchunk stores of the data.

Here's a neat image rendering the chunk grid we were working with, note how the corners are empty: 
![Screenshot 2024-07-19 171140](https://github.com/user-attachments/assets/94cce97b-a2b4-483f-afcc-058f6aed2a14)

- [x] Tests added
- [x] Tests passing
- [x] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
