### PR TITLE
Handle scalar dataset variables

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,4 @@
+import h5py
 import pytest
 import xarray as xr
 
@@ -50,3 +51,21 @@ def netcdf4_files(tmpdir):
     ds2.close()
 
     return filepath1, filepath2
+
+
+@pytest.fixture
+def hdf5_empty(tmpdir):
+    filepath = f"{tmpdir}/empty.nc"
+    f = h5py.File(filepath, "w")
+    dataset = f.create_dataset("empty", shape=(), dtype="float32")
+    dataset.attrs["empty"] = "true"
+    return filepath
+
+
+@pytest.fixture
+def hdf5_scalar(tmpdir):
+    filepath = f"{tmpdir}/scalar.nc"
+    f = h5py.File(filepath, "w")
+    dataset = f.create_dataset("scalar", data=0.1, dtype="float32")
+    dataset.attrs["scalar"] = "true"
+    return filepath

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -9,6 +9,9 @@ v1.0.1 (unreleased)
 New Features
 ~~~~~~~~~~~~
 
+- Load scalar variables by default. (:pull:`205`)
+  By `Gustavo Hidalgo <https://github.com/ghidalgo3>`_.
+
 Breaking changes
 ~~~~~~~~~~~~~~~~
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ test = [
     "fsspec",
     "s3fs",
     "fastparquet",
+    "h5py"
 ]
 
 

--- a/virtualizarr/tests/test_xarray.py
+++ b/virtualizarr/tests/test_xarray.py
@@ -419,31 +419,15 @@ class TestLoadVirtualDataset:
         }
         mock_read_kerchunk.assert_called_once_with(**args)
 
-    @patch("virtualizarr.kerchunk.parse_array_refs")
-    def test_open_dataset_with_scalars(self, mock_parse_array_refs, tmpdir):
-        expected_attrs = {"units": "K", "long_name": "scalar"}
-        mock_parse_array_refs.return_value = (
-            None,
-            ZArray(
-                chunks=(),
-                shape=(),
-                compressor={},
-                dtype=np.dtype("float32"),
-                fill_value=0.0,
-                filters=None,
-                order="C",
-                zarr_format=2,
-            ),
-            {**expected_attrs, **{"_ARRAY_DIMENSIONS": []}},
-        )
+    def test_open_dataset_with_empty(self, hdf5_empty, tmpdir):
+        vds = open_virtual_dataset(hdf5_empty)
+        assert vds.empty.dims == ()
+        assert vds.empty.attrs == {"empty": "true"}
 
-        ds = xr.Dataset()
-        ds["scalar"] = xr.Variable(dims=(), data=None, attrs=expected_attrs)
-        ds.to_netcdf(f"{tmpdir}/scalar.nc")
-        vds = open_virtual_dataset(f"{tmpdir}/scalar.nc")
+    def test_open_dataset_with_scalar(self, hdf5_scalar, tmpdir):
+        vds = open_virtual_dataset(hdf5_scalar)
         assert vds.scalar.dims == ()
-        assert vds.scalar.data == 0.0
-        assert vds.scalar.attrs == expected_attrs
+        assert vds.scalar.attrs == {"scalar": "true"}
 
 
 class TestRenamePaths:

--- a/virtualizarr/xarray.py
+++ b/virtualizarr/xarray.py
@@ -333,13 +333,16 @@ def variable_from_kerchunk_refs(
 
     arr_refs = kerchunk.extract_array_refs(refs, var_name)
     chunk_dict, zarray, zattrs = kerchunk.parse_array_refs(arr_refs)
-
-    manifest = ChunkManifest._from_kerchunk_chunk_dict(chunk_dict)
-
     # we want to remove the _ARRAY_DIMENSIONS from the final variables' .attrs
     dims = zattrs.pop("_ARRAY_DIMENSIONS")
-
-    varr = virtual_array_class(zarray=zarray, chunkmanifest=manifest)
+    if chunk_dict:
+        manifest = ChunkManifest._from_kerchunk_chunk_dict(chunk_dict)
+        varr = virtual_array_class(zarray=zarray, chunkmanifest=manifest)
+    else:
+        # This means we encountered a scalar variable of dimension 0,
+        # very likely that it actually has no numeric value and its only purpose
+        # is to communicate dataset attributes.
+        varr = zarray.fill_value
 
     return xr.Variable(data=varr, dims=dims, attrs=zattrs)
 


### PR DESCRIPTION
Some real-world NetCDF files have scalar variables that `kerchunk` parsers to a ChunkDict of `{}`. Previously, these variables would need to be explicitly loaded or dropped to make a `open_virtual_dataset` call work. With this change, the variable will be loaded into `xr.Variables` of dimension 0 and their attributes passed up to the XArray dataset.

- [x] Closes #194
- [x] Tests added
- [x] Tests passing
- [x] Full type hint coverage
- [x] Changes are documented in `docs/releases.rst`
