### PR TITLE
Set ZArray default fill_value as NaT for datetime64

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -23,6 +23,9 @@ Bug fixes
 
 - Exclude empty chunks during `ChunkDict` construction. (:pull:`198`)
   By `Gustavo Hidalgo <https://github.com/ghidalgo3>`_.
+- Fixed regression in `fill_value` handling for datetime dtypes making virtual
+  Zarr stores unreadable (:pr:`206`)
+  By `Timothy Hodson <https://github.com/thodson-usgs>`_
 
 Documentation
 ~~~~~~~~~~~~~

--- a/virtualizarr/zarr.py
+++ b/virtualizarr/zarr.py
@@ -39,7 +39,7 @@ ZARR_DEFAULT_FILL_VALUE: dict[str, FillValueT] = {
     np.dtype("int").kind: 0,
     np.dtype("float").kind: 0.0,
     np.dtype("complex").kind: [0.0, 0.0],
-    np.dtype("datetime64").kind: np.datetime64("NaT").view("i8").item(),
+    np.dtype("datetime64").kind: 0,
 }
 """
 The value and format of the fill_value depend on the `data_type` of the array.

--- a/virtualizarr/zarr.py
+++ b/virtualizarr/zarr.py
@@ -67,7 +67,7 @@ class ZArray(BaseModel):
     chunks: tuple[int, ...]
     compressor: dict | None = None
     dtype: np.dtype
-    fill_value: FillValueT = Field(default=0.0, validate_default=True)
+    fill_value: FillValueT = Field(default=np.nan, validate_default=True)
     filters: list[dict] | None = None
     order: Literal["C", "F"]
     shape: tuple[int, ...]

--- a/virtualizarr/zarr.py
+++ b/virtualizarr/zarr.py
@@ -32,13 +32,14 @@ ZAttrs = NewType(
 )  # just the .zattrs (for one array or for the whole store/group)
 FillValueT = bool | str | float | int | list | None
 
-ZARR_DEFAULT_FILL_VALUE: dict[np.dtype, FillValueT] = {
+ZARR_DEFAULT_FILL_VALUE: dict[str, FillValueT] = {
     # numpy dtypes's hierarchy lets us avoid checking for all the widths
     # https://numpy.org/doc/stable/reference/arrays.scalars.html
-    np.dtype("bool"): False,
-    np.dtype("int"): 0,
-    np.dtype("float"): 0.0,
-    np.dtype("complex"): [0.0, 0.0],
+    np.dtype("bool").kind: False,
+    np.dtype("int").kind: 0,
+    np.dtype("float").kind: 0.0,
+    np.dtype("complex").kind: [0.0, 0.0],
+    np.dtype("datetime64").kind: np.datetime64("NaT").view("i8").item(),
 }
 """
 The value and format of the fill_value depend on the `data_type` of the array.
@@ -67,7 +68,7 @@ class ZArray(BaseModel):
     chunks: tuple[int, ...]
     compressor: dict | None = None
     dtype: np.dtype
-    fill_value: FillValueT = Field(default=np.nan, validate_default=True)
+    fill_value: FillValueT = Field(None, validate_default=True)
     filters: list[dict] | None = None
     order: Literal["C", "F"]
     shape: tuple[int, ...]
@@ -90,7 +91,7 @@ class ZArray(BaseModel):
     @model_validator(mode="after")
     def _check_fill_value(self) -> Self:
         if self.fill_value is None:
-            self.fill_value = ZARR_DEFAULT_FILL_VALUE.get(self.dtype, 0.0)
+            self.fill_value = ZARR_DEFAULT_FILL_VALUE.get(self.dtype.kind, 0.0)
         return self
 
     @property


### PR DESCRIPTION
This PR fixes an error introduced in 10bd53dc3dae08303e57fe5aefe49804d9c4517d, which broke the default fill_value for datetime64 fields. Closes #201.


To replicate the error:
```bash
aws s3api get-object --region us-west-2 --no-sign-request --bucket wrf-se-ak-ar5 --key ccsm/rcp85/daily/2060/WRFDS_2060-01-01.nc WRFDS_2060-01-01.nc
aws s3api get-object --region us-west-2 --no-sign-request --bucket wrf-se-ak-ar5 --key ccsm/rcp85/daily/2060/WRFDS_2060-01-02.nc WRFDS_2060-01-02.nc
```
then run this `example.py`
```python
import xarray as xr
import glob
from virtualizarr import open_virtual_dataset

virtual_datasets = [
    open_virtual_dataset(filepath,
                         indexes={},
                         loadable_variables=['Time'],
                         cftime_variables=['Time'])
    for filepath in glob.glob('*.nc')
]

virtual_ds = xr.combine_nested(virtual_datasets, concat_dim=["Time"], coords="minimal", compat="override")
virtual_ds.virtualize.to_kerchunk('combined.json', format='json')

ds = xr.open_dataset('combined.json', engine="kerchunk")
```

The PR implements Tom's suggestion below: https://github.com/zarr-developers/VirtualiZarr/pull/206#issuecomment-2260955421