### PR TITLE
Handle uncompressed variables in parsing metadata

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -23,6 +23,8 @@ Bug fixes
 
 - Exclude empty chunks during `ChunkDict` construction. (:pull:`198`)
   By `Gustavo Hidalgo <https://github.com/ghidalgo3>`_.
+- Parse uncompressed variable codecs correctly. (:pull:`207`)
+  By `Gustavo Hidalgo <https://github.com/ghidalgo3>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/virtualizarr/tests/test_zarr.py
+++ b/virtualizarr/tests/test_zarr.py
@@ -52,6 +52,15 @@ def test_metadata_roundtrip(tmpdir, vds_with_manifest_arrays: xr.Dataset):
     assert zarray == vds_with_manifest_arrays.a.data.zarray
 
 
+def test_uncompressed_variable_roundtrips(tmpdir, vds_with_manifest_arrays):
+    vds_with_manifest_arrays.a.data.zarray.compressor = None
+    vds_with_manifest_arrays.a.data.zarray.filters = None
+    dataset_to_zarr(vds_with_manifest_arrays, tmpdir / "store.zarr")
+    vds = open_virtual_dataset(tmpdir / "store.zarr", filetype="zarr_v3", indexes={})
+    assert vds.a.data.zarray.compressor is None
+    assert vds.a.data.zarray.filters is None
+
+
 def test_zarr_v3_metadata_conformance(tmpdir, vds_with_manifest_arrays: xr.Dataset):
     """
     Checks that the output metadata of an array variable conforms to this spec

--- a/virtualizarr/zarr.py
+++ b/virtualizarr/zarr.py
@@ -368,9 +368,14 @@ def metadata_from_zarr_json(filepath: Path) -> tuple[ZArray, list[str], dict]:
         for codec in metadata["codecs"]
         if codec["name"] not in ("transpose", "bytes")
     ]
-    compressor, *filters = [
+    num_codec_configs = [
         _configurable_to_num_codec_config(_filter) for _filter in all_codecs
     ]
+    # Uncompressed variables may have no codecs
+    if num_codec_configs:
+        compressor, *filters = num_codec_configs
+    else:
+        compressor, filters = None, []
     zarray = ZArray(
         chunks=chunk_shape,
         compressor=compressor,


### PR DESCRIPTION
When reading in a ZarrV3 store, it is very possible that a variable is uncompressed. The code that assigns codecs to `compressors` and `filters` doesn't handle the case when there are no codecs to assign. This PR addresses that gap.

- [x] Tests added
- [x] Tests passing
- [x] Full type hint coverage
- [x] Changes are documented in `docs/releases.rst`
