### PR TITLE
Fix for typo? in filetype docstring

### DIFF
--- a/virtualizarr/xarray.py
+++ b/virtualizarr/xarray.py
@@ -58,7 +58,7 @@ def open_virtual_dataset(
         File path to open as a set of virtualized zarr arrays.
     filetype : FileType, default None
         Type of file to be opened. Used to determine which kerchunk file format backend to use.
-        Can be one of {'netCDF3', 'netCDF4', 'HDF', 'TIFF', 'GRIB', 'FITS', 'zarr_v3'}.
+        Can be one of {'netcdf3', 'netcdf4', 'hdf4', 'tiff', 'grib', 'fits', 'zarr_v3'}.
         If not provided will attempt to automatically infer the correct filetype from header bytes.
     drop_variables: list[str], default is None
         Variables in the file to drop before returning.


### PR DESCRIPTION
I just ran into a minor, but confusing issue with the docstrings for the `filetype` input for `open_virtual_dataset`. 

When I look at the docstring (specifically [this line](https://github.com/zarr-developers/VirtualiZarr/blob/b34a1ee47572901ed6a3623c97d340157a0fa62a/virtualizarr/xarray.py#L61)), it suggests that this would work:

```python
from virtualizarr import open_virtual_dataset
vds = open_virtual_dataset(
        ...,
        filetype='netCDF3',
) 
```

but it raises the following error

<details>

</details>

the following works:
```python
vds = open_virtual_dataset(
        ...,
        filetype='netcdf3',
) 
```

Looking at the [tests](https://github.com/zarr-developers/VirtualiZarr/blob/b34a1ee47572901ed6a3623c97d340157a0fa62a/virtualizarr/tests/test_xarray.py#L341), I suspect this is simply a typo in the docstring (upercase `'CDF'` vs lowercase `'cdf'`), but maybe I am missing something?

Happy to add more if desired.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
