### PR TITLE
Update .pre-commit-config mypy + bump ruff version 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: "v0.4.7"
+    rev: "v0.5.6"
     hooks:
       # Run the linter.
       - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: "v0.5.6"
+    rev: "v0.5.0"
     hooks:
       # Run the linter.
       - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,10 +27,10 @@ repos:
         exclude: "properties|asv_bench|docs"
         additional_dependencies: [
             # Type stubs
-            types-python-dateutil,
-            types-pkg_resources,
-            types-PyYAML,
-            types-pytz,
+            # types-python-dateutil,
+            # types-pkg_resources,
+            # types-PyYAML,
+            # types-pytz,
             # Dependencies that are typed
             numpy,
             typing-extensions>=4.1.0,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: "v0.5.0"
+    rev: "v0.5.6"
     hooks:
       # Run the linter.
       - id: ruff
@@ -27,10 +27,10 @@ repos:
         exclude: "properties|asv_bench|docs"
         additional_dependencies: [
             # Type stubs
-            # types-python-dateutil,
-            # types-pkg_resources,
-            # types-PyYAML,
-            # types-pytz,
+            types-python-dateutil,
+            types-setuptools,
+            types-PyYAML,
+            types-pytz,
             # Dependencies that are typed
             numpy,
             typing-extensions>=4.1.0,


### PR DESCRIPTION
In https://github.com/zarr-developers/VirtualiZarr/issues/180, it seems like the Github pre-commit CI wasn't working on PR's. I enabled the app in the repo (08-05-2024). This is a tiny PR that bumps a ruff version & updates the .pre-commit-config.yaml mypy section to replace `types-pkg_resources` with `types-setuptools`.