### PR TITLE
[Draft] Testing CI speed of uv + pip vs mamba

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,16 +34,15 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          uv venv .venv
-          # echo "VIRTUAL_ENV=.venv" >> $GITHUB_ENV
+      # - name: Install uv
+      #   run: |
+      #     curl -LsSf https://astral.sh/uv/install.sh | sh
+      #     uv venv .venv
+      #     # echo "VIRTUAL_ENV=.venv" >> $GITHUB_ENV
 
       - name: Install virtualizarr
         run: |
-           uv pip install --system '.'
-           uv pip install --system '.[test]'
+           pip install '.[test]'
 
       - name: Running Tests
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,8 @@ on:
     - 'docs/**'
   schedule:
     - cron: "0 0 * * *"
+env:
+  UV_HTTP_TIMEOUT: 500
 
 jobs:
 
@@ -26,21 +28,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup micromamba
-        uses: mamba-org/setup-micromamba@v1
+      - name: Setup Python
+        id: setup-python
+        uses: actions/setup-python@v5
         with:
-          environment-file: ci/environment.yml
-          cache-environment: true
-          create-args: >-
-            python=${{matrix.python-version}}
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        run: pip install uv
 
       - name: Install virtualizarr
         run: |
-           python -m pip install -e . --no-deps
-      - name: Conda list information
-        run: |
-          conda env list
-          conda list
+           uv pip install '.[test]'
+
 
       - name: Running Tests
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,12 +38,11 @@ jobs:
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
           uv venv .venv
-          echo "VIRTUAL_ENV=.venv" >> $GITHUB_ENV
+          # echo "VIRTUAL_ENV=.venv" >> $GITHUB_ENV
 
       - name: Install virtualizarr
         run: |
            uv pip install --system '.[test]'
-
 
       - name: Running Tests
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,11 +35,14 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        run: pip install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          uv venv .venv
+          echo "VIRTUAL_ENV=.venv" >> $GITHUB_ENV
 
       - name: Install virtualizarr
         run: |
-           uv pip install '.[test]'
+           uv pip install --system '.[test]'
 
 
       - name: Running Tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,7 @@ jobs:
 
       - name: Install virtualizarr
         run: |
+           uv pip install --system '.'
            uv pip install --system '.[test]'
 
       - name: Running Tests

--- a/conftest.py
+++ b/conftest.py
@@ -1,7 +1,7 @@
 import h5py
 import pytest
 import xarray as xr
-import netCDF4 # type: ignore
+
 
 def pytest_addoption(parser):
     """Add command-line flags for pytest."""
@@ -27,7 +27,7 @@ def netcdf4_file(tmpdir):
 
     # Save it to disk as netCDF (in temporary directory)
     filepath = f"{tmpdir}/air.nc"
-    ds.to_netcdf(filepath, format="NETCDF4", engine='netcdf4')
+    ds.to_netcdf(filepath, format="NETCDF4")
     ds.close()
 
     return filepath
@@ -45,8 +45,8 @@ def netcdf4_files(tmpdir):
     # Save it to disk as netCDF (in temporary directory)
     filepath1 = f"{tmpdir}/air1.nc"
     filepath2 = f"{tmpdir}/air2.nc"
-    ds1.to_netcdf(filepath1, format="NETCDF4", engine='netcdf4')
-    ds2.to_netcdf(filepath2, format="NETCDF4", engine='netcdf4')
+    ds1.to_netcdf(filepath1)
+    ds2.to_netcdf(filepath2)
     ds1.close()
     ds2.close()
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,7 +1,7 @@
 import h5py
 import pytest
 import xarray as xr
-
+import netCDF4 # type: ignore
 
 def pytest_addoption(parser):
     """Add command-line flags for pytest."""
@@ -27,7 +27,7 @@ def netcdf4_file(tmpdir):
 
     # Save it to disk as netCDF (in temporary directory)
     filepath = f"{tmpdir}/air.nc"
-    ds.to_netcdf(filepath, format="NETCDF4")
+    ds.to_netcdf(filepath, format="NETCDF4", engine='netcdf4')
     ds.close()
 
     return filepath
@@ -45,8 +45,8 @@ def netcdf4_files(tmpdir):
     # Save it to disk as netCDF (in temporary directory)
     filepath1 = f"{tmpdir}/air1.nc"
     filepath2 = f"{tmpdir}/air2.nc"
-    ds1.to_netcdf(filepath1)
-    ds2.to_netcdf(filepath2)
+    ds1.to_netcdf(filepath1, format="NETCDF4", engine='netcdf4')
+    ds2.to_netcdf(filepath2, format="NETCDF4", engine='netcdf4')
     ds1.close()
     ds2.close()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 requires-python = ">=3.10"
 dynamic = ["version"]
 dependencies = [
-    "xarray>=2024.06.0",
+    "xarray>=2024.6.0",
     "kerchunk>=0.2.5",
     "h5netcdf",
     "pydantic",
@@ -45,7 +45,11 @@ test = [
     "fsspec",
     "s3fs",
     "fastparquet",
-    "h5py"
+    "h5py",
+    "hdf5",
+    "tifffile",
+    "astropy"
+
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ test = [
     "s3fs",
     "fastparquet",
     "h5py",
-    "hdf5",
     "tifffile",
     "astropy"
 


### PR DESCRIPTION
This PR allows the CI to build an env and install virtualizarr from the dependencies listed in the `pyproject.toml` via `uv` & pip.