### PR TITLE
Adds concurrency to CI w/ cancel-in-progress=True

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,10 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   test:


### PR DESCRIPTION
Adds concurrency field to main.yml in Github CI. Ensures in-progress jobs are canceled on re-runs. Completes one of the [repo-review results](https://github.com/zarr-developers/VirtualiZarr/issues/99) - `├── GH102 Auto-cancel on repeated PRs ❌`


