### PR TITLE
use the theme options for `pydata_sphinx_theme`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,6 +55,7 @@ todo_include_todos = False
 
 html_theme = "pydata_sphinx_theme"
 html_theme_options = {
+    "use_edit_page_button": True,
     "github_user": "zarr-developers",
     "github_repo": "VirtualiZarr",
     "github_version": "main",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,7 +63,7 @@ html_theme_options = {
         {
             "name": "GitHub",
             "url": "https://github.com/zarr-developers/VirtualiZarr",
-            "icon": "fa-brands fa-square-github",
+            "icon": "fa-brands fa-github",
             "type": "fontawesome",
         },
     ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,9 +55,10 @@ todo_include_todos = False
 
 html_theme = "pydata_sphinx_theme"
 html_theme_options = {
-    "repository_url": "https://github.com/TomNicholas/VirtualiZarr",
-    "repository_branch": "main",
-    "path_to_docs": "docs",
+    "github_user": "zarr-developers",
+    "github_repo": "VirtualiZarr",
+    "github_version": "main",
+    "doc_path": "docs",
 }
 html_title = "VirtualiZarr"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,6 +59,14 @@ html_theme_options = {
     "github_repo": "VirtualiZarr",
     "github_version": "main",
     "doc_path": "docs",
+    "icon_links": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/zarr-developers/VirtualiZarr",
+            "icon": "fa-brands fa-square-github",
+            "type": "fontawesome",
+        },
+    ]
 }
 html_title = "VirtualiZarr"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,10 +56,6 @@ todo_include_todos = False
 html_theme = "pydata_sphinx_theme"
 html_theme_options = {
     "use_edit_page_button": True,
-    "github_user": "zarr-developers",
-    "github_repo": "VirtualiZarr",
-    "github_version": "main",
-    "doc_path": "docs",
     "icon_links": [
         {
             "name": "GitHub",
@@ -70,6 +66,12 @@ html_theme_options = {
     ]
 }
 html_title = "VirtualiZarr"
+html_context = {
+    "github_user": "zarr-developers",
+    "github_repo": "VirtualiZarr",
+    "github_version": "main",
+    "doc_path": "docs",
+}
 
 # remove sidebar, see GH issue #82
 html_css_files = [


### PR DESCRIPTION
- [x] Closes #220

This is option 1 from https://github.com/zarr-developers/VirtualiZarr/issues/220#issuecomment-2284548652: keep using `pydata_sphinx_theme`, but use the proper html theme options.

Edit: looks like the `html_context` options (`github_user`, `github_repo`, `github_version`, `docs`) are there to add a source edit link, which has to be enabled with `use_edit_page_button`.

For the link to github, we needed to add an [icon link](https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/header-links.html#icon-links).