### PR TITLE
Adds defaults in `open_virtual_dataset_from_v3_store`

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -8,6 +8,9 @@ v1.0.1 (unreleased)
 
 New Features
 ~~~~~~~~~~~~
+- Adds defaults for `open_virtual_dataset_from_v3_store` in (:pull:`234`)
+  By `Raphael Hagen <https://github.com/norlandrhagen>`_.
+
 - New ``group`` option on ``open_virtual_dataset`` enables extracting specific HDF Groups.
   (:pull:`165`) By `Scott Henderson <https://github.com/scottyhq>`_.
 

--- a/virtualizarr/readers/zarr.py
+++ b/virtualizarr/readers/zarr.py
@@ -15,7 +15,7 @@ from virtualizarr.zarr import ZArray
 
 def open_virtual_dataset_from_v3_store(
     storepath: str,
-    drop_variables: list[str] = None,
+    drop_variables: list[str] = [],
     indexes: Mapping[str, Index] | None = None,
 ) -> Dataset:
     """

--- a/virtualizarr/readers/zarr.py
+++ b/virtualizarr/readers/zarr.py
@@ -15,8 +15,8 @@ from virtualizarr.zarr import ZArray
 
 def open_virtual_dataset_from_v3_store(
     storepath: str,
-    drop_variables: list[str],
-    indexes: Mapping[str, Index] | None,
+    drop_variables: list[str] = None,
+    indexes: Mapping[str, Index] | None = None,
 ) -> Dataset:
     """
     Read a Zarr v3 store and return an xarray Dataset containing virtualized arrays.


### PR DESCRIPTION
Tiny PR that adds `None` as defaults to `drop_variables` and `indexes` in `open_virtual_dataset_from_v3_store`. These defaults mirror `open_virtual_dataset`. 
Might add a bit of QOL for behavior like: `TypeError: open_virtual_dataset_from_v3_store() missing 1 required positional argument: 'drop_variables'
`


- [x] Tests passing
- [x] Full type hint coverage
- [x] Changes are documented in `docs/releases.rst`

