### PR TITLE
Allow `open_virtual_dataset` to read existing Kerchunk references

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,9 +46,9 @@ jobs:
           conda env list
           conda list
 
-      # - name: Type check
-      #   run: |
-      #     mypy virtualizarr
+      - name: Type check
+        run: |
+          mypy virtualizarr
 
       - name: Running Tests
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,9 +46,9 @@ jobs:
           conda env list
           conda list
 
-      - name: Type check
-        run: |
-          mypy virtualizarr
+      # - name: Type check
+      #   run: |
+      #     mypy virtualizarr
 
       - name: Running Tests
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ cython_debug/
 #.idea/
 virtualizarr/_version.py
 docs/generated/
+examples/

--- a/ci/doc.yml
+++ b/ci/doc.yml
@@ -13,4 +13,3 @@ dependencies:
       - "sphinx_design"
       - "sphinx_togglebutton"
       - "sphinx-autodoc-typehints"
-      # - -e  "..[test]"

--- a/ci/doc.yml
+++ b/ci/doc.yml
@@ -13,4 +13,4 @@ dependencies:
       - "sphinx_design"
       - "sphinx_togglebutton"
       - "sphinx-autodoc-typehints"
-      - -e  "..[test]"
+      # - -e  "..[test]"

--- a/conftest.py
+++ b/conftest.py
@@ -82,3 +82,26 @@ def hdf5_scalar(tmpdir):
     dataset = f.create_dataset("scalar", data=0.1, dtype="float32")
     dataset.attrs["scalar"] = "true"
     return filepath
+
+
+@pytest.fixture
+def example_reference_dict() -> dict:
+    return {
+        "version": 1,
+        "refs": {
+            ".zgroup": '{"zarr_format":2}',
+            ".zattrs": '{"coordinates":"lat time lon"}',
+            "air/0.0.0": ["tmp.nc", 9123, 10600],
+            "air/.zarray": '{"shape":[4,25,53],"chunks":[4,25,53],"dtype":"<i2","fill_value":null,"order":"C","compressor":null,"filters":null,"zarr_format":2}',
+            "air/.zattrs": '{"scale_factor":0.01,"_ARRAY_DIMENSIONS":["time","lat","lon"]}',
+            "lat/0": ["tmp.nc", 4927, 100],
+            "lat/.zarray": '{"shape":[25],"chunks":[25],"dtype":"<f4","fill_value":null,"order":"C","compressor":null,"filters":null,"zarr_format":2}',
+            "lat/.zattrs": '{"axis":"Y","long_name":"Latitude","standard_name":"latitude","units":"degrees_north","_ARRAY_DIMENSIONS":["lat"]}',
+            "time/0": ["tmp.nc", 23396, 16],
+            "time/.zarray": '{"shape":[4],"chunks":[4],"dtype":"<f4","fill_value":null,"order":"C","compressor":null,"filters":null,"zarr_format":2}',
+            "time/.zattrs": '{"calendar":"standard","long_name":"Time","standard_name":"time","units":"hours since 1800-01-01","_ARRAY_DIMENSIONS":["time"]}',
+            "lon/0": ["tmp.nc", 23184, 212],
+            "lon/.zarray": '{"shape":[53],"chunks":[53],"dtype":"<f4","fill_value":null,"order":"C","compressor":null,"filters":null,"zarr_format":2}',
+            "lon/.zattrs": '{"axis":"X","long_name":"Longitude","standard_name":"longitude","units":"degrees_east","_ARRAY_DIMENSIONS":["lon"]}',
+        },
+    }

--- a/conftest.py
+++ b/conftest.py
@@ -34,6 +34,20 @@ def netcdf4_file(tmpdir):
 
 
 @pytest.fixture
+def netcdf4_virtual_dataset(netcdf4_file):
+    from virtualizarr import open_virtual_dataset
+
+    return open_virtual_dataset(netcdf4_file, indexes={})
+
+
+@pytest.fixture
+def netcdf4_inlined_ref(netcdf4_file):
+    from kerchunk.hdf import SingleHdf5ToZarr
+
+    return SingleHdf5ToZarr(netcdf4_file, inline_threshold=1000).translate()
+
+
+@pytest.fixture
 def hdf5_groups_file(tmpdir):
     # Set up example xarray dataset
     ds = xr.tutorial.open_dataset("air_temperature")
@@ -82,26 +96,3 @@ def hdf5_scalar(tmpdir):
     dataset = f.create_dataset("scalar", data=0.1, dtype="float32")
     dataset.attrs["scalar"] = "true"
     return filepath
-
-
-@pytest.fixture
-def example_reference_dict() -> dict:
-    return {
-        "version": 1,
-        "refs": {
-            ".zgroup": '{"zarr_format":2}',
-            ".zattrs": '{"coordinates":"lat time lon"}',
-            "air/0.0.0": ["tmp.nc", 9123, 10600],
-            "air/.zarray": '{"shape":[4,25,53],"chunks":[4,25,53],"dtype":"<i2","fill_value":null,"order":"C","compressor":null,"filters":null,"zarr_format":2}',
-            "air/.zattrs": '{"scale_factor":0.01,"_ARRAY_DIMENSIONS":["time","lat","lon"]}',
-            "lat/0": ["tmp.nc", 4927, 100],
-            "lat/.zarray": '{"shape":[25],"chunks":[25],"dtype":"<f4","fill_value":null,"order":"C","compressor":null,"filters":null,"zarr_format":2}',
-            "lat/.zattrs": '{"axis":"Y","long_name":"Latitude","standard_name":"latitude","units":"degrees_north","_ARRAY_DIMENSIONS":["lat"]}',
-            "time/0": ["tmp.nc", 23396, 16],
-            "time/.zarray": '{"shape":[4],"chunks":[4],"dtype":"<f4","fill_value":null,"order":"C","compressor":null,"filters":null,"zarr_format":2}',
-            "time/.zattrs": '{"calendar":"standard","long_name":"Time","standard_name":"time","units":"hours since 1800-01-01","_ARRAY_DIMENSIONS":["time"]}',
-            "lon/0": ["tmp.nc", 23184, 212],
-            "lon/.zarray": '{"shape":[53],"chunks":[53],"dtype":"<f4","fill_value":null,"order":"C","compressor":null,"filters":null,"zarr_format":2}',
-            "lon/.zattrs": '{"axis":"X","long_name":"Longitude","standard_name":"longitude","units":"degrees_east","_ARRAY_DIMENSIONS":["lon"]}',
-        },
-    }

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -8,6 +8,11 @@ v1.0.1 (unreleased)
 
 New Features
 ~~~~~~~~~~~~
+
+
+- Can open `kerchunk` reference files with ``open_virtual_dataset``.
+  (:pull:`251`, :pull:`186`) By `Raphael Hagen <https://github.com/norlandrhagen>`_ & `Kristen Thyng <https://github.com/kthyng>`_.
+
 - Adds defaults for `open_virtual_dataset_from_v3_store` in (:pull:`234`)
   By `Raphael Hagen <https://github.com/norlandrhagen>`_.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -421,6 +421,17 @@ Currently there are not yet any zarr v3 readers which understand the chunk manif
 This store can however be read by {py:func}`~virtualizarr.xarray.open_virtual_dataset`, by passing `filetype="zarr_v3"`.
 ```
 
+## Opening kerchunk references from disk as virtual datasets
+
+You can open kerchunk references from disk as virtual datasets. This may be useful in appending workflows or creating checkpoints for larger datasets.
+
+```python
+vds = open_virtual_dataset('combined.json', format='kerchunk_json')
+# or
+vds = open_virtual_dataset('combined.parquet', format='kerchunk_parquet')
+
+```
+
 ## Rewriting existing manifests
 
 Sometimes it can be useful to rewrite the contents of an already-generated manifest or virtual dataset.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -423,13 +423,14 @@ This store can however be read by {py:func}`~virtualizarr.xarray.open_virtual_da
 
 ## Opening Kerchunk references from disk as virtual datasets
 
-You can open kerchunk references from disk as virtual datasets. This may be useful in appending workflows or creating checkpoints for larger datasets.
+You can open `json` or `paruqet` Kerchunk references from disk as virtual datasets. This may be useful in appending workflows or creating checkpoints for larger datasets.
 
 ```python
 
-vds = open_virtual_dataset('combined.json', format='kerchunk_json')
+vds = open_virtual_dataset('combined.json', format='kerchunk')
 # or
-vds = open_virtual_dataset('combined.parquet', format='kerchunk_parquet')
+vds = open_virtual_dataset('combined.parquet', format='kerchunk')
+
 
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -421,16 +421,15 @@ Currently there are not yet any zarr v3 readers which understand the chunk manif
 This store can however be read by {py:func}`~virtualizarr.xarray.open_virtual_dataset`, by passing `filetype="zarr_v3"`.
 ```
 
-## Opening Kerchunk references from disk as virtual datasets
+## Opening Kerchunk references as virtual datasets
 
-You can open `json` or `paruqet` Kerchunk references from disk as virtual datasets. This may be useful in appending workflows or creating checkpoints for larger datasets.
+You can open existing Kerchunk `json` or `parquet` references as Virtualizarr virtual datasets. This may be useful for converting existing Kerchunk formatted references to storage formats like [Icechunk](https://icechunk.io/).
 
 ```python
 
 vds = open_virtual_dataset('combined.json', format='kerchunk')
 # or
 vds = open_virtual_dataset('combined.parquet', format='kerchunk')
-
 
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -421,11 +421,12 @@ Currently there are not yet any zarr v3 readers which understand the chunk manif
 This store can however be read by {py:func}`~virtualizarr.xarray.open_virtual_dataset`, by passing `filetype="zarr_v3"`.
 ```
 
-## Opening kerchunk references from disk as virtual datasets
+## Opening Kerchunk references from disk as virtual datasets
 
 You can open kerchunk references from disk as virtual datasets. This may be useful in appending workflows or creating checkpoints for larger datasets.
 
 ```python
+
 vds = open_virtual_dataset('combined.json', format='kerchunk_json')
 # or
 vds = open_virtual_dataset('combined.parquet', format='kerchunk_parquet')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,8 @@ test = [
     "pytest",
     "ruff",
     "s3fs",
-    "scipy"]
+    "scipy",
+]
 
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,7 @@ test = [
     "pytest",
     "ruff",
     "s3fs",
-    "scipy",
-]
+    "scipy"]
 
 
 [project.urls]
@@ -85,6 +84,10 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "kerchunk.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "ujson.*"
 ignore_missing_imports = true
 
 [tool.ruff]

--- a/virtualizarr/backend.py
+++ b/virtualizarr/backend.py
@@ -141,26 +141,14 @@ def open_virtual_dataset(
         filetype = FileType(filetype)
 
     if filetype == FileType.kerchunk:
-        # add parquet path
-        from fsspec.implementations.reference import LazyReferenceMapper
-
         from virtualizarr.readers.kerchunk import dataset_from_kerchunk_refs
 
         fs = _FsspecFSFromFilepath(filepath=filepath, reader_options=reader_options)
 
-        # yuck, but JSON doesn't have magic bytes
-        if fs.filepath.endswith(".json"):
-            import ujson
-
-            from virtualizarr.readers.kerchunk import dataset_from_kerchunk_refs
-
-            fpath = fs.open_file()
-
-            refs = ujson.load(fpath)
-            return dataset_from_kerchunk_refs(KerchunkStoreRefs(refs))
-
-        # also yuck, but the .parquet isn't actually a parquet it's a directory that contains named parquets for each group.
+        # The kerchunk .parquet storage format isn't actually a parquet, but a directory that contains named parquets for each group/variable.
         if fs.filepath.endswith("ref.parquet"):
+            from fsspec.implementations.reference import LazyReferenceMapper
+
             lrm = LazyReferenceMapper(filepath, fs.fs)
 
             # build reference dict from KV pairs in LazyReferenceMapper
@@ -170,6 +158,21 @@ def open_virtual_dataset(
             full_reference = {"refs": array_refs}
 
             return dataset_from_kerchunk_refs(KerchunkStoreRefs(full_reference))
+
+        # JSON has no magic bytes, but the Kerchunk version 1 spec starts with 'version':
+        # https://fsspec.github.io/kerchunk/spec.html
+        elif fs.read_bytes(9).startswith(b'{"version'):
+            import ujson
+
+            with fs.open_file() as of:
+                refs = ujson.load(of)
+
+            return dataset_from_kerchunk_refs(KerchunkStoreRefs(refs))
+
+        else:
+            raise ValueError(
+                "The input Kerchunk reference did not seem to be in Kerchunk's JSON or Parquet spec: https://fsspec.github.io/kerchunk/spec.html. The Kerchunk format autodetection is quite flaky, so if your reference matches the Kerchunk spec feel free to open an issue: https://github.com/zarr-developers/VirtualiZarr/issues"
+            )
 
     if filetype == FileType.zarr_v3:
         # TODO is there a neat way of auto-detecting this?

--- a/virtualizarr/backend.py
+++ b/virtualizarr/backend.py
@@ -164,10 +164,10 @@ def open_virtual_dataset(
             lrm = LazyReferenceMapper(filepath, fs.fs)
 
             # build reference dict from KV pairs in LazyReferenceMapper
+            # is there a better / more preformant way to extract this?
             array_refs = {k: lrm[k] for k in lrm.keys()}
 
-            # where does version come from? Is it always 1?
-            full_reference = {"version": 1, "refs": array_refs}
+            full_reference = {"refs": array_refs}
 
             return dataset_from_kerchunk_refs(KerchunkStoreRefs(full_reference))
 

--- a/virtualizarr/backend.py
+++ b/virtualizarr/backend.py
@@ -158,7 +158,7 @@ def open_virtual_dataset(
         return dataset_from_kerchunk_refs(KerchunkStoreRefs(full_reference))
 
     if filetype == FileType.kerchunk_json:
-        import ast
+        import ujson
 
         from virtualizarr.readers.kerchunk import dataset_from_kerchunk_refs
 
@@ -166,8 +166,7 @@ def open_virtual_dataset(
             filepath=filepath, reader_options=reader_options
         ).open_file()
 
-        refs = ast.literal_eval(fpath.read().decode("utf-8"))
-
+        refs = ujson.load(fpath)
         return dataset_from_kerchunk_refs(KerchunkStoreRefs(refs))
 
     if filetype == FileType.zarr_v3:

--- a/virtualizarr/manifests/manifest.py
+++ b/virtualizarr/manifests/manifest.py
@@ -309,7 +309,9 @@ class ChunkManifest:
         chunk_entries: dict[ChunkKey, ChunkDictEntry] = {}
         for k, v in kerchunk_chunk_dict.items():
             if isinstance(v, (str, bytes)):
-                raise NotImplementedError("TODO: handle inlined data")
+                raise NotImplementedError(
+                    "Reading inlined reference data is currently not supported. [ToDo]"
+                )
             elif not isinstance(v, (tuple, list)):
                 raise TypeError(f"Unexpected type {type(v)} for chunk value: {v}")
             chunk_entries[k] = ChunkEntry.from_kerchunk(v).dict()

--- a/virtualizarr/readers/kerchunk.py
+++ b/virtualizarr/readers/kerchunk.py
@@ -13,7 +13,7 @@ from virtualizarr.types.kerchunk import (
     KerchunkArrRefs,
     KerchunkStoreRefs,
 )
-from virtualizarr.utils import _fsspec_openfile_from_filepath
+from virtualizarr.utils import _FsspecFSFromFilepath
 from virtualizarr.zarr import ZArray, ZAttrs
 
 
@@ -28,9 +28,9 @@ def _automatically_determine_filetype(
         raise NotImplementedError()
 
     # Read magic bytes from local or remote file
-    fpath = _fsspec_openfile_from_filepath(
+    fpath = _FsspecFSFromFilepath(
         filepath=filepath, reader_options=reader_options
-    )
+    ).open_file()
     magic_bytes = fpath.read(8)
     fpath.close()
 

--- a/virtualizarr/tests/test_backend.py
+++ b/virtualizarr/tests/test_backend.py
@@ -341,43 +341,22 @@ class TestLoadVirtualDataset:
 @pytest.mark.parametrize(
     "reference_format",
     [
-        pytest.param(
-            "kerchunk_json", marks=pytest.mark.xfail(reason="asserts fail - WIP")
-        ),
-        pytest.param(
-            "kerchunk_parquet",
-            marks=pytest.mark.skip(reason="parquet reading not yet added"),
-        ),
+        "kerchunk_json",
+        pytest.param("kerchunk_parquet", marks=pytest.mark.skip(reason="wip")),
     ],
 )
 def test_open_virtual_dataset_existing_kerchunk_refs(
-    tmp_path, netcdf4_file, reference_format
+    tmp_path, example_reference_dict, reference_format
 ):
-    from kerchunk.hdf import SingleHdf5ToZarr
-
-    # FIXME/WARNING/TODO: `inline_threshold` set to 1, so we don't get inlining of refs.
-    # Reading inlined vars as ManifestArrays is currently not implemented.
-    refs = SingleHdf5ToZarr(netcdf4_file, inline_threshold=1).translate()
-
     if reference_format == "kerchunk_json":
-        import ujson
-
         ref_filepath = tmp_path / "ref.json"
-        with open(ref_filepath, "wb") as f:
-            f.write(ujson.dumps(refs).encode())
-    # WIP
-    # if reference_format == 'kerchunk_parquet':
-    #     ref_filepath = tmp_path / 'ref.parquet'
-    #     from kerchunk.df import refs_to_dataframe
-    #     refs_to_dataframe(fo=refs, url = ref_filepath.as_posix())
+        with open(ref_filepath, "w") as f:
+            f.write(repr(example_reference_dict))
 
     vds = open_virtual_dataset(
         filepath=ref_filepath, filetype=reference_format, indexes={}
     )
 
-    # FIXME: variable names have a trailing \
-    assert list(vds) == ["time", "lat", "air", "lon"]
-    # FIXME: coodinates empty
-    assert set(vds.coords) == set("lat", "lon", "time")
-    # FIXME: coords [lat, lon, time] are in data variables
-    assert list(vds.variables) == ["air"]
+    assert list(vds) == ["air"]
+    assert set(vds.coords) == set(["lat", "lon", "time"])
+    assert set(vds.variables) == set(["lat", "air", "lon", "time"])

--- a/virtualizarr/tests/test_backend.py
+++ b/virtualizarr/tests/test_backend.py
@@ -342,7 +342,7 @@ class TestLoadVirtualDataset:
     "reference_format",
     [
         "kerchunk_json",
-        pytest.param("kerchunk_parquet", marks=pytest.mark.skip(reason="wip")),
+        "kerchunk_parquet",
     ],
 )
 def test_open_virtual_dataset_existing_kerchunk_refs(
@@ -353,8 +353,14 @@ def test_open_virtual_dataset_existing_kerchunk_refs(
         with open(ref_filepath, "w") as f:
             f.write(repr(example_reference_dict))
 
+    if reference_format == "kerchunk_parquet":
+        from kerchunk.df import refs_to_dataframe
+
+        ref_filepath = tmp_path / "ref.parquet"
+        refs_to_dataframe(fo=example_reference_dict, url=ref_filepath.as_posix())
+
     vds = open_virtual_dataset(
-        filepath=ref_filepath, filetype=reference_format, indexes={}
+        filepath=ref_filepath.as_posix(), filetype=reference_format, indexes={}
     )
 
     assert list(vds) == ["air"]

--- a/virtualizarr/tests/test_backend.py
+++ b/virtualizarr/tests/test_backend.py
@@ -350,15 +350,17 @@ def test_open_virtual_dataset_existing_kerchunk_refs(
 ):
     if reference_format == "kerchunk_json":
         ref_filepath = tmp_path / "ref.json"
-        with open(ref_filepath, "w") as f:
-            f.write(repr(example_reference_dict))
+
+        import ujson
+
+        with open(ref_filepath, "w") as json_file:
+            ujson.dump(example_reference_dict, json_file)
 
     if reference_format == "kerchunk_parquet":
         from kerchunk.df import refs_to_dataframe
 
         ref_filepath = tmp_path / "ref.parquet"
         refs_to_dataframe(fo=example_reference_dict, url=ref_filepath.as_posix())
-
     vds = open_virtual_dataset(
         filepath=ref_filepath.as_posix(), filetype=reference_format, indexes={}
     )

--- a/virtualizarr/tests/test_backend.py
+++ b/virtualizarr/tests/test_backend.py
@@ -341,8 +341,13 @@ class TestLoadVirtualDataset:
 @pytest.mark.parametrize(
     "reference_format",
     [
-        "kerchunk_json",
-        pytest.param("kerchunk_parquet", marks=pytest.mark.skip(reason="wip")),
+        pytest.param(
+            "kerchunk_json", marks=pytest.mark.xfail(reason="asserts fail - WIP")
+        ),
+        pytest.param(
+            "kerchunk_parquet",
+            marks=pytest.mark.skip(reason="parquet reading not yet added"),
+        ),
     ],
 )
 def test_open_virtual_dataset_existing_kerchunk_refs(

--- a/virtualizarr/tests/test_utils.py
+++ b/virtualizarr/tests/test_utils.py
@@ -7,7 +7,7 @@ import fsspec.implementations.memory
 import pytest
 import xarray as xr
 
-from virtualizarr.utils import _fsspec_openfile_from_filepath
+from virtualizarr.utils import _FsspecFSFromFilepath
 
 
 @pytest.fixture
@@ -21,7 +21,7 @@ def test_fsspec_openfile_from_path(tmp_path: pathlib.Path, dataset: xr.Dataset) 
     f = tmp_path / "dataset.nc"
     dataset.to_netcdf(f)
 
-    result = _fsspec_openfile_from_filepath(filepath=f.as_posix())
+    result = _FsspecFSFromFilepath(filepath=f.as_posix()).open_file()
     assert isinstance(result, fsspec.implementations.local.LocalFileOpener)
 
 
@@ -32,6 +32,6 @@ def test_fsspec_openfile_memory(dataset: xr.Dataset):
         with fs.open("dataset.nc", mode="wb") as f:
             dataset.to_netcdf(f, engine="h5netcdf")
 
-    result = _fsspec_openfile_from_filepath(filepath="memory://dataset.nc")
+    result = _FsspecFSFromFilepath(filepath="memory://dataset.nc").open_file()
     with result:
         assert isinstance(result, fsspec.implementations.memory.MemoryFile)

--- a/virtualizarr/utils.py
+++ b/virtualizarr/utils.py
@@ -45,6 +45,10 @@ class _FsspecFSFromFilepath:
         """
         return self.fs.open(self.filepath)
 
+    def read_bytes(self, bytes: int) -> bytes:
+        with self.open_file() as of:
+            return of.read(bytes)
+
     def __post_init__(self) -> None:
         """Initialize the fsspec filesystem object"""
         import fsspec

--- a/virtualizarr/utils.py
+++ b/virtualizarr/utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import io
-from typing import TYPE_CHECKING, Dict, Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 if TYPE_CHECKING:
     import fsspec.core
@@ -25,14 +25,14 @@ class _FsspecFSFromFilepath:
     filepath : str
         Input filepath
     reader_options : dict, optional
-        Dict containing kwargs to pass to file opener, by default {}
+        dict containing kwargs to pass to file opener, by default {}
     fs : Option | None
         The fsspec filesystem object, created in __post_init__
 
     """
 
     filepath: str
-    reader_options: Optional[Dict] = field(default_factory=dict)
+    reader_options: Optional[dict] = field(default_factory=dict)
     fs: fsspec.AbstractFileSystem = field(init=False)
 
     def open_file(self) -> OpenFileType:

--- a/virtualizarr/utils.py
+++ b/virtualizarr/utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import io
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Dict, Optional, Union
 
 if TYPE_CHECKING:
     import fsspec.core
@@ -13,12 +13,12 @@ if TYPE_CHECKING:
     ]
 
 
-def _fsspec_openfile_from_filepath(
-    *,
-    filepath: str,
-    reader_options: Optional[dict] = None,
-) -> OpenFileType:
-    """Converts input filepath to fsspec openfile object.
+from dataclasses import dataclass, field
+
+
+@dataclass
+class _FsspecFSFromFilepath:
+    """Class to create fsspec Filesystem from input filepath.
 
     Parameters
     ----------
@@ -26,29 +26,34 @@ def _fsspec_openfile_from_filepath(
         Input filepath
     reader_options : dict, optional
         Dict containing kwargs to pass to file opener, by default {}
+    fs : Option | None
+        The fsspec filesystem object, created in __post_init__
 
-    Returns
-    -------
-    OpenFileType
-        An open file-like object, specific to the protocol supplied in filepath.
-
-    Raises
-    ------
-    NotImplementedError
-        Raises a Not Implemented Error if filepath protocol is not supported.
     """
 
-    import fsspec
-    from upath import UPath
+    filepath: str
+    reader_options: Optional[Dict] = field(default_factory=dict)
+    fs: fsspec.AbstractFileSystem = field(init=False)
 
-    universal_filepath = UPath(filepath)
-    protocol = universal_filepath.protocol
+    def open_file(self) -> OpenFileType:
+        """Calls `.open` on fsspec.Filesystem instantiation using self.filepath as an input.
 
-    if reader_options is None:
-        reader_options = {}
+        Returns
+        -------
+        OpenFileType
+            file opened with fsspec
+        """
+        return self.fs.open(self.filepath)
 
-    storage_options = reader_options.get("storage_options", {})  # type: ignore
+    def __post_init__(self) -> None:
+        """Initialize the fsspec filesystem object"""
+        import fsspec
+        from upath import UPath
 
-    fpath = fsspec.filesystem(protocol, **storage_options).open(filepath)
+        universal_filepath = UPath(self.filepath)
+        protocol = universal_filepath.protocol
 
-    return fpath
+        self.reader_options = self.reader_options or {}
+        storage_options = self.reader_options.get("storage_options", {})  # type: ignore
+
+        self.fs = fsspec.filesystem(protocol, **storage_options)


### PR DESCRIPTION
## Allow `open_virtual_dataset` to read existing Kerchunk references as virtual datasets

- [x] Closes https://github.com/zarr-developers/VirtualiZarr/issues/118
- [x] Tests added
- [x] Tests passing
- [x] Changes are documented in `docs/releases.rst`
- [x] New functionality has documentation


To Do:
- [x] [JSON] trailing `\\` in variable names. Fixed. `json` was adding trailing slashes on ref write.
- [x] [JSON] coordinates not recognized. Fixed. This was related to `json` write.
- [x] [JSON] coordinates set as data variables. Fixed. This was related to `json` write.
- [x] [PARQUET] extract references from 1. LazyReferenceMapper or 2. Reconstruct reference from :sparkles:_Zarrquet_ :sparkles: format.
- [x] [FUTURE PR] Convert `inlined` vars into numpy arrays. Note: After talking with @sharkinsspatial, it seems like the HDF reader he is working on won't inline at all. Should we: 1. Raise an error if any inline data exists or 2. Add logic to convert any inlined bytes to numpy arrays to maintain more compatibility with other Kerchunk readers?

Notes:
- Mypy checks in CI are currently disabled! https://github.com/zarr-developers/VirtualiZarr/issues/249
- The utility function `_fsspec_openfile_from_filepath` forced the fsspec filesystem to open a filepath (the fault of past me). I replaced it with a simple class that has a `.open_file` method that can be used as needed. The Kerchunk `LazyReferenceMapper` required a fsspec filesystem. 



