### PR TITLE
Change nan default fill_value for kerchunk arrays

### DIFF
--- a/virtualizarr/tests/test_kerchunk.py
+++ b/virtualizarr/tests/test_kerchunk.py
@@ -23,7 +23,7 @@ def test_kerchunk_roundtrip_in_memory_no_concat():
             chunks=(2, 2),
             compressor=None,
             filters=None,
-            fill_value=np.nan,
+            fill_value=None,
             order="C",
         ),
         chunkmanifest=manifest,

--- a/virtualizarr/tests/test_manifests/test_array.py
+++ b/virtualizarr/tests/test_manifests/test_array.py
@@ -46,7 +46,7 @@ class TestManifestArray:
         assert marr.chunks == (2, 3)
         assert marr.dtype == np.dtype("int64")
         assert marr.zarray.compressor is None
-        assert marr.zarray.fill_value is None
+        assert marr.zarray.fill_value == 0
         assert marr.zarray.filters is None
         assert marr.zarray.order == "C"
 

--- a/virtualizarr/tests/test_manifests/test_array.py
+++ b/virtualizarr/tests/test_manifests/test_array.py
@@ -46,7 +46,7 @@ class TestManifestArray:
         assert marr.chunks == (2, 3)
         assert marr.dtype == np.dtype("int64")
         assert marr.zarray.compressor is None
-        assert marr.zarray.fill_value is np.nan
+        assert marr.zarray.fill_value is None
         assert marr.zarray.filters is None
         assert marr.zarray.order == "C"
 

--- a/virtualizarr/tests/test_readers/test_kerchunk.py
+++ b/virtualizarr/tests/test_readers/test_kerchunk.py
@@ -37,7 +37,7 @@ def test_dataset_from_df_refs():
 
     assert da.data.zarray.compressor is None
     assert da.data.zarray.filters is None
-    assert da.data.zarray.fill_value is np.nan
+    assert da.data.zarray.fill_value is None
     assert da.data.zarray.order == "C"
 
     assert da.data.manifest.dict() == {

--- a/virtualizarr/tests/test_readers/test_kerchunk.py
+++ b/virtualizarr/tests/test_readers/test_kerchunk.py
@@ -37,7 +37,7 @@ def test_dataset_from_df_refs():
 
     assert da.data.zarray.compressor is None
     assert da.data.zarray.filters is None
-    assert da.data.zarray.fill_value is None
+    assert da.data.zarray.fill_value == 0
     assert da.data.zarray.order == "C"
 
     assert da.data.manifest.dict() == {

--- a/virtualizarr/tests/test_zarr.py
+++ b/virtualizarr/tests/test_zarr.py
@@ -27,3 +27,31 @@ def test_replace_total():
     result = arr.replace(**kwargs)
     expected = ZArray(**kwargs)
     assert result == expected
+
+
+def test_nan_fill_value_from_kerchunk():
+    i_arr = ZArray.from_kerchunk_refs({
+        "chunks": [2, 3],
+        "compressor": None,
+        "dtype": "<i8",
+        "fill_value": None,
+        "filters": None,
+        "order": "C",
+        "shape": [2, 3],
+        "zarr_format": 2,
+    })
+
+    assert i_arr.fill_value == 0
+
+    f_arr = ZArray.from_kerchunk_refs({
+        "chunks": [2, 3],
+        "compressor": None,
+        "dtype": "<f8",
+        "fill_value": None,
+        "filters": None,
+        "order": "C",
+        "shape": [2, 3],
+        "zarr_format": 2,
+    })
+
+    assert f_arr.fill_value is np.nan

--- a/virtualizarr/tests/test_zarr.py
+++ b/virtualizarr/tests/test_zarr.py
@@ -30,28 +30,32 @@ def test_replace_total():
 
 
 def test_nan_fill_value_from_kerchunk():
-    i_arr = ZArray.from_kerchunk_refs({
-        "chunks": [2, 3],
-        "compressor": None,
-        "dtype": "<i8",
-        "fill_value": None,
-        "filters": None,
-        "order": "C",
-        "shape": [2, 3],
-        "zarr_format": 2,
-    })
+    i_arr = ZArray.from_kerchunk_refs(
+        {
+            "chunks": [2, 3],
+            "compressor": None,
+            "dtype": "<i8",
+            "fill_value": None,
+            "filters": None,
+            "order": "C",
+            "shape": [2, 3],
+            "zarr_format": 2,
+        }
+    )
 
     assert i_arr.fill_value == 0
 
-    f_arr = ZArray.from_kerchunk_refs({
-        "chunks": [2, 3],
-        "compressor": None,
-        "dtype": "<f8",
-        "fill_value": None,
-        "filters": None,
-        "order": "C",
-        "shape": [2, 3],
-        "zarr_format": 2,
-    })
+    f_arr = ZArray.from_kerchunk_refs(
+        {
+            "chunks": [2, 3],
+            "compressor": None,
+            "dtype": "<f8",
+            "fill_value": None,
+            "filters": None,
+            "order": "C",
+            "shape": [2, 3],
+            "zarr_format": 2,
+        }
+    )
 
     assert f_arr.fill_value is np.nan

--- a/virtualizarr/zarr.py
+++ b/virtualizarr/zarr.py
@@ -73,9 +73,12 @@ class ZArray:
 
     @classmethod
     def from_kerchunk_refs(cls, decoded_arr_refs_zarray) -> "ZArray":
-        # coerce type of fill_value as kerchunk can be inconsistent with this
+        # coerce type of fill_value for floats, as kerchunk can be inconsistent with this
+        dtype = np.dtype(decoded_arr_refs_zarray["dtype"])
         fill_value = decoded_arr_refs_zarray["fill_value"]
-        if fill_value == "NaN" or fill_value == "nan":
+        if np.issubdtype(dtype, np.floating) and (
+            fill_value is None or fill_value == "NaN" or fill_value == "nan"
+        ):
             fill_value = np.nan
 
         compressor = decoded_arr_refs_zarray["compressor"]
@@ -86,7 +89,7 @@ class ZArray:
         return ZArray(
             chunks=tuple(decoded_arr_refs_zarray["chunks"]),
             compressor=compressor,
-            dtype=np.dtype(decoded_arr_refs_zarray["dtype"]),
+            dtype=dtype,
             fill_value=fill_value,
             filters=decoded_arr_refs_zarray["filters"],
             order=decoded_arr_refs_zarray["order"],

--- a/virtualizarr/zarr.py
+++ b/virtualizarr/zarr.py
@@ -75,7 +75,7 @@ class ZArray:
     def from_kerchunk_refs(cls, decoded_arr_refs_zarray) -> "ZArray":
         # coerce type of fill_value as kerchunk can be inconsistent with this
         fill_value = decoded_arr_refs_zarray["fill_value"]
-        if fill_value is None or fill_value == "NaN" or fill_value == "nan":
+        if fill_value == "NaN" or fill_value == "nan":
             fill_value = np.nan
 
         compressor = decoded_arr_refs_zarray["compressor"]


### PR DESCRIPTION
This removes adding `nan` as the `fill_value` for kerchunk references that incklude `fill_value=null`. This is necessary because only floats can have `nan` values represented 

- [ ] Closes #xxxx
- [x] Tests added
- [x] Tests passing
- [x] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
