### PR TITLE
Import top-level version of xarray classes

### DIFF
--- a/virtualizarr/backend.py
+++ b/virtualizarr/backend.py
@@ -7,8 +7,7 @@ from typing import (
     Optional,
 )
 
-from xarray import Dataset
-from xarray.core.indexes import Index
+from xarray import Dataset, Index
 
 from virtualizarr.manifests import ManifestArray
 from virtualizarr.readers import (

--- a/virtualizarr/readers/dmrpp.py
+++ b/virtualizarr/readers/dmrpp.py
@@ -6,9 +6,7 @@ from typing import Any, Iterable, Optional
 from xml.etree import ElementTree as ET
 
 import numpy as np
-from xarray import Coordinates, Dataset
-from xarray.core.indexes import Index
-from xarray.core.variable import Variable
+from xarray import Coordinates, Dataset, Index, Variable
 
 from virtualizarr.manifests import ChunkManifest, ManifestArray
 from virtualizarr.readers.common import VirtualBackend

--- a/virtualizarr/readers/fits.py
+++ b/virtualizarr/readers/fits.py
@@ -1,7 +1,6 @@
 from typing import Iterable, Mapping, Optional
 
-from xarray import Dataset
-from xarray.core.indexes import Index
+from xarray import Dataset, Index
 
 from virtualizarr.readers.common import (
     VirtualBackend,

--- a/virtualizarr/readers/hdf5.py
+++ b/virtualizarr/readers/hdf5.py
@@ -1,7 +1,6 @@
 from typing import Iterable, Mapping, Optional
 
-from xarray import Dataset
-from xarray.core.indexes import Index
+from xarray import Dataset, Index
 
 from virtualizarr.readers.common import (
     VirtualBackend,

--- a/virtualizarr/readers/kerchunk.py
+++ b/virtualizarr/readers/kerchunk.py
@@ -1,8 +1,7 @@
 from typing import Iterable, Mapping, Optional
 
 import ujson
-from xarray import Dataset
-from xarray.core.indexes import Index
+from xarray import Dataset, Index
 
 from virtualizarr.readers.common import VirtualBackend
 from virtualizarr.translators.kerchunk import dataset_from_kerchunk_refs

--- a/virtualizarr/readers/netcdf3.py
+++ b/virtualizarr/readers/netcdf3.py
@@ -1,7 +1,6 @@
 from typing import Iterable, Mapping, Optional
 
-from xarray import Dataset
-from xarray.core.indexes import Index
+from xarray import Dataset, Index
 
 from virtualizarr.readers.common import (
     VirtualBackend,

--- a/virtualizarr/readers/tiff.py
+++ b/virtualizarr/readers/tiff.py
@@ -1,8 +1,7 @@
 import warnings
 from typing import Iterable, Mapping, Optional
 
-from xarray import Dataset
-from xarray.core.indexes import Index
+from xarray import Dataset, Index
 
 from virtualizarr.readers.common import (
     VirtualBackend,

--- a/virtualizarr/readers/zarr_v3.py
+++ b/virtualizarr/readers/zarr_v3.py
@@ -4,9 +4,7 @@ from typing import Iterable, Mapping, Optional
 
 import numcodecs
 import numpy as np
-from xarray import Dataset
-from xarray.core.indexes import Index
-from xarray.core.variable import Variable
+from xarray import Dataset, Index, Variable
 
 from virtualizarr.manifests import ChunkManifest, ManifestArray
 from virtualizarr.readers.common import VirtualBackend, separate_coords


### PR DESCRIPTION
For some reason I always thought that `Variable` and `Index` were private xarray internals, but they are actually available in the top-level namespace!

Now the only things we import from xarray that aren't at the top level are

```python
from xarray.backends import AbstractDataStore, BackendArray
from xarray.core.indexes import PandasIndex
```

which are both semi-public anyway.