### PR TITLE
Bump minimum Xarray dependency to 2024.10.0

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - h5py
   - hdf5
   - netcdf4
-  - xarray>=2024.6.0
+  - xarray>=2024.10.0
   - kerchunk>=0.2.5
   - numpy>=2.0.0
   - ujson

--- a/ci/min-deps.yml
+++ b/ci/min-deps.yml
@@ -7,7 +7,7 @@ dependencies:
   - h5py
   - hdf5
   - netcdf4
-  - xarray>=2024.6.0
+  - xarray>=2024.10.0
   - numpy>=2.0.0
   - numcodecs
   - packaging

--- a/ci/upstream.yml
+++ b/ci/upstream.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
+  - xarray>=2024.10.0
   - h5netcdf
   - h5py
   - hdf5
@@ -25,6 +26,5 @@ dependencies:
   - pip
   - pip:
     - icechunk # Installs zarr v3 as dependency
-    - git+https://github.com/pydata/xarray@zarr-v3  # zarr-v3 compatibility branch
     - git+https://github.com/zarr-developers/numcodecs@zarr3-codecs  # zarr-v3 compatibility branch
     # - git+https://github.com/fsspec/kerchunk@main  # kerchunk is currently incompatible with zarr-python v3 (https://github.com/fsspec/kerchunk/pull/516)

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -42,6 +42,8 @@ Breaking changes
 - VirtualiZarr's `ZArray`, `ChunkEntry`, and `Codec` no longer subclass
   `pydantic.BaseModel` (:pull:`210`)
 - `ZArray`'s `__init__` signature has changed to match `zarr.Array`'s (:pull:`210`)
+- Minimum required version of Xarray is now v2024.10.0.
+  (:pull:`284`) By `Tom Nicholas <https://github.com/TomNicholas>`_.
 
 Deprecations
 ~~~~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 requires-python = ">=3.10"
 dynamic = ["version"]
 dependencies = [
-    "xarray>=2024.06.0",
+    "xarray>=2024.10.0",
     "numpy>=2.0.0",
     "packaging",
     "universal-pathlib",

--- a/virtualizarr/readers/common.py
+++ b/virtualizarr/readers/common.py
@@ -4,7 +4,6 @@ from abc import ABC
 from collections.abc import Iterable, Mapping, MutableMapping
 from io import BufferedIOBase
 from typing import (
-    TYPE_CHECKING,
     Any,
     Hashable,
     Optional,
@@ -14,6 +13,7 @@ from typing import (
 from xarray import (
     Coordinates,
     Dataset,
+    DataTree,
     Index,
     IndexVariable,
     Variable,
@@ -25,12 +25,6 @@ from xarray.core.indexes import PandasIndex
 from virtualizarr.utils import _FsspecFSFromFilepath
 
 XArrayOpenT = str | os.PathLike[Any] | BufferedIOBase | AbstractDataStore
-
-if TYPE_CHECKING:
-    try:
-        from xarray import DataTree  # type: ignore[attr-defined]
-    except ImportError:
-        DataTree = Any
 
 
 def open_loadable_vars_and_indexes(
@@ -194,5 +188,5 @@ class VirtualBackend(ABC):
         decode_times: bool | None = None,
         indexes: Mapping[str, Index] | None = None,
         reader_options: Optional[dict] = None,
-    ) -> "DataTree":
+    ) -> DataTree:
         raise NotImplementedError()


### PR DESCRIPTION
This bumps the minimum required version of xarray to the most recent release, which includes support for zarr-python v3 and for `xr.DataTree`. This shouldn't break compatibility with anything.
