### PR TITLE
Tiff zarr reader

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -27,7 +27,8 @@ dependencies:
   - fsspec
   - s3fs
   - fastparquet
-  # for opening tiff files
+  # for opening and creating test tiff files
   - tifffile
+  - pillow
   # for opening FITS files
   - astropy

--- a/conftest.py
+++ b/conftest.py
@@ -120,3 +120,16 @@ def simple_netcdf4(tmpdir):
     ds.to_netcdf(filepath)
 
     return filepath
+
+
+@pytest.fixture
+def random_tiff(tmpdir):
+    from PIL import Image
+
+    array = np.random.randint(0, 255, (128, 128), dtype=np.uint8)
+    img = Image.fromarray(array)
+
+    filepath = tmpdir / "rand.tiff"
+    img.save(filepath)
+
+    return str(filepath)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,8 @@ test = [
     "ruff",
     "s3fs",
     "scipy",
+    "tifffile",
+    "pillow",
 ]
 
 

--- a/virtualizarr/__init__.py
+++ b/virtualizarr/__init__.py
@@ -1,6 +1,6 @@
 from virtualizarr.manifests import ChunkManifest, ManifestArray  # type: ignore # noqa
 from virtualizarr.accessor import VirtualiZarrDatasetAccessor  # type: ignore # noqa
-from virtualizarr.backend import open_virtual_dataset  # noqa: F401
+from virtualizarr.backend import open_virtual_dataset, open_virtual_dataarray  # noqa: F401
 
 from importlib.metadata import version as _version
 

--- a/virtualizarr/readers/common.py
+++ b/virtualizarr/readers/common.py
@@ -12,6 +12,7 @@ from typing import (
 
 from xarray import (
     Coordinates,
+    DataArray,
     Dataset,
     DataTree,
     Index,
@@ -93,11 +94,11 @@ def open_loadable_vars_and_indexes(
 
 
 def construct_virtual_dataset(
-    virtual_vars,
-    loadable_vars,
-    indexes,
-    coord_names,
-    attrs,
+    virtual_vars: Mapping[str, Variable],
+    loadable_vars: Mapping[str, Variable],
+    indexes: Mapping[str, Index],
+    coord_names: Iterable[str],
+    attrs: dict[str, str],
 ) -> Dataset:
     """Construct a virtual Datset from consistuent parts."""
 
@@ -115,6 +116,23 @@ def construct_virtual_dataset(
     # TODO we should probably also use vds.set_close() to tell xarray how to close the file we opened
 
     return vds
+
+
+def construct_virtual_dataarray(
+    virtual_var: Variable,
+    loadable_vars: Mapping[str, Variable],
+    indexes: Mapping[str, Index],
+    coord_names: Iterable[str],
+    attrs: dict[str, str],
+) -> DataArray:
+
+    vda = DataArray(
+        data=virtual_var,
+        coords=coord_names,
+        # indexes={},  # TODO should be added in a later version of xarray
+        attrs=attrs,
+    )
+    return vda
 
 
 def separate_coords(
@@ -167,6 +185,18 @@ def separate_coords(
 
 
 class VirtualBackend(ABC):
+    @staticmethod
+    def open_virtual_dataarray(
+        filepath: str,
+        group: str | None = None,
+        drop_variables: Iterable[str] | None = None,
+        loadable_variables: Iterable[str] | None = None,
+        decode_times: bool | None = None,
+        indexes: Mapping[str, Index] | None = None,
+        reader_options: Optional[dict] = None,
+    ) -> DataArray:
+        raise NotImplementedError()
+
     @staticmethod
     def open_virtual_dataset(
         filepath: str,

--- a/virtualizarr/readers/tiff.py
+++ b/virtualizarr/readers/tiff.py
@@ -9,7 +9,6 @@ from virtualizarr.readers.common import (
     open_loadable_vars_and_indexes,
 )
 from virtualizarr.translators.kerchunk import (
-    extract_group,
     virtual_vars_and_metadata_from_kerchunk_refs,
 )
 from virtualizarr.types.kerchunk import KerchunkStoreRefs
@@ -45,7 +44,9 @@ class TIFFVirtualBackend(VirtualBackend):
         # handle inconsistency in kerchunk, see GH issue https://github.com/zarr-developers/VirtualiZarr/issues/160
         refs = KerchunkStoreRefs({"refs": tiff_to_zarr(filepath, **reader_options)})
 
-        refs = extract_group(refs, group)
+        print(refs)
+
+        # refs = extract_group(refs, group)
 
         virtual_vars, attrs, coord_names = virtual_vars_and_metadata_from_kerchunk_refs(
             refs,

--- a/virtualizarr/readers/zarr.py
+++ b/virtualizarr/readers/zarr.py
@@ -1,0 +1,50 @@
+import io
+
+from xarray import Variable
+import zarr
+
+from virtualizarr.zarr import ZArray
+from virtualizarr.manifests import ChunkManifest, ManifestArray
+
+
+def virtual_variable_from_zarr_array(za: zarr.Array) -> Variable:
+    """
+    Create a virtual xarray.Variable wrapping a ManifestArray from a single zarr.Array.
+    """
+
+    # TODO this only works with zarr-python v2 for now
+
+    attrs = dict(za.attrs)
+
+    # extract _ARRAY_DIMENSIONS and remove it from attrs
+    # TODO handle v3 DIMENSION_NAMES too
+    dims = attrs.pop("_ARRAY_DIMENSIONS")
+
+    zarray = ZArray(
+        shape=za.shape,
+        chunks=za.chunks,
+        dtype=za.dtype,
+        fill_value=za.fill_value,
+        order=za.order,
+        compressor=za.compressor,
+        filters=za.filters,
+        #zarr_format=za.zarr_format,
+    )
+    
+    manifest = chunkmanifest_from_zarr_array(za)
+
+    ma = ManifestArray(chunkmanifest=manifest, zarray=zarray)
+
+    return Variable(data=ma, dims=dims, attrs=attrs)
+
+
+def chunkmanifest_from_zarr_array(za: zarr.Array) -> ChunkManifest:
+    import ujson
+
+    of2 = io.StringIO()
+
+    # TODO handle remote urls
+    za.store.write_fsspec(of2)# , url=url)
+    out = ujson.loads(of2.getvalue())
+
+    print(out)

--- a/virtualizarr/tests/__init__.py
+++ b/virtualizarr/tests/__init__.py
@@ -37,6 +37,7 @@ has_kerchunk, requires_kerchunk = _importorskip("kerchunk")
 has_s3fs, requires_s3fs = _importorskip("s3fs")
 has_scipy, requires_scipy = _importorskip("scipy")
 has_tifffile, requires_tifffile = _importorskip("tifffile")
+has_pillow, requires_pillow = _importorskip("PIL")
 
 
 def create_manifestarray(

--- a/virtualizarr/tests/test_readers/test_tiff.py
+++ b/virtualizarr/tests/test_readers/test_tiff.py
@@ -1,0 +1,26 @@
+from xarray import Dataset
+import numpy as np
+
+from virtualizarr.tests import requires_pillow
+from virtualizarr import open_virtual_dataset
+from virtualizarr.manifests import ManifestArray
+
+
+@requires_pillow
+def test_random_tiff(random_tiff):
+    vds = open_virtual_dataset(random_tiff, indexes={})
+
+    assert isinstance(vds, Dataset)
+
+    # TODO what is the name of this array expected to be??    
+    assert list(vds.variables) == ["foo"]
+    vda = vds["foo"]
+
+    assert vda.sizes == {"X": 128, "Y": 128}
+    assert vda.dtype == np.uint8
+
+    assert isinstance(vda.data, ManifestArray)
+    manifest = vda.data.manifest
+    assert manifest.dict() == {
+        '0.0': {'path': random_tiff, 'offset': 122, 'length': 16384} 
+    }

--- a/virtualizarr/tests/test_readers/test_tiff.py
+++ b/virtualizarr/tests/test_readers/test_tiff.py
@@ -1,20 +1,16 @@
 import numpy as np
-from xarray import Dataset
+from xarray import DataArray
 
-from virtualizarr import open_virtual_dataset
+from virtualizarr import open_virtual_dataarray
 from virtualizarr.manifests import ManifestArray
 from virtualizarr.tests import requires_pillow
 
 
 @requires_pillow
 def test_random_tiff(random_tiff):
-    vds = open_virtual_dataset(random_tiff, indexes={})
+    vda = open_virtual_dataarray(random_tiff, indexes={})
 
-    assert isinstance(vds, Dataset)
-
-    # TODO what is the name of this array expected to be??
-    assert list(vds.variables) == ["foo"]
-    vda = vds["foo"]
+    assert isinstance(vda, DataArray)
 
     assert vda.sizes == {"X": 128, "Y": 128}
     assert vda.dtype == np.uint8

--- a/virtualizarr/tests/test_readers/test_tiff.py
+++ b/virtualizarr/tests/test_readers/test_tiff.py
@@ -1,9 +1,9 @@
-from xarray import Dataset
 import numpy as np
+from xarray import Dataset
 
-from virtualizarr.tests import requires_pillow
 from virtualizarr import open_virtual_dataset
 from virtualizarr.manifests import ManifestArray
+from virtualizarr.tests import requires_pillow
 
 
 @requires_pillow
@@ -12,7 +12,7 @@ def test_random_tiff(random_tiff):
 
     assert isinstance(vds, Dataset)
 
-    # TODO what is the name of this array expected to be??    
+    # TODO what is the name of this array expected to be??
     assert list(vds.variables) == ["foo"]
     vda = vds["foo"]
 
@@ -22,5 +22,5 @@ def test_random_tiff(random_tiff):
     assert isinstance(vda.data, ManifestArray)
     manifest = vda.data.manifest
     assert manifest.dict() == {
-        '0.0': {'path': random_tiff, 'offset': 122, 'length': 16384} 
+        "0.0": {"path": random_tiff, "offset": 122, "length": 16384}
     }


### PR DESCRIPTION
Alternative approach to #291, that uses `tifffile` directly instead of via kerchunk's `tiff_to_zarr`. However it doesn't work yet, not least because `tifffile` doesn't support zarr-python v3.

- [x] Closes #291
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
