### PR TITLE
Remove numcodecs specific install

### DIFF
--- a/ci/upstream.yml
+++ b/ci/upstream.yml
@@ -26,5 +26,4 @@ dependencies:
   - pip
   - pip:
     - icechunk # Installs zarr v3 as dependency
-    - git+https://github.com/zarr-developers/numcodecs@zarr3-codecs  # zarr-v3 compatibility branch
     # - git+https://github.com/fsspec/kerchunk@main  # kerchunk is currently incompatible with zarr-python v3 (https://github.com/fsspec/kerchunk/pull/516)


### PR DESCRIPTION
support for zarr v3 numcodecs codecs has been released in numcodecs 0.14.0. This PR just updates the upstream ci to match

As noted in https://github.com/earth-mover/icechunk/issues/197

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
