### PR TITLE
Update pkg install in docs contribution guide

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -26,7 +26,7 @@ Whilst the CI will build the updated documentation for each PR, it can also be u
 ```bash
 mamba env create -f ci/doc.yml
 mamba activate virtualizarr-docs
-pip install -e . # From project's root - needed to generate API docs
+python -m pip install -e .  # From project's root - needed to generate API docs
 cd docs # From project's root
 rm -rf generated
 make clean

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -37,6 +37,8 @@ Documentation
   (:issue:`291`, :pull:`296`) By `Tom Nicholas <https://github.com/TomNicholas>`_.
 - Minor improvements to the Contributing Guide.
   (:pull:`298`) By `Tom Nicholas <https://github.com/TomNicholas>`_.
+- More minor improvements to the Contributing Guide.
+  (:pull:`304`) By `Doug Latornell <https://github.com/DougLatornell>`_.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Changed the command to install the project for docs development to use `python -m pip`. This ensures that the Python interpreter from the activated environment is used when installing the package in editable mode.

- [x] Changes are documented in `docs/releases.rst`
