### PR TITLE
Support downstream type checking by including py.typed

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -43,6 +43,9 @@ Documentation
 Internal Changes
 ~~~~~~~~~~~~~~~~
 
+- Support downstream type checking by adding py.typed marker file.
+  (:pull:`306`) By `Max Jones <https://github.com/maxrjones>`_.
+
 .. _v1.1.0:
 
 v1.1.0 (22nd Oct 2024)


### PR DESCRIPTION
Following https://peps.python.org/pep-0561/, a package must add a marker file named `py.typed` to their package to suppoer type checking of their code. I'd like to use VirtualiZarr's type checking in https://github.com/developmentseed/virtualize-nex-gddp-cmip6 and expect others would find this helpful, so this PR adds the marker file to the package.