### PR TITLE
Add reader_kwargs argument to open_virtual_dataset

### DIFF
--- a/virtualizarr/backend.py
+++ b/virtualizarr/backend.py
@@ -113,6 +113,7 @@ def open_virtual_dataset(
     cftime_variables: Iterable[str] | None = None,
     indexes: Mapping[str, Index] | None = None,
     virtual_array_class=ManifestArray,
+    reader_kwargs: Optional[dict] = None,
     reader_options: Optional[dict] = None,
     backend: Optional[VirtualBackend] = None,
 ) -> Dataset:
@@ -147,6 +148,8 @@ def open_virtual_dataset(
     virtual_array_class
         Virtual array class to use to represent the references to the chunks in each on-disk array.
         Currently can only be ManifestArray, but once VirtualZarrArray is implemented the default should be changed to that.
+    reader_kwargs: dict, default is None
+        Dictionary of keyword arguments passed down to this reader. Allows passing arguments specific to certain readers.
     reader_options: dict, default {}
         Dict passed into Kerchunk file readers, to allow reading from remote filesystems.
         Note: Each Kerchunk file reader has distinct arguments, so ensure reader_options match selected Kerchunk reader arguments.
@@ -201,6 +204,7 @@ def open_virtual_dataset(
         loadable_variables=loadable_variables,
         decode_times=decode_times,
         indexes=indexes,
+        reader_kwargs=reader_kwargs,
         reader_options=reader_options,
     )
 

--- a/virtualizarr/readers/common.py
+++ b/virtualizarr/readers/common.py
@@ -175,6 +175,7 @@ class VirtualBackend(ABC):
         loadable_variables: Iterable[str] | None = None,
         decode_times: bool | None = None,
         indexes: Mapping[str, Index] | None = None,
+        reader_kwargs: Optional[dict] = None,
         reader_options: Optional[dict] = None,
     ) -> Dataset:
         raise NotImplementedError()
@@ -187,6 +188,7 @@ class VirtualBackend(ABC):
         loadable_variables: Iterable[str] | None = None,
         decode_times: bool | None = None,
         indexes: Mapping[str, Index] | None = None,
+        reader_kwargs: Optional[dict] = None,
         reader_options: Optional[dict] = None,
     ) -> DataTree:
         raise NotImplementedError()

--- a/virtualizarr/readers/dmrpp.py
+++ b/virtualizarr/readers/dmrpp.py
@@ -23,12 +23,18 @@ class DMRPPVirtualBackend(VirtualBackend):
         loadable_variables: Iterable[str] | None = None,
         decode_times: bool | None = None,
         indexes: Mapping[str, Index] | None = None,
+        reader_kwargs: Optional[dict] = None,
         reader_options: Optional[dict] = None,
     ) -> Dataset:
         loadable_variables, drop_variables = check_for_collisions(
             drop_variables=drop_variables,
             loadable_variables=loadable_variables,
         )
+
+        if reader_kwargs:
+            raise NotImplementedError(
+                "DMR++ reader does not understand any reader_kwargs"
+            )
 
         if loadable_variables != [] or decode_times or indexes is None:
             raise NotImplementedError(

--- a/virtualizarr/readers/fits.py
+++ b/virtualizarr/readers/fits.py
@@ -23,9 +23,15 @@ class FITSVirtualBackend(VirtualBackend):
         loadable_variables: Iterable[str] | None = None,
         decode_times: bool | None = None,
         indexes: Mapping[str, Index] | None = None,
+        reader_kwargs: Optional[dict] = None,
         reader_options: Optional[dict] = None,
     ) -> Dataset:
         from kerchunk.fits import process_file
+
+        if reader_kwargs:
+            raise NotImplementedError(
+                "FITS reader does not understand any reader_kwargs"
+            )
 
         # handle inconsistency in kerchunk, see GH issue https://github.com/zarr-developers/VirtualiZarr/issues/160
         refs = KerchunkStoreRefs({"refs": process_file(filepath, **reader_options)})

--- a/virtualizarr/readers/hdf/hdf.py
+++ b/virtualizarr/readers/hdf/hdf.py
@@ -38,8 +38,14 @@ class HDFVirtualBackend(VirtualBackend):
         loadable_variables: Iterable[str] | None = None,
         decode_times: bool | None = None,
         indexes: Mapping[str, Index] | None = None,
+        reader_kwargs: Optional[dict] = None,
         reader_options: Optional[dict] = None,
     ) -> xr.Dataset:
+        if reader_kwargs:
+            raise NotImplementedError(
+                "HDF reader does not understand any reader_kwargs"
+            )
+
         drop_variables, loadable_variables = check_for_collisions(
             drop_variables,
             loadable_variables,

--- a/virtualizarr/readers/hdf5.py
+++ b/virtualizarr/readers/hdf5.py
@@ -23,9 +23,15 @@ class HDF5VirtualBackend(VirtualBackend):
         loadable_variables: Iterable[str] | None = None,
         decode_times: bool | None = None,
         indexes: Mapping[str, Index] | None = None,
+        reader_kwargs: Optional[dict] = None,
         reader_options: Optional[dict] = None,
     ) -> Dataset:
         from kerchunk.hdf import SingleHdf5ToZarr
+
+        if reader_kwargs:
+            raise NotImplementedError(
+                "HDF5 reader does not understand any reader_kwargs"
+            )
 
         drop_variables, loadable_variables = check_for_collisions(
             drop_variables,

--- a/virtualizarr/readers/kerchunk.py
+++ b/virtualizarr/readers/kerchunk.py
@@ -20,9 +20,15 @@ class KerchunkVirtualBackend(VirtualBackend):
         loadable_variables: Iterable[str] | None = None,
         decode_times: bool | None = None,
         indexes: Mapping[str, Index] | None = None,
+        reader_kwargs: Optional[dict] = None,
         reader_options: Optional[dict] = None,
     ) -> Dataset:
         """Reads existing kerchunk references (in JSON or parquet) format."""
+
+        if reader_kwargs:
+            raise NotImplementedError(
+                "Kerchunk reader does not understand any reader_kwargs"
+            )
 
         if group:
             raise NotImplementedError()

--- a/virtualizarr/readers/netcdf3.py
+++ b/virtualizarr/readers/netcdf3.py
@@ -23,9 +23,15 @@ class NetCDF3VirtualBackend(VirtualBackend):
         loadable_variables: Iterable[str] | None = None,
         decode_times: bool | None = None,
         indexes: Mapping[str, Index] | None = None,
+        reader_kwargs: Optional[dict] = None,
         reader_options: Optional[dict] = None,
     ) -> Dataset:
         from kerchunk.netCDF3 import NetCDF3ToZarr
+
+        if reader_kwargs:
+            raise NotImplementedError(
+                "netcdf3 reader does not understand any reader_kwargs"
+            )
 
         drop_variables, loadable_variables = check_for_collisions(
             drop_variables,

--- a/virtualizarr/readers/tiff.py
+++ b/virtualizarr/readers/tiff.py
@@ -25,8 +25,14 @@ class TIFFVirtualBackend(VirtualBackend):
         loadable_variables: Iterable[str] | None = None,
         decode_times: bool | None = None,
         indexes: Mapping[str, Index] | None = None,
+        reader_kwargs: Optional[dict] = None,
         reader_options: Optional[dict] = None,
     ) -> Dataset:
+        if reader_kwargs:
+            raise NotImplementedError(
+                "TIFF reader does not understand any reader_kwargs"
+            )
+
         from kerchunk.tiff import tiff_to_zarr
 
         drop_variables, loadable_variables = check_for_collisions(

--- a/virtualizarr/readers/zarr_v3.py
+++ b/virtualizarr/readers/zarr_v3.py
@@ -20,6 +20,7 @@ class ZarrV3VirtualBackend(VirtualBackend):
         loadable_variables: Iterable[str] | None = None,
         decode_times: bool | None = None,
         indexes: Mapping[str, Index] | None = None,
+        reader_kwargs: Optional[dict] = None,
         reader_options: Optional[dict] = None,
     ) -> Dataset:
         """
@@ -27,6 +28,11 @@ class ZarrV3VirtualBackend(VirtualBackend):
 
         This is experimental - chunk manifests are not part of the Zarr v3 Spec.
         """
+        if reader_kwargs:
+            raise NotImplementedError(
+                "Zarr_v3 reader does not understand any reader_kwargs"
+            )
+
         storepath = Path(filepath)
 
         if group:


### PR DESCRIPTION
For https://github.com/zarr-developers/VirtualiZarr/pull/243#issuecomment-2492341326 we need to pass a `fs_root` kwarg down to some but not all readers. We will have other reader-specific kwargs like this come up in future too. To be in keeping with `xarray.open_dataset`'s API these should be passed as a dict called `reader_kwargs` or `backend_kwargs`.

However there is an existing `reader_options` kwarg, which is meant to be specifically for `fsspec` options. Having both `reader_options` and `reader_kwargs` would be confusing, so should we
a) rename `reader_options` to `reader_kwargs`, having it include fsspec options too,
b) have `reader_kwargs` and `fsspec_kwargs`, deprecating `reader_options`?

So far this PR just adds a `reader_kwargs` option to all backends, but raises if it is used.

cc @norlandrhagen @sharkinsspatial 

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
