### PR TITLE
Expand xarray openable type hint with ReadBuffer

### DIFF
--- a/virtualizarr/readers/common.py
+++ b/virtualizarr/readers/common.py
@@ -21,10 +21,13 @@ from xarray import (
 )
 from xarray.backends import AbstractDataStore
 from xarray.core.indexes import PandasIndex
+from xarray.core.types import ReadBuffer
 
 from virtualizarr.utils import _FsspecFSFromFilepath
 
-XArrayOpenT = str | os.PathLike[Any] | BufferedIOBase | AbstractDataStore
+XArrayOpenT = (
+    str | os.PathLike[Any] | ReadBuffer[Any] | BufferedIOBase | AbstractDataStore
+)
 
 
 def open_loadable_vars_and_indexes(


### PR DESCRIPTION
Should hopefully fix the [typing error](https://github.com/zarr-developers/VirtualiZarr/actions/runs/11988810253/job/33424495927?pr=314) that appeared in the last few days, which I think is caused by https://github.com/pydata/xarray/pull/9787 upstream.

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
