### PR TITLE
Fix group kwarg

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -38,6 +38,18 @@ def netcdf4_file(tmpdir):
 
 
 @pytest.fixture
+def netcdf4_file_with_data_in_multiple_groups(tmpdir):
+    filepath = str(tmpdir / 'test.nc')
+
+    ds1 = xr.DataArray([1, 2, 3], name="foo").to_dataset()
+    ds1.to_netcdf(filepath)
+    ds2 = xr.DataArray([4, 5], name="bar").to_dataset()
+    ds2.to_netcdf(filepath, group="subgroup", mode="a")
+
+    return filepath
+
+
+@pytest.fixture
 def netcdf4_files_factory(tmpdir) -> callable:
     def create_netcdf4_files(
         encoding: Optional[Dict[str, Dict[str, Any]]] = None,

--- a/conftest.py
+++ b/conftest.py
@@ -27,7 +27,7 @@ def pytest_runtest_setup(item):
 @pytest.fixture
 def empty_netcdf4_file(tmpdir):
     # Set up example xarray dataset
-    ds = xr.Dataset()    # Save it to disk as netCDF (in temporary directory)
+    ds = xr.Dataset()  # Save it to disk as netCDF (in temporary directory)
     filepath = f"{tmpdir}/empty.nc"
     ds.to_netcdf(filepath, format="NETCDF4")
     ds.close()
@@ -50,7 +50,7 @@ def netcdf4_file(tmpdir):
 
 @pytest.fixture
 def netcdf4_file_with_data_in_multiple_groups(tmpdir):
-    filepath = str(tmpdir / 'test.nc')
+    filepath = str(tmpdir / "test.nc")
 
     ds1 = xr.DataArray([1, 2, 3], name="foo").to_dataset()
     ds1.to_netcdf(filepath)

--- a/conftest.py
+++ b/conftest.py
@@ -25,6 +25,17 @@ def pytest_runtest_setup(item):
 
 
 @pytest.fixture
+def empty_netcdf4_file(tmpdir):
+    # Set up example xarray dataset
+    ds = xr.Dataset()    # Save it to disk as netCDF (in temporary directory)
+    filepath = f"{tmpdir}/empty.nc"
+    ds.to_netcdf(filepath, format="NETCDF4")
+    ds.close()
+
+    return filepath
+
+
+@pytest.fixture
 def netcdf4_file(tmpdir):
     # Set up example xarray dataset
     ds = xr.tutorial.open_dataset("air_temperature")

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -52,3 +52,4 @@ Anyone with commit privileges to the repository can issue a release.
 9. Select 'Publish' to publish the release. This should automatically upload the new release to [PyPI](https://pypi.org/project/virtualizarr/) and [conda-forge](https://anaconda.org/conda-forge/virtualizarr).
 10. Check that this has run successfully (PyPI should show the new version number very quickly, but conda-forge might take several hours).
 11. Create and merge a PR to add a new empty section to the `docs/releases.rst` for the next release in the future.
+12. (Optional) Advertise the release on social media 📣

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -39,7 +39,7 @@ Open `docs/_build/html/index.html` in a web browser (on MacOS you can do this fr
 
 ## Making a release
 
-Anyone with commit privileges to the repository can issue a release.
+Anyone with commit privileges to the repository can issue a release, and you should feel free to issue a release at any point in time when all the CI tests on `main` are passing.
 
 1. Decide on the release version number for the new release, following the [EffVer](https://jacobtomlinson.dev/effver/) versioning scheme (e.g., releasing v0.2.0 as the next release after v0.1.0 denotes that “some small effort may be required to make sure this version works for you”).
 2. Write a high-level summary of the changes in this release, and write it into the release notes in `docs/releases.rst`. Create and merge a PR which adds the summary and also changes the release notes to say today's date and the version number of the new release. Don't add the blank template for future releases yet.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -41,11 +41,13 @@ Open `docs/_build/html/index.html` in a web browser (on MacOS you can do this fr
 
 Anyone with commit privileges to the repository can issue a release.
 
-1. Navigate to the [https://github.com/zarr-developers/virtualizarr/releases](https://github.com/zarr-developers/virtualizarr/releases) releases page.
-2. Select draft a new release.
-3. Select 'Choose a tag', then 'create a new tag'
-4. Enter the name for the new tag following the [EffVer](https://jacobtomlinson.dev/effver/) versioning scheme (e.g., releasing v0.2.0 as the next release after v0.1.0 denotes that “some small effort may be required to make sure this version works for you”).
-4. Click 'Generate Release Notes' to draft notes based on merged pull requests.
-5. Edit the draft release notes for consistency.
-6. Select 'Publish' to publish the release. This should automatically upload the new release to PyPI and Conda-Forge.
-7. Create and merge a PR to add a new empty section to the `docs/releases.rst` for the next release in the future.
+1. Decide on the release version number for the new release, following the [EffVer](https://jacobtomlinson.dev/effver/) versioning scheme (e.g., releasing v0.2.0 as the next release after v0.1.0 denotes that “some small effort may be required to make sure this version works for you”).
+2. Write a high-level summary of the changes in this release, and write it into the release notes in `docs/releases.rst`. Create and merge a PR which adds the summary and also changes the release notes to say today's date and the version number of the new release. Don't add the blank template for future releases yet.
+3. Navigate to the [https://github.com/zarr-developers/virtualizarr/releases](https://github.com/zarr-developers/virtualizarr/releases) releases page.
+4. Select 'Draft a new release'.
+5. Select 'Choose a tag', then 'Create a new tag'
+6. Enter the name for the new tag (i.e. the release version number).
+7. Click 'Generate Release Notes' to draft notes based on merged pull requests, and paste the same release summary you wrote earlier at the top.
+8. Edit the draft release notes for consistency.
+9. Select 'Publish' to publish the release. This should automatically upload the new release to PyPI and Conda-Forge.
+10. Create and merge a PR to add a new empty section to the `docs/releases.rst` for the next release in the future.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -49,5 +49,6 @@ Anyone with commit privileges to the repository can issue a release.
 6. Enter the name for the new tag (i.e. the release version number).
 7. Click 'Generate Release Notes' to draft notes based on merged pull requests, and paste the same release summary you wrote earlier at the top.
 8. Edit the draft release notes for consistency.
-9. Select 'Publish' to publish the release. This should automatically upload the new release to PyPI and Conda-Forge.
-10. Create and merge a PR to add a new empty section to the `docs/releases.rst` for the next release in the future.
+9. Select 'Publish' to publish the release. This should automatically upload the new release to [PyPI](https://pypi.org/project/virtualizarr/) and [conda-forge](https://anaconda.org/conda-forge/virtualizarr).
+10. Check that this has run successfully (PyPI should show the new version number very quickly, but conda-forge might take several hours).
+11. Create and merge a PR to add a new empty section to the `docs/releases.rst` for the next release in the future.

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -21,7 +21,6 @@ Bug fixes
 - Fix bug preventing generating references for the root group of a file when a subgroup exists.
   (:issue:`336`, :pull:`337`) By `Tom Nicholas <https://github.com/TomNicholas>`_.
 
-
 Documentation
 ~~~~~~~~~~~~~
 

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -18,6 +18,10 @@ Deprecations
 Bug fixes
 ~~~~~~~~~
 
+- Fix bug preventing generating references for the root group of a file when a subgroup exists.
+  (:issue:`336`, :pull:`337`) By `Tom Nicholas <https://github.com/TomNicholas>`_.
+
+
 Documentation
 ~~~~~~~~~~~~~
 

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -12,6 +12,10 @@ New Features
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
+- Passing ``group=None`` (the default) to ``open_virtual_dataset`` for a file with multiple groups no longer raises an error, instead it gives you the root group.
+  This new behaviour is more consistent with ``xarray.open_dataset``.
+  (:issue:`336`, :pull:`337`) By `Tom Nicholas <https://github.com/TomNicholas>`_.
+
 Deprecations
 ~~~~~~~~~~~~
 

--- a/virtualizarr/readers/fits.py
+++ b/virtualizarr/readers/fits.py
@@ -37,7 +37,9 @@ class FITSVirtualBackend(VirtualBackend):
         # handle inconsistency in kerchunk, see GH issue https://github.com/zarr-developers/VirtualiZarr/issues/160
         refs = KerchunkStoreRefs({"refs": process_file(filepath, **reader_options)})
 
-        refs = extract_group(refs, group)
+        # both group=None and group='' mean to read root group
+        if group:
+            refs = extract_group(refs, group)
 
         virtual_vars, attrs, coord_names = virtual_vars_and_metadata_from_kerchunk_refs(
             refs,

--- a/virtualizarr/readers/hdf5.py
+++ b/virtualizarr/readers/hdf5.py
@@ -43,9 +43,15 @@ class HDF5VirtualBackend(VirtualBackend):
             filepath, inline_threshold=0, **reader_options
         ).translate()
 
+        from pprint import pprint
+
+        pprint(refs)
+
         # both group=None and group='' mean to read root group
         if group:
             refs = extract_group(refs, group)
+
+        pprint(refs)
 
         virtual_vars, attrs, coord_names = virtual_vars_and_metadata_from_kerchunk_refs(
             refs,

--- a/virtualizarr/readers/hdf5.py
+++ b/virtualizarr/readers/hdf5.py
@@ -43,15 +43,9 @@ class HDF5VirtualBackend(VirtualBackend):
             filepath, inline_threshold=0, **reader_options
         ).translate()
 
-        from pprint import pprint
-
-        pprint(refs)
-
         # both group=None and group='' mean to read root group
         if group:
             refs = extract_group(refs, group)
-
-        pprint(refs)
 
         virtual_vars, attrs, coord_names = virtual_vars_and_metadata_from_kerchunk_refs(
             refs,

--- a/virtualizarr/readers/hdf5.py
+++ b/virtualizarr/readers/hdf5.py
@@ -43,7 +43,9 @@ class HDF5VirtualBackend(VirtualBackend):
             filepath, inline_threshold=0, **reader_options
         ).translate()
 
-        refs = extract_group(refs, group)
+        # both group=None and group='' mean to read root group
+        if group:
+            refs = extract_group(refs, group)
 
         virtual_vars, attrs, coord_names = virtual_vars_and_metadata_from_kerchunk_refs(
             refs,

--- a/virtualizarr/readers/netcdf3.py
+++ b/virtualizarr/readers/netcdf3.py
@@ -9,7 +9,6 @@ from virtualizarr.readers.common import (
     open_loadable_vars_and_indexes,
 )
 from virtualizarr.translators.kerchunk import (
-    extract_group,
     virtual_vars_and_metadata_from_kerchunk_refs,
 )
 from virtualizarr.utils import check_for_collisions
@@ -41,7 +40,11 @@ class NetCDF3VirtualBackend(VirtualBackend):
 
         refs = NetCDF3ToZarr(filepath, inline_threshold=0, **reader_options).translate()
 
-        refs = extract_group(refs, group)
+        # both group=None and group='' mean to read root group
+        if group:
+            raise ValueError(
+                "group kwarg passed, but netCDF3 files can't have multiple groups!"
+            )
 
         virtual_vars, attrs, coord_names = virtual_vars_and_metadata_from_kerchunk_refs(
             refs,

--- a/virtualizarr/readers/tiff.py
+++ b/virtualizarr/readers/tiff.py
@@ -52,7 +52,9 @@ class TIFFVirtualBackend(VirtualBackend):
         # handle inconsistency in kerchunk, see GH issue https://github.com/zarr-developers/VirtualiZarr/issues/160
         refs = KerchunkStoreRefs({"refs": tiff_to_zarr(filepath, **reader_options)})
 
-        refs = extract_group(refs, group)
+        # both group=None and group='' mean to read root group
+        if group:
+            refs = extract_group(refs, group)
 
         virtual_vars, attrs, coord_names = virtual_vars_and_metadata_from_kerchunk_refs(
             refs,

--- a/virtualizarr/tests/test_backend.py
+++ b/virtualizarr/tests/test_backend.py
@@ -315,7 +315,15 @@ class TestOpenVirtualDatasetHDFGroup:
         vds_expected = open_virtual_dataset(netcdf4_file, indexes={})
         xrt.assert_identical(vds, vds_expected)
 
-    def test_open_root_group_by_default(self): ...
+    def test_open_root_group_manually(self, hdf5_groups_file):
+        vds = open_virtual_dataset(hdf5_groups_file, group='', indexes={})
+        vds_expected = xr.Dataset()  # should be nothing in root group
+        xrt.assert_identical(vds, vds_expected)
+
+    def test_open_root_group_by_default(self, hdf5_groups_file):
+        vds = open_virtual_dataset(hdf5_groups_file, indexes={})
+        vds_expected = xr.Dataset()  # should be nothing in root group
+        xrt.assert_identical(vds, vds_expected)
 
     def test_raise_on_nonexistent_group(self): ...
 

--- a/virtualizarr/tests/test_backend.py
+++ b/virtualizarr/tests/test_backend.py
@@ -310,22 +310,28 @@ class TestReadFromURL:
 
 
 class TestOpenVirtualDatasetHDFGroup:
-    def test_open_group(self, hdf5_groups_file, netcdf4_file):
-        vds = open_virtual_dataset(hdf5_groups_file, group="test/group", indexes={})
-        vds_expected = open_virtual_dataset(netcdf4_file, indexes={})
-        xrt.assert_identical(vds, vds_expected)
+    def test_open_subgroup(self, netcdf4_file_with_data_in_multiple_groups):
+        vds = open_virtual_dataset(netcdf4_file_with_data_in_multiple_groups, group="subgroup", indexes={})
+        assert list(vds.variables) == ['bar']
+        assert isinstance(vds['bar'].data, ManifestArray)
+        assert vds['bar'].shape == (2, 1)
 
-    def test_open_root_group_manually(self, hdf5_groups_file):
-        vds = open_virtual_dataset(hdf5_groups_file, group='', indexes={})
-        vds_expected = xr.Dataset()  # should be nothing in root group
-        xrt.assert_identical(vds, vds_expected)
+    def test_open_root_group_manually(self, netcdf4_file_with_data_in_multiple_groups):
+        vds = open_virtual_dataset(netcdf4_file_with_data_in_multiple_groups, group="", indexes={})
+        assert list(vds.variables) == ['foo']
+        assert isinstance(vds['foo'].data, ManifestArray)
+        assert vds['foo'].shape == (3, 1)
 
-    def test_open_root_group_by_default(self, hdf5_groups_file):
-        vds = open_virtual_dataset(hdf5_groups_file, indexes={})
-        vds_expected = xr.Dataset()  # should be nothing in root group
-        xrt.assert_identical(vds, vds_expected)
+    def test_open_root_group_by_default(self, netcdf4_file_with_data_in_multiple_groups):
+        vds = open_virtual_dataset(netcdf4_file_with_data_in_multiple_groups, indexes={})
+        assert list(vds.variables) == ['foo']
+        assert isinstance(vds['foo'].data, ManifestArray)
+        assert vds['foo'].shape == (3, 1)
 
     def test_raise_on_nonexistent_group(self): ...
+
+    def test_open_empty_group(self):
+        ...
 
 
 @requires_kerchunk

--- a/virtualizarr/tests/test_backend.py
+++ b/virtualizarr/tests/test_backend.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 import xarray as xr
 import xarray.testing as xrt
-from xarray import open_dataset
+from xarray import open_dataset, Dataset
 from xarray.core.indexes import Index
 
 from virtualizarr import open_virtual_dataset
@@ -307,6 +307,13 @@ class TestReadFromURL:
 
         # xrt.assert_identical(dsXR, dsV) #Attribute order changes
         xrt.assert_equal(dsXR, dsV)
+
+
+def test_open_empty_group(empty_netcdf4_file):
+    vds = open_virtual_dataset(empty_netcdf4_file, indexes={})
+    assert isinstance(vds, xr.Dataset)
+    expected = Dataset()
+    xrt.assert_identical(vds, expected)
 
 
 class TestOpenVirtualDatasetHDFGroup:

--- a/virtualizarr/tests/test_backend.py
+++ b/virtualizarr/tests/test_backend.py
@@ -309,6 +309,17 @@ class TestReadFromURL:
         xrt.assert_equal(dsXR, dsV)
 
 
+class TestOpenVirtualDatasetHDFGroup:
+    def test_open_group(self, hdf5_groups_file, netcdf4_file):
+        vds = open_virtual_dataset(hdf5_groups_file, group="test/group", indexes={})
+        vds_expected = open_virtual_dataset(netcdf4_file, indexes={})
+        xrt.assert_identical(vds, vds_expected)
+
+    def test_open_root_group_by_default(self): ...
+
+    def test_raise_on_nonexistent_group(self): ...
+
+
 @requires_kerchunk
 class TestLoadVirtualDataset:
     @pytest.mark.parametrize("hdf_backend", [HDF5VirtualBackend, HDFVirtualBackend])

--- a/virtualizarr/tests/test_backend.py
+++ b/virtualizarr/tests/test_backend.py
@@ -395,8 +395,6 @@ class TestLoadVirtualDataset:
                     hdf5_groups_file, group="doesnt_exist", backend=hdf_backend
                 )
         if hdf_backend == HDF5VirtualBackend:
-            with pytest.raises(ValueError, match="Multiple HDF Groups found"):
-                open_virtual_dataset(hdf5_groups_file)
             with pytest.raises(ValueError, match="not found in"):
                 open_virtual_dataset(hdf5_groups_file, group="doesnt_exist")
 

--- a/virtualizarr/tests/test_backend.py
+++ b/virtualizarr/tests/test_backend.py
@@ -314,19 +314,19 @@ class TestOpenVirtualDatasetHDFGroup:
         vds = open_virtual_dataset(netcdf4_file_with_data_in_multiple_groups, group="subgroup", indexes={})
         assert list(vds.variables) == ['bar']
         assert isinstance(vds['bar'].data, ManifestArray)
-        assert vds['bar'].shape == (2, 1)
+        assert vds['bar'].shape == (2,)
 
     def test_open_root_group_manually(self, netcdf4_file_with_data_in_multiple_groups):
         vds = open_virtual_dataset(netcdf4_file_with_data_in_multiple_groups, group="", indexes={})
         assert list(vds.variables) == ['foo']
         assert isinstance(vds['foo'].data, ManifestArray)
-        assert vds['foo'].shape == (3, 1)
+        assert vds['foo'].shape == (3,)
 
     def test_open_root_group_by_default(self, netcdf4_file_with_data_in_multiple_groups):
         vds = open_virtual_dataset(netcdf4_file_with_data_in_multiple_groups, indexes={})
         assert list(vds.variables) == ['foo']
         assert isinstance(vds['foo'].data, ManifestArray)
-        assert vds['foo'].shape == (3, 1)
+        assert vds['foo'].shape == (3,)
 
     def test_raise_on_nonexistent_group(self): ...
 

--- a/virtualizarr/tests/test_backend.py
+++ b/virtualizarr/tests/test_backend.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 import xarray as xr
 import xarray.testing as xrt
-from xarray import open_dataset, Dataset
+from xarray import Dataset, open_dataset
 from xarray.core.indexes import Index
 
 from virtualizarr import open_virtual_dataset
@@ -318,27 +318,34 @@ def test_open_empty_group(empty_netcdf4_file):
 
 class TestOpenVirtualDatasetHDFGroup:
     def test_open_subgroup(self, netcdf4_file_with_data_in_multiple_groups):
-        vds = open_virtual_dataset(netcdf4_file_with_data_in_multiple_groups, group="subgroup", indexes={})
-        assert list(vds.variables) == ['bar']
-        assert isinstance(vds['bar'].data, ManifestArray)
-        assert vds['bar'].shape == (2,)
+        vds = open_virtual_dataset(
+            netcdf4_file_with_data_in_multiple_groups, group="subgroup", indexes={}
+        )
+        assert list(vds.variables) == ["bar"]
+        assert isinstance(vds["bar"].data, ManifestArray)
+        assert vds["bar"].shape == (2,)
 
     def test_open_root_group_manually(self, netcdf4_file_with_data_in_multiple_groups):
-        vds = open_virtual_dataset(netcdf4_file_with_data_in_multiple_groups, group="", indexes={})
-        assert list(vds.variables) == ['foo']
-        assert isinstance(vds['foo'].data, ManifestArray)
-        assert vds['foo'].shape == (3,)
+        vds = open_virtual_dataset(
+            netcdf4_file_with_data_in_multiple_groups, group="", indexes={}
+        )
+        assert list(vds.variables) == ["foo"]
+        assert isinstance(vds["foo"].data, ManifestArray)
+        assert vds["foo"].shape == (3,)
 
-    def test_open_root_group_by_default(self, netcdf4_file_with_data_in_multiple_groups):
-        vds = open_virtual_dataset(netcdf4_file_with_data_in_multiple_groups, indexes={})
-        assert list(vds.variables) == ['foo']
-        assert isinstance(vds['foo'].data, ManifestArray)
-        assert vds['foo'].shape == (3,)
+    def test_open_root_group_by_default(
+        self, netcdf4_file_with_data_in_multiple_groups
+    ):
+        vds = open_virtual_dataset(
+            netcdf4_file_with_data_in_multiple_groups, indexes={}
+        )
+        assert list(vds.variables) == ["foo"]
+        assert isinstance(vds["foo"].data, ManifestArray)
+        assert vds["foo"].shape == (3,)
 
     def test_raise_on_nonexistent_group(self): ...
 
-    def test_open_empty_group(self):
-        ...
+    def test_open_empty_group(self): ...
 
 
 @requires_kerchunk

--- a/virtualizarr/tests/test_backend.py
+++ b/virtualizarr/tests/test_backend.py
@@ -309,6 +309,7 @@ class TestReadFromURL:
         xrt.assert_equal(dsXR, dsV)
 
 
+@requires_kerchunk
 def test_open_empty_group(empty_netcdf4_file):
     vds = open_virtual_dataset(empty_netcdf4_file, indexes={})
     assert isinstance(vds, xr.Dataset)
@@ -316,6 +317,7 @@ def test_open_empty_group(empty_netcdf4_file):
     xrt.assert_identical(vds, expected)
 
 
+@requires_kerchunk
 class TestOpenVirtualDatasetHDFGroup:
     def test_open_subgroup(self, netcdf4_file_with_data_in_multiple_groups):
         vds = open_virtual_dataset(
@@ -342,10 +344,6 @@ class TestOpenVirtualDatasetHDFGroup:
         assert list(vds.variables) == ["foo"]
         assert isinstance(vds["foo"].data, ManifestArray)
         assert vds["foo"].shape == (3,)
-
-    def test_raise_on_nonexistent_group(self): ...
-
-    def test_open_empty_group(self): ...
 
 
 @requires_kerchunk

--- a/virtualizarr/tests/test_integration.py
+++ b/virtualizarr/tests/test_integration.py
@@ -13,7 +13,6 @@ from virtualizarr.readers.hdf import HDFVirtualBackend
 from virtualizarr.tests import requires_kerchunk
 from virtualizarr.translators.kerchunk import (
     dataset_from_kerchunk_refs,
-    find_var_names,
 )
 from virtualizarr.zarr import ZArray
 

--- a/virtualizarr/tests/test_integration.py
+++ b/virtualizarr/tests/test_integration.py
@@ -49,12 +49,6 @@ def test_kerchunk_roundtrip_in_memory_no_concat():
     xrt.assert_equal(roundtrip, ds)
 
 
-def test_no_duplicates_find_var_names():
-    """Verify that we get a deduplicated list of var names"""
-    ref_dict = {"refs": {"x/something": {}, "x/otherthing": {}}}
-    assert len(find_var_names(ref_dict)) == 1
-
-
 @requires_kerchunk
 @pytest.mark.parametrize(
     "inline_threshold, vars_to_inline",

--- a/virtualizarr/translators/kerchunk.py
+++ b/virtualizarr/translators/kerchunk.py
@@ -47,6 +47,9 @@ def extract_group(vds_refs: KerchunkStoreRefs, group: str) -> KerchunkStoreRefs:
     """
     Extract only the part of the kerchunk reference dict that is relevant to a single HDF group.
 
+    Parameters
+    ----------
+    vds_refs : KerchunkStoreRefs
     group : str
         Should be a non-empty string
     """

--- a/virtualizarr/translators/kerchunk.py
+++ b/virtualizarr/translators/kerchunk.py
@@ -59,27 +59,34 @@ def extract_group(vds_refs: KerchunkStoreRefs, group: str | None) -> KerchunkSto
             # open root group by default
             group = ''
 
-        # Ensure supplied group kwarg is consistent with kerchunk keys
-        if not group.endswith("/"):
-            group += "/"
-        if group.startswith("/"):
-            group = group.removeprefix("/")
+        print(hdf_groups)
+        print(vds_refs)
 
-        if group not in hdf_groups:
-            raise ValueError(f'Group "{group}" not found in {hdf_groups}')
+        if group is '':
+            # don't need to remove any group prefixes from keys
+            return KerchunkStoreRefs(vds_refs)
+        else:
+            # Ensure supplied group kwarg is consistent with kerchunk keys
+            if not group.endswith("/"):
+                group += "/"
+            if group.startswith("/"):
+                group = group.removeprefix("/")
 
-        # Filter by group prefix and remove prefix from all keys
-        groupdict = {
-            k.removeprefix(group): v
-            for k, v in vds_refs["refs"].items()
-            if k.startswith(group)
-        }
-        # Also remove group prefix from _ARRAY_DIMENSIONS
-        for k, v in groupdict.items():
-            if isinstance(v, str):
-                groupdict[k] = v.replace("\\/", "/").replace(group, "")
+            if group not in hdf_groups:
+                raise ValueError(f'Group "{group}" not found in {hdf_groups}')
 
-        vds_refs["refs"] = groupdict
+            # Filter by group prefix and remove prefix from all keys
+            groupdict = {
+                k.removeprefix(group): v
+                for k, v in vds_refs["refs"].items()
+                if k.startswith(group)
+            }
+            # Also remove group prefix from _ARRAY_DIMENSIONS
+            for k, v in groupdict.items():
+                if isinstance(v, str):
+                    groupdict[k] = v.replace("\\/", "/").replace(group, "")
+
+            vds_refs["refs"] = groupdict
 
         return KerchunkStoreRefs(vds_refs)
 

--- a/virtualizarr/translators/kerchunk.py
+++ b/virtualizarr/translators/kerchunk.py
@@ -103,7 +103,6 @@ def virtual_vars_from_kerchunk_refs(
     var_names_to_keep = [
         var_name for var_name in var_names if var_name not in drop_variables
     ]
-    print(var_names_to_keep)
 
     vars = {
         var_name: variable_from_kerchunk_refs(

--- a/virtualizarr/translators/kerchunk.py
+++ b/virtualizarr/translators/kerchunk.py
@@ -48,19 +48,22 @@ def extract_group(vds_refs: KerchunkStoreRefs, group: str | None) -> KerchunkSto
     hdf_groups = [
         k.removesuffix(".zgroup") for k in vds_refs["refs"].keys() if ".zgroup" in k
     ]
+
+    print(hdf_groups)
+    print(group)
+
     if len(hdf_groups) == 1:
         return vds_refs
     else:
         if group is None:
-            raise ValueError(
-                f"Multiple HDF Groups found. Must specify group= keyword to select one of {hdf_groups}"
-            )
-        else:
-            # Ensure supplied group kwarg is consistent with kerchunk keys
-            if not group.endswith("/"):
-                group += "/"
-            if group.startswith("/"):
-                group = group.removeprefix("/")
+            # open root group by default
+            group = ''
+
+        # Ensure supplied group kwarg is consistent with kerchunk keys
+        if not group.endswith("/"):
+            group += "/"
+        if group.startswith("/"):
+            group = group.removeprefix("/")
 
         if group not in hdf_groups:
             raise ValueError(f'Group "{group}" not found in {hdf_groups}')

--- a/virtualizarr/translators/kerchunk.py
+++ b/virtualizarr/translators/kerchunk.py
@@ -226,7 +226,7 @@ def find_var_names(ds_reference_dict: KerchunkStoreRefs) -> list[str]:
     for key in refs.keys():
         # has to capture "foo/.zarray", but ignore ".zgroup", ".zattrs", and "subgroup/bar/.zarray"
         # TODO this might be a sign that we should introduce a KerchunkGroupRefs type and cut down the references before getting to this point...
-        if key not in (".zgroup", ".zattrs"):
+        if key not in (".zgroup", ".zattrs", ".zmetadata"):
             first_part, second_part, *_ = key.split("/")
             if second_part == ".zarray":
                 found_var_names.append(first_part)


### PR DESCRIPTION
This also changes the expected behaviour of `open_virtual_dataset(file, group=None)` (i.e. the default value of the `group` kwarg) when multiple groups are encountered. It now just opens the root group instead of raising, which is more consistent with `xr.open_dataset`.

- [x] Closes #336
- [x] Tests added
- [x] Tests passing
- [x] Full type hint coverage
- [x] Changes are documented in `docs/releases.rst`
- [ ] ~~New functions/methods are listed in `api.rst`~~
- [ ] ~~New functionality has documentation~~
