### PR TITLE
Load 1d coord vars by default

### DIFF
--- a/virtualizarr/backend.py
+++ b/virtualizarr/backend.py
@@ -21,7 +21,7 @@ from virtualizarr.readers import (
     ZarrV3VirtualBackend,
 )
 from virtualizarr.readers.common import VirtualBackend
-from virtualizarr.utils import _FsspecFSFromFilepath, check_for_collisions
+from virtualizarr.utils import _FsspecFSFromFilepath
 
 # TODO add entrypoint to allow external libraries to add to this mapping
 VIRTUAL_BACKENDS = {
@@ -109,9 +109,9 @@ def open_virtual_dataset(
     filetype: FileType | str | None = None,
     group: str | None = None,
     drop_variables: Iterable[str] | None = None,
-    loadable_variables: Literal["1d_coords"]
+    loadable_variables: Literal["1d_coord_dims"]
     | Literal["all_coords"]
-    | Iterable[str] = "1d_coords",
+    | Iterable[str] = "1d_coord_dims",
     decode_times: bool | None = None,
     cftime_variables: Iterable[str] | None = None,
     indexes: Mapping[str, Index] | None = None,
@@ -139,12 +139,12 @@ def open_virtual_dataset(
         Path to the HDF5/netCDF4 group in the given file to open. Given as a str, supported by filetypes “netcdf4”, “hdf5”, and "dmrpp".
     drop_variables: list[str], default is None
         Variables in the file to drop before returning.
-    loadable_variables: '1d_coords', 'all_coords', or list[str], default is '1d_coords'
+    loadable_variables: '1d_coord_dims', 'all_coords', or list[str], default is '1d_coord_dims'
         Variables in the file to open as lazy numpy/dask arrays instead of instances of virtual_array_class.
         Passing an empty list will turn this feature off entirely, i.e. open all variables as virtual arrays (i.e. ManifestArray).
-        ``1d_coords`` will load only one-dimensional coordinate variables with the same name as their only dimension (what xarray sometimes calls "dimension coordinates").
+        ``1d_coord_dims`` will load only one-dimensional coordinate variables with the same name as their only dimension (what xarray sometimes calls "dimension coordinates").
         ``all_coords`` will load all coordinate variables.
-        Default is '1d_coords', to be similar to the default behaviour of ``xarray.open_dataset``.
+        Default is '1d_coord_dims', to be similar to the default behaviour of ``xarray.open_dataset``.
     decode_times: bool | None, default is None
         Bool that is passed into Xarray's open_dataset. Allows time to be decoded into a datetime object.
     indexes : Mapping[str, Index], default is None
@@ -176,10 +176,10 @@ def open_virtual_dataset(
 
     # TODO this won't work without an explicit list of loadable_variables
     # TODO so it probably has to be moved inside the backends
-    drop_variables, loadable_variables = check_for_collisions(
-        drop_variables,
-        loadable_variables,
-    )
+    # drop_variables, loadable_variables = check_for_collisions(
+    #     drop_variables,
+    #     loadable_variables,
+    # )
 
     if virtual_array_class is not ManifestArray:
         raise NotImplementedError()

--- a/virtualizarr/backend.py
+++ b/virtualizarr/backend.py
@@ -4,6 +4,7 @@ from enum import Enum, auto
 from pathlib import Path
 from typing import (
     Any,
+    Literal,
     Optional,
 )
 
@@ -108,7 +109,9 @@ def open_virtual_dataset(
     filetype: FileType | str | None = None,
     group: str | None = None,
     drop_variables: Iterable[str] | None = None,
-    loadable_variables: Iterable[str] | None = None,
+    loadable_variables: Literal["1d_coords"]
+    | Literal["all_coords"]
+    | Iterable[str] = "1d_coords",
     decode_times: bool | None = None,
     cftime_variables: Iterable[str] | None = None,
     indexes: Mapping[str, Index] | None = None,
@@ -136,9 +139,12 @@ def open_virtual_dataset(
         Path to the HDF5/netCDF4 group in the given file to open. Given as a str, supported by filetypes “netcdf4”, “hdf5”, and "dmrpp".
     drop_variables: list[str], default is None
         Variables in the file to drop before returning.
-    loadable_variables: list[str], default is None
+    loadable_variables: '1d_coords', 'all_coords', or list[str], default is '1d_coords'
         Variables in the file to open as lazy numpy/dask arrays instead of instances of virtual_array_class.
-        Default is to open all variables as virtual arrays (i.e. ManifestArray).
+        Passing an empty list will turn this feature off entirely, i.e. open all variables as virtual arrays (i.e. ManifestArray).
+        ``1d_coords`` will load only one-dimensional coordinate variables with the same name as their only dimension (what xarray sometimes calls "dimension coordinates").
+        ``all_coords`` will load all coordinate variables.
+        Default is '1d_coords', to be similar to the default behaviour of ``xarray.open_dataset``.
     decode_times: bool | None, default is None
         Bool that is passed into Xarray's open_dataset. Allows time to be decoded into a datetime object.
     indexes : Mapping[str, Index], default is None
@@ -157,7 +163,7 @@ def open_virtual_dataset(
     Returns
     -------
     vds
-        An xarray Dataset containing instances of virtual_array_cls for each variable, or normal lazily indexed arrays for each variable in loadable_variables.
+        An xarray Dataset containing instances of ``virtual_array_cls`` for each variable, or normal lazily indexed arrays for each variable in ``loadable_variables``.
     """
 
     if cftime_variables is not None:
@@ -168,6 +174,8 @@ def open_virtual_dataset(
             stacklevel=2,
         )
 
+    # TODO this won't work without an explicit list of loadable_variables
+    # TODO so it probably has to be moved inside the backends
     drop_variables, loadable_variables = check_for_collisions(
         drop_variables,
         loadable_variables,

--- a/virtualizarr/readers/common.py
+++ b/virtualizarr/readers/common.py
@@ -4,6 +4,7 @@ from collections.abc import Iterable, Mapping, MutableMapping
 from typing import (
     Any,
     Hashable,
+    Literal,
     Optional,
 )
 
@@ -92,7 +93,7 @@ def construct_virtual_dataset(
     coord_names,
     attrs,
 ) -> Dataset:
-    """Construct a virtual Datset from consistuent parts."""
+    """Construct a virtual Dataset from constituent parts."""
 
     vars = {**virtual_vars, **loadable_vars}
 
@@ -165,7 +166,9 @@ class VirtualBackend(ABC):
         filepath: str,
         group: str | None = None,
         drop_variables: Iterable[str] | None = None,
-        loadable_variables: Iterable[str] | None = None,
+        loadable_variables: Literal["1d_coords"]
+        | Literal["all_coords"]
+        | Iterable[str] = "1d_coords",
         decode_times: bool | None = None,
         indexes: Mapping[str, Index] | None = None,
         virtual_backend_kwargs: Optional[dict] = None,
@@ -178,7 +181,9 @@ class VirtualBackend(ABC):
         path: str,
         group: str | None = None,
         drop_variables: Iterable[str] | None = None,
-        loadable_variables: Iterable[str] | None = None,
+        loadable_variables: Literal["1d_coords"]
+        | Literal["all_coords"]
+        | Iterable[str] = "1d_coords",
         decode_times: bool | None = None,
         indexes: Mapping[str, Index] | None = None,
         virtual_backend_kwargs: Optional[dict] = None,

--- a/virtualizarr/readers/hdf5.py
+++ b/virtualizarr/readers/hdf5.py
@@ -51,8 +51,7 @@ class HDF5VirtualBackend(VirtualBackend):
 
         virtual_vars, attrs, coord_names = virtual_vars_and_metadata_from_kerchunk_refs(
             refs,
-            loadable_variables,
-            drop_variables,
+            drop_variables=drop_variables,
             fs_root=Path.cwd().as_uri(),
         )
 

--- a/virtualizarr/readers/hdf5.py
+++ b/virtualizarr/readers/hdf5.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Iterable, Mapping, Optional
+from typing import Iterable, Literal, Mapping, Optional
 
 from xarray import Dataset, Index
 
@@ -21,7 +21,9 @@ class HDF5VirtualBackend(VirtualBackend):
         filepath: str,
         group: str | None = None,
         drop_variables: Iterable[str] | None = None,
-        loadable_variables: Iterable[str] | None = None,
+        loadable_variables: Literal["1d_coord_dims"]
+        | Literal["all_coords"]
+        | Iterable[str] = "1d_coord_dims",
         decode_times: bool | None = None,
         indexes: Mapping[str, Index] | None = None,
         virtual_backend_kwargs: Optional[dict] = None,

--- a/virtualizarr/tests/test_backend.py
+++ b/virtualizarr/tests/test_backend.py
@@ -354,27 +354,38 @@ class TestLoadVirtualDataset:
         [
             (["air", "time"], ["air", "time"]),
             ([], []),
-            ("1d_coords", ["time"]),
+            ("1d_coord_dims", ["lat", "lon", "time"]),
             ("all_coords", ["lat", "lon", "time"]),
         ],
     )
     def test_loadable_variables(
         self, netcdf4_file, hdf_backend, loadable_variables, expected_loaded_variables
     ):
+        print(loadable_variables)
         vds = open_virtual_dataset(
             netcdf4_file,
             loadable_variables=loadable_variables,
-            indexes={},
+            indexes=None,
             backend=hdf_backend,
         )
 
+        print(vds)
+
         full_ds = xr.open_dataset(netcdf4_file, decode_times=True)
+        print(full_ds)
+
         for name in full_ds.variables:
+            assert name in list(vds.variables.keys())
             if name in expected_loaded_variables:
                 assert isinstance(vds[name].data, np.ndarray), name
+                print(vds.variables[name])
+                print(full_ds.variables[name])
                 xrt.assert_identical(vds.variables[name], full_ds.variables[name])
             else:
                 assert isinstance(vds[name].data, ManifestArray), name
+
+    # TODO test raises when passing ['1d_coord_dims']
+    # TODO test raises if any of loadable_variables not present
 
     def test_explicit_filetype(self, netcdf4_file):
         with pytest.raises(ValueError):

--- a/virtualizarr/tests/test_backend.py
+++ b/virtualizarr/tests/test_backend.py
@@ -438,3 +438,7 @@ class TestLoadVirtualDataset:
         vds = open_virtual_dataset(hdf5_scalar, backend=hdf_backend)
         assert vds.scalar.dims == ()
         assert vds.scalar.attrs == {"scalar": "true"}
+
+    @pytest.mark.parametrize("hdf_backend", [HDF5VirtualBackend, HDFVirtualBackend])
+    def test_loadable_vars_options(self, hdf5_scalar, hdf_backend):
+        ...

--- a/virtualizarr/tests/test_backend.py
+++ b/virtualizarr/tests/test_backend.py
@@ -368,17 +368,13 @@ class TestLoadVirtualDataset:
             backend=hdf_backend,
         )
 
-        for name in vds.variables:
-            if name in expected_loaded_variables:
-                assert isinstance(vds[name].data, np.ndarray), name
-            else:
-                assert isinstance(vds[name].data, ManifestArray), name
-
         full_ds = xr.open_dataset(netcdf4_file, decode_times=True)
-
         for name in full_ds.variables:
             if name in expected_loaded_variables:
+                assert isinstance(vds[name].data, np.ndarray), name
                 xrt.assert_identical(vds.variables[name], full_ds.variables[name])
+            else:
+                assert isinstance(vds[name].data, ManifestArray), name
 
     def test_explicit_filetype(self, netcdf4_file):
         with pytest.raises(ValueError):

--- a/virtualizarr/translators/kerchunk.py
+++ b/virtualizarr/translators/kerchunk.py
@@ -16,7 +16,6 @@ from virtualizarr.zarr import ZArray, ZAttrs, determine_chunk_grid_shape
 
 def virtual_vars_and_metadata_from_kerchunk_refs(
     vds_refs: KerchunkStoreRefs,
-    loadable_variables,
     drop_variables,
     virtual_array_class=ManifestArray,
     fs_root: str | None = None,
@@ -33,7 +32,7 @@ def virtual_vars_and_metadata_from_kerchunk_refs(
 
     virtual_vars = virtual_vars_from_kerchunk_refs(
         vds_refs,
-        drop_variables=drop_variables + loadable_variables,
+        drop_variables=drop_variables,
         virtual_array_class=virtual_array_class,
         fs_root=fs_root,
     )


### PR DESCRIPTION
Adds two options for `loadable_variables`: `1d_coord_dims` and `all_coords`, and changes the default to `1d_coord_dims`.

- [x] Closes #335
- [x] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functionality has documentation
