### PR TITLE
Remove warning when passing  indexes=None

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -20,7 +20,6 @@ Reading
 
     open_virtual_dataset
 
-
 Serialization
 -------------
 

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -15,6 +15,9 @@ Breaking changes
 - Passing ``group=None`` (the default) to ``open_virtual_dataset`` for a file with multiple groups no longer raises an error, instead it gives you the root group.
   This new behaviour is more consistent with ``xarray.open_dataset``.
   (:issue:`336`, :pull:`337`) By `Tom Nicholas <https://github.com/TomNicholas>`_.
+- Indexes are now created by default for any loadable one-dimensional coordinate variables. 
+  Also a warning is no longer thrown when ``indexes=None`` is passed to ``open_virtual_dataset``, and the recommendations in the docs updated to match.
+  (:pull:`357`) By `Tom Nicholas <https://github.com/TomNicholas>`_.
 
 Deprecations
 ~~~~~~~~~~~~

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -17,7 +17,8 @@ Breaking changes
   (:issue:`336`, :pull:`338`) By `Tom Nicholas <https://github.com/TomNicholas>`_.
 - Indexes are now created by default for any loadable one-dimensional coordinate variables. 
   Also a warning is no longer thrown when ``indexes=None`` is passed to ``open_virtual_dataset``, and the recommendations in the docs updated to match.
-  (:pull:`357`) By `Tom Nicholas <https://github.com/TomNicholas>`_.
+  This also means that ``xarray.combine_by_coords`` will now work when the necessary dimension coordinates are specified in ``loadable_variables``.
+  (:issue:`18`, :pull:`357`) By `Tom Nicholas <https://github.com/TomNicholas>`_.
 
 Deprecations
 ~~~~~~~~~~~~

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -14,7 +14,7 @@ Breaking changes
 
 - Passing ``group=None`` (the default) to ``open_virtual_dataset`` for a file with multiple groups no longer raises an error, instead it gives you the root group.
   This new behaviour is more consistent with ``xarray.open_dataset``.
-  (:issue:`336`, :pull:`337`) By `Tom Nicholas <https://github.com/TomNicholas>`_.
+  (:issue:`336`, :pull:`338`) By `Tom Nicholas <https://github.com/TomNicholas>`_.
 - Indexes are now created by default for any loadable one-dimensional coordinate variables. 
   Also a warning is no longer thrown when ``indexes=None`` is passed to ``open_virtual_dataset``, and the recommendations in the docs updated to match.
   (:pull:`357`) By `Tom Nicholas <https://github.com/TomNicholas>`_.
@@ -26,7 +26,7 @@ Bug fixes
 ~~~~~~~~~
 
 - Fix bug preventing generating references for the root group of a file when a subgroup exists.
-  (:issue:`336`, :pull:`337`) By `Tom Nicholas <https://github.com/TomNicholas>`_.
+  (:issue:`336`, :pull:`338`) By `Tom Nicholas <https://github.com/TomNicholas>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -266,25 +266,6 @@ TODO: Note about variable-length chunking?
 
 The simplest case of concatenation is when you have a set of files and you know which order they should be concatenated in, _without looking inside the files_. In this case it is sufficient to open the files one-by-one, then pass the virtual datasets as a list to the concatenation function.
 
-For manual concatenation we can actually avoid creating any xarray indexes, as we won't need them. Without indexes we can avoid loading any data whatsoever from the files. However, you should first be confident that the archival files actually do have compatible data, as only the array shapes and dimension names will be checked for consistency.
-
-You can specify that you don't want any indexes to be created by passing `indexes={}` to `open_virtual_dataset`.
-
-```python
-vds1 = open_virtual_dataset('air1.nc', indexes={})
-vds2 = open_virtual_dataset('air2.nc', indexes={})
-```
-
-We can see that the datasets have no indexes.
-
-```python
-vds1.indexes
-```
-```
-Indexes:
-    *empty*
-```
-
 As we know the correct order a priori, we can just combine along one dimension using `xarray.concat`.
 
 ```
@@ -343,6 +324,12 @@ In future we would like for it to be possible to just use `xr.open_mfdataset` to
     )
 
 but this requires some [upstream changes](https://github.com/TomNicholas/VirtualiZarr/issues/35) in xarray.
+```
+
+```{note}
+For manual concatenation we can actually avoid creating any xarray indexes, as we won't need them. Without indexes we can avoid loading any data whatsoever from the files. However, you should first be confident that the archival files actually do have compatible data, as the coordinate values then cannot be efficiently compared for consistency (i.e. aligned).
+
+By default indexes are created for 1-dimensional ``loadable_variables`` whose name matches their only dimension (i.e. "dimension coordinates"), but if you wish you can load variables without creating any indexes by passing ``indexes={}`` to ``open_virtual_dataset``.
 ```
 
 ### Automatic ordering using coordinate data
@@ -440,9 +427,9 @@ This store can however be read by {py:func}`~virtualizarr.open_virtual_dataset`,
 You can open existing Kerchunk `json` or `parquet` references as Virtualizarr virtual datasets. This may be useful for converting existing Kerchunk formatted references to storage formats like [Icechunk](https://icechunk.io/).
 
 ```python
-vds = open_virtual_dataset('combined.json', filetype='kerchunk', indexes={})
+vds = open_virtual_dataset('combined.json', filetype='kerchunk')
 # or
-vds = open_virtual_dataset('combined.parquet', filetype='kerchunk', indexes={})
+vds = open_virtual_dataset('combined.parquet', filetype='kerchunk')
 ```
 
 One difference between the kerchunk references format and virtualizarr's internal manifest representation (as well as icechunk's format) is that paths in kerchunk references can be relative paths. Opening kerchunk references that contain relative local filepaths therefore requires supplying another piece of information: the directory of the ``fsspec`` filesystem which the filepath was defined relative to.
@@ -455,7 +442,6 @@ You can dis-ambuiguate kerchunk references containing relative paths by passing 
 vds = open_virtual_dataset(
     'relative_refs.json',
     filetype='kerchunk',
-
     virtual_backend_kwargs={'fs_root': 'file:///some_directory/'}
 )
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -360,7 +360,7 @@ combined_vds['air'].data.manifest.dict()
 
 ### Ordering using metadata
 
-TODO: Use preprocess to create a new index from the metadata
+TODO: Use preprocess to create a new index from the metadata. Requires ``open_virtual_mfdataset`` to be implemented in [PR #349](https://github.com/zarr-developers/VirtualiZarr/pull/349).
 
 ## Writing virtual stores to disk
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -184,6 +184,8 @@ The full Zarr model (for a single group) includes multiple arrays, array names, 
 
 The problem of combining many archival format files (e.g. netCDF files) into one virtual Zarr store therefore becomes just a matter of opening each file using `open_virtual_dataset` and using [xarray's various combining functions](https://docs.xarray.dev/en/stable/user-guide/combining.html) to combine them into one aggregate virtual dataset.
 
+But before we combine our data, we might want to consider loading some variables into memory.
+
 ## Loading variables
 
 Whilst the values of virtual variables (i.e. those backed by `ManifestArray` objects) cannot be loaded into memory, you do have the option of opening specific variables from the file as loadable lazy numpy/dask arrays, just like `xr.open_dataset` normally returns. These variables are specified using the `loadable_variables` argument:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -266,7 +266,7 @@ TODO: Note about variable-length chunking?
 
 The simplest case of concatenation is when you have a set of files and you know which order they should be concatenated in, _without looking inside the files_. In this case it is sufficient to open the files one-by-one, then pass the virtual datasets as a list to the concatenation function.
 
-We can actually avoid creating any xarray indexes, as we won't need them. Without indexes we can avoid loading any data whatsoever from the files, making our opening and combining much faster than it normally would be. **Therefore if you can do your combining manually you should.** However, you should first be confident that the archival files actually do have compatible data, as only the array shapes and dimension names will be checked for consistency.
+For manual concatenation we can actually avoid creating any xarray indexes, as we won't need them. Without indexes we can avoid loading any data whatsoever from the files. However, you should first be confident that the archival files actually do have compatible data, as only the array shapes and dimension names will be checked for consistency.
 
 You can specify that you don't want any indexes to be created by passing `indexes={}` to `open_virtual_dataset`.
 
@@ -455,7 +455,7 @@ You can dis-ambuiguate kerchunk references containing relative paths by passing 
 vds = open_virtual_dataset(
     'relative_refs.json',
     filetype='kerchunk',
-    indexes={},
+
     virtual_backend_kwargs={'fs_root': 'file:///some_directory/'}
 )
 

--- a/virtualizarr/readers/common.py
+++ b/virtualizarr/readers/common.py
@@ -1,4 +1,3 @@
-import warnings
 from abc import ABC
 from collections.abc import Iterable, Mapping, MutableMapping
 from typing import (
@@ -55,13 +54,13 @@ def open_loadable_vars_and_indexes(
         )
 
         if indexes is None:
-            warnings.warn(
-                "Specifying `indexes=None` will create in-memory pandas indexes for each 1D coordinate, but concatenation of ManifestArrays backed by pandas indexes is not yet supported (see issue #18)."
-                "You almost certainly want to pass `indexes={}` to `open_virtual_dataset` instead."
-            )
-
             # add default indexes by reading data from file
-            indexes = {name: index for name, index in ds.xindexes.items()}
+            # virtual variables should never be backed by an in-memory index
+            indexes = {
+                name: index
+                for name, index in ds.xindexes.items()
+                if name in loadable_variables
+            }
         elif indexes != {}:
             # TODO allow manual specification of index objects
             raise NotImplementedError()

--- a/virtualizarr/readers/common.py
+++ b/virtualizarr/readers/common.py
@@ -55,7 +55,7 @@ def open_loadable_vars_and_indexes(
 
         if indexes is None:
             # add default indexes by reading data from file
-            # virtual variables should never be backed by an in-memory index
+            # but avoid creating an in-memory index for virtual variables by default
             indexes = {
                 name: index
                 for name, index in ds.xindexes.items()

--- a/virtualizarr/tests/test_backend.py
+++ b/virtualizarr/tests/test_backend.py
@@ -89,13 +89,21 @@ class TestOpenVirtualDatasetIndexes:
         vds = open_virtual_dataset(netcdf4_file, indexes={}, backend=hdf_backend)
         assert vds.indexes == {}
 
-    def test_create_default_indexes(self, netcdf4_file, hdf_backend):
-        with pytest.warns(UserWarning, match="will create in-memory pandas indexes"):
-            vds = open_virtual_dataset(netcdf4_file, indexes=None, backend=hdf_backend)
+    def test_create_default_indexes_for_loadable_variables(
+        self, netcdf4_file, hdf_backend
+    ):
+        loadable_variables = ["time", "lat"]
+
+        vds = open_virtual_dataset(
+            netcdf4_file,
+            indexes=None,
+            backend=hdf_backend,
+            loadable_variables=loadable_variables,
+        )
         ds = open_dataset(netcdf4_file, decode_times=True)
 
         # TODO use xr.testing.assert_identical(vds.indexes, ds.indexes) instead once class supported by assertion comparison, see https://github.com/pydata/xarray/issues/5812
-        assert index_mappings_equal(vds.xindexes, ds.xindexes)
+        assert index_mappings_equal(vds.xindexes, ds[loadable_variables].xindexes)
 
 
 def index_mappings_equal(indexes1: Mapping[str, Index], indexes2: Mapping[str, Index]):

--- a/virtualizarr/tests/test_xarray.py
+++ b/virtualizarr/tests/test_xarray.py
@@ -6,7 +6,7 @@ import xarray as xr
 
 from virtualizarr import open_virtual_dataset
 from virtualizarr.manifests import ChunkManifest, ManifestArray
-from virtualizarr.readers.hdf import HDFVirtualBackend
+from virtualizarr.readers import HDF5VirtualBackend, HDFVirtualBackend
 from virtualizarr.tests import requires_kerchunk
 from virtualizarr.zarr import ZArray
 
@@ -227,15 +227,17 @@ class TestConcat:
 
 
 @requires_kerchunk
-@pytest.mark.parametrize("hdf_backend", [None, HDFVirtualBackend])
+@pytest.mark.parametrize("hdf_backend", [HDF5VirtualBackend, HDFVirtualBackend])
 class TestCombineUsingIndexes:
     def test_combine_by_coords(self, netcdf4_files_factory: Callable, hdf_backend):
         filepath1, filepath2 = netcdf4_files_factory()
 
-        with pytest.warns(UserWarning, match="will create in-memory pandas indexes"):
-            vds1 = open_virtual_dataset(filepath1, backend=hdf_backend)
-        with pytest.warns(UserWarning, match="will create in-memory pandas indexes"):
-            vds2 = open_virtual_dataset(filepath2, backend=hdf_backend)
+        vds1 = open_virtual_dataset(
+            filepath1, backend=hdf_backend, loadable_variables=["time", "lat", "lon"]
+        )
+        vds2 = open_virtual_dataset(
+            filepath2, backend=hdf_backend, loadable_variables=["time", "lat", "lon"]
+        )
 
         combined_vds = xr.combine_by_coords(
             [vds2, vds1],
@@ -247,10 +249,8 @@ class TestCombineUsingIndexes:
     def test_combine_by_coords_keeping_manifestarrays(self, netcdf4_files, hdf_backend):
         filepath1, filepath2 = netcdf4_files
 
-        with pytest.warns(UserWarning, match="will create in-memory pandas indexes"):
-            vds1 = open_virtual_dataset(filepath1, backend=hdf_backend)
-        with pytest.warns(UserWarning, match="will create in-memory pandas indexes"):
-            vds2 = open_virtual_dataset(filepath2, backend=hdf_backend)
+        vds1 = open_virtual_dataset(filepath1, backend=hdf_backend)
+        vds2 = open_virtual_dataset(filepath2, backend=hdf_backend)
 
         combined_vds = xr.combine_by_coords(
             [vds2, vds1],


### PR DESCRIPTION
I think the warning being thrown here was really a misguided attempt to ensure that variables in the virtual dataset aren't too large. But generally it's much simpler to just create indexes for loadable variables instead, and not throw a warning.

- [x] Closes #18
- [x] Tests added
- [x] Tests passing
- [x] Full type hint coverage
- [x] Changes are documented in `docs/releases.rst`
- [ ] ~~New functions/methods are listed in `api.rst`~~
- [x] New functionality has documentation
