### PR TITLE
Align accepted filetypes with docstring description

### DIFF
--- a/virtualizarr/backend.py
+++ b/virtualizarr/backend.py
@@ -184,7 +184,7 @@ def open_virtual_dataset(
 
     if filetype is not None:
         # if filetype is user defined, convert to FileType
-        filetype = FileType(filetype)
+        filetype = FileType(filetype.lower())
     else:
         filetype = automatically_determine_filetype(
             filepath=filepath, reader_options=reader_options

--- a/virtualizarr/tests/test_backend.py
+++ b/virtualizarr/tests/test_backend.py
@@ -385,6 +385,8 @@ class TestLoadVirtualDataset:
         with pytest.raises(NotImplementedError):
             open_virtual_dataset(netcdf4_file, filetype="grib")
 
+        open_virtual_dataset(netcdf4_file, filetype="netCDF4")
+
     def test_explicit_filetype_and_backend(self, netcdf4_file):
         with pytest.raises(ValueError):
             open_virtual_dataset(


### PR DESCRIPTION
The docs state the filetype `Can be one of {‘netCDF3’, ‘netCDF4’, ‘HDF’, ‘TIFF’, ‘GRIB’, ‘FITS’, ‘dmrpp’, ‘zarr_v3’, ‘kerchunk’}"` but in reality few of these arguments actually worked due to case sensitivity.
