### PR TITLE
Configure codecov to ignore tests folder

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,17 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 100
+        threshold: 0.1
+    patch:
+      default:
+        target: 100
+comment:
+  layout: "diff, files"
+  behavior: default
+  require_changes: true  # if true: only post the comment if coverage changes
+  branches:               # branch names that can post comment
+    - "main"
+ignore:
+  - "virtualizarr/tests"  # ignore folders and all its contents

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -2,11 +2,11 @@ coverage:
   status:
     project:
       default:
-        target: 100
+        target: 75
         threshold: 0.1
     patch:
       default:
-        target: 100
+        target: 75
 comment:
   layout: "diff, files"
   behavior: default

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,3 +58,4 @@ jobs:
           env_vars: OS,PYTHON
           name: codecov-umbrella
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Based on Zarr-Python, I think it should work to put the configuration inside .github rather than the repository root, but let's see...