### PR TITLE
Test FITS reader on Hubble Space Telescope data

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -31,6 +31,8 @@ Bug fixes
 
 - Fix bug preventing generating references for the root group of a file when a subgroup exists.
   (:issue:`336`, :pull:`338`) By `Tom Nicholas <https://github.com/TomNicholas>`_.
+- Fix bug passing arguments to FITS reader, and test it on Hubble Space Telescope data.
+  (:pull:`363`) By `Tom Nicholas <https://github.com/TomNicholas>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/virtualizarr/readers/fits.py
+++ b/virtualizarr/readers/fits.py
@@ -42,7 +42,7 @@ class FITSVirtualBackend(VirtualBackend):
 
         # TODO This wouldn't work until either you had an xarray backend for FITS installed, or issue #124 is implemented to load data from ManifestArrays directly
         # TODO Once we have one of those we can use ``maybe_open_loadable_vars_and_indexes`` here
-        if loadable_variables != [] or indexes != {} or decode_times:
+        if loadable_variables or indexes:
             raise NotImplementedError(
                 "Cannot load variables or indexes from FITS files as there is no xarray backend engine for FITS"
             )

--- a/virtualizarr/tests/__init__.py
+++ b/virtualizarr/tests/__init__.py
@@ -9,7 +9,8 @@ from virtualizarr.manifests import ChunkManifest, ManifestArray
 from virtualizarr.manifests.manifest import join
 from virtualizarr.zarr import ZArray, ceildiv
 
-network = pytest.mark.network
+# TODO rename to requires_network?
+requires_network = pytest.mark.network
 
 
 def _importorskip(

--- a/virtualizarr/tests/__init__.py
+++ b/virtualizarr/tests/__init__.py
@@ -9,7 +9,6 @@ from virtualizarr.manifests import ChunkManifest, ManifestArray
 from virtualizarr.manifests.manifest import join
 from virtualizarr.zarr import ZArray, ceildiv
 
-# TODO rename to requires_network?
 requires_network = pytest.mark.network
 
 

--- a/virtualizarr/tests/test_backend.py
+++ b/virtualizarr/tests/test_backend.py
@@ -15,8 +15,8 @@ from virtualizarr.readers import HDF5VirtualBackend
 from virtualizarr.readers.hdf import HDFVirtualBackend
 from virtualizarr.tests import (
     has_astropy,
-    network,
     requires_kerchunk,
+    requires_network,
     requires_s3fs,
     requires_scipy,
 )
@@ -193,7 +193,7 @@ class TestDetermineCoords:
         assert set(vds.coords) == set(expected_coords)
 
 
-@network
+@requires_network
 @requires_s3fs
 class TestReadFromS3:
     @pytest.mark.parametrize(
@@ -216,7 +216,7 @@ class TestReadFromS3:
             assert isinstance(vds[var].data, ManifestArray), var
 
 
-@network
+@requires_network
 @pytest.mark.parametrize("hdf_backend", [HDF5VirtualBackend, HDFVirtualBackend])
 class TestReadFromURL:
     @pytest.mark.parametrize(

--- a/virtualizarr/tests/test_readers/test_dmrpp.py
+++ b/virtualizarr/tests/test_readers/test_dmrpp.py
@@ -11,7 +11,7 @@ import xarray.testing as xrt
 from virtualizarr import open_virtual_dataset
 from virtualizarr.manifests.manifest import ChunkManifest
 from virtualizarr.readers.dmrpp import DMRParser
-from virtualizarr.tests import network
+from virtualizarr.tests import requires_network
 
 urls = [
     (
@@ -177,7 +177,7 @@ def dmrparser(dmrpp_xml_str: str, tmp_path: Path, filename="test.nc") -> DMRPars
     )
 
 
-@network
+@requires_network
 @pytest.mark.parametrize("data_url, dmrpp_url", urls)
 @pytest.mark.skip(reason="Fill_val mismatch")
 def test_NASA_dmrpp(data_url, dmrpp_url):

--- a/virtualizarr/tests/test_readers/test_fits.py
+++ b/virtualizarr/tests/test_readers/test_fits.py
@@ -1,0 +1,25 @@
+import pytest
+
+from xarray import Dataset
+
+from virtualizarr import open_virtual_dataset
+from virtualizarr.tests import network, requires_kerchunk
+
+
+pytest.importorskip("astropy")
+
+
+@requires_kerchunk
+@network
+def test_open_hubble_data():
+    # data from https://registry.opendata.aws/hst/
+    vds = open_virtual_dataset(
+        "s3://stpubdata/hst/public/f05i/f05i0201m/f05i0201m_a1f.fits",
+        reader_options={'storage_options': {'anon': True}}
+    )
+    
+    assert isinstance(vds, Dataset)
+    assert list(vds.variables) == ['PRIMARY']
+    var = vds['PRIMARY'].variable
+    assert var.sizes == {'y': 17, 'x': 589}
+    assert var.dtype == '>i4'

--- a/virtualizarr/tests/test_readers/test_fits.py
+++ b/virtualizarr/tests/test_readers/test_fits.py
@@ -1,25 +1,23 @@
 import pytest
-
 from xarray import Dataset
 
 from virtualizarr import open_virtual_dataset
-from virtualizarr.tests import network, requires_kerchunk
-
+from virtualizarr.tests import requires_kerchunk, requires_network
 
 pytest.importorskip("astropy")
 
 
 @requires_kerchunk
-@network
+@requires_network
 def test_open_hubble_data():
     # data from https://registry.opendata.aws/hst/
     vds = open_virtual_dataset(
         "s3://stpubdata/hst/public/f05i/f05i0201m/f05i0201m_a1f.fits",
-        reader_options={'storage_options': {'anon': True}}
+        reader_options={"storage_options": {"anon": True}},
     )
-    
+
     assert isinstance(vds, Dataset)
-    assert list(vds.variables) == ['PRIMARY']
-    var = vds['PRIMARY'].variable
-    assert var.sizes == {'y': 17, 'x': 589}
-    assert var.dtype == '>i4'
+    assert list(vds.variables) == ["PRIMARY"]
+    var = vds["PRIMARY"].variable
+    assert var.sizes == {"y": 17, "x": 589}
+    assert var.dtype == ">i4"


### PR DESCRIPTION
Small bugfix for the FITS reader, tested by trying to read one of the FITS files stored in AWS comprising the Hubble Space Telescope data archive.

Also renames the `@network` test decorator to `@requires_network`.

- [ ] Closes #xxxx
- [x] Tests added
- [x] Tests passing
- [x] Full type hint coverage
- [x] Changes are documented in `docs/releases.rst`
