### PR TITLE
Keep fill value for encoding

### DIFF
--- a/ci/upstream.yml
+++ b/ci/upstream.yml
@@ -28,6 +28,6 @@ dependencies:
   - fsspec
   - pip
   - pip:
-      - icechunk>=0.1.0a8 # Installs zarr v3 as dependency
+      - icechunk==0.1.0a8 # Installs zarr v3 beta 3 as dependency
       # - git+https://github.com/fsspec/kerchunk@main  # kerchunk is currently incompatible with zarr-python v3 (https://github.com/fsspec/kerchunk/pull/516)
       - imagecodecs-numcodecs==2024.6.1

--- a/ci/upstream.yml
+++ b/ci/upstream.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - xarray>=2024.10.0
+  - xarray>=2024.10.0,<2025.0.0
   - h5netcdf
   - h5py
   - hdf5

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -24,6 +24,8 @@ Bug fixes
 
 - Fix bug preventing generating references for the root group of a file when a subgroup exists.
   (:issue:`336`, :pull:`337`) By `Tom Nicholas <https://github.com/TomNicholas>`_.
+- Fix bug in dmrpp reader so _FillValue is passed to variables' encodings.
+  (:pull:`369`) By `Aimee Barciauskas <https://github.com/abarciauskas-bgse>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -35,7 +35,7 @@ Bug fixes
 
 - Fix bug preventing generating references for the root group of a file when a subgroup exists.
   (:issue:`336`, :pull:`338`) By `Tom Nicholas <https://github.com/TomNicholas>`_.
-- Fix bug in dmrpp reader so _FillValue is passed to variables' encodings.
+- Fix bug in dmrpp reader so _FillValue is included in variables' encodings.
   (:pull:`369`) By `Aimee Barciauskas <https://github.com/abarciauskas-bgse>`_.
 - Fix bug passing arguments to FITS reader, and test it on Hubble Space Telescope data.
   (:pull:`363`) By `Tom Nicholas <https://github.com/TomNicholas>`_.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 requires-python = ">=3.10"
 dynamic = ["version"]
 dependencies = [
-    "xarray>=2024.10.0",
+    "xarray>=2024.10.0,<2025.0.0",
     "numpy>=2.0.0",
     "packaging",
     "universal-pathlib",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ hdf_reader = [
     "numcodecs"
 ]
 icechunk = [
-    "icechunk>=0.1.0a8",
+    "icechunk==0.1.0a8",
 ]
 test = [
     "codecov",

--- a/virtualizarr/readers/dmrpp.py
+++ b/virtualizarr/readers/dmrpp.py
@@ -412,7 +412,7 @@ class DMRParser:
         for attr_tag in var_tag.iterfind("dap:Attribute", self._NS):
             attrs.update(self._parse_attribute(attr_tag))
         # Fill value is placed in encoding and thus removed from attributes
-        fill_value = attrs.pop("_FillValue", None)
+        fill_value = attrs.get("_FillValue", None)
         # create ManifestArray and ZArray
         zarray = ZArray(
             chunks=chunks_shape,

--- a/virtualizarr/readers/dmrpp.py
+++ b/virtualizarr/readers/dmrpp.py
@@ -411,8 +411,9 @@ class DMRParser:
         attrs: dict[str, Any] = {}
         for attr_tag in var_tag.iterfind("dap:Attribute", self._NS):
             attrs.update(self._parse_attribute(attr_tag))
-        # Fill value is placed in encoding and thus removed from attributes
-        fill_value = attrs.get("_FillValue", None)
+        # Fill value is placed in zarr array's fill_value and variable encoding and removed from attributes
+        encoding = {k: attrs.get(k) for k in self._ENCODING_KEYS if k in attrs}
+        fill_value = attrs.pop("_FillValue", None)
         # create ManifestArray and ZArray
         zarray = ZArray(
             chunks=chunks_shape,
@@ -423,7 +424,6 @@ class DMRParser:
             shape=shape,
         )
         marr = ManifestArray(zarray=zarray, chunkmanifest=chunkmanifest)
-        encoding = {k: attrs.get(k) for k in self._ENCODING_KEYS if k in attrs}
         return Variable(dims=dims.keys(), data=marr, attrs=attrs, encoding=encoding)
 
     def _parse_attribute(self, attr_tag: ET.Element) -> dict[str, Any]:

--- a/virtualizarr/tests/test_readers/test_dmrpp.py
+++ b/virtualizarr/tests/test_readers/test_dmrpp.py
@@ -307,7 +307,6 @@ def test_parse_variable(tmp_path):
         "coordinates": "x y z",
         "add_offset": 298.15,
         "scale_factor": 0.001,
-        "_FillValue": -32768,
     }
 
 

--- a/virtualizarr/tests/test_readers/test_dmrpp.py
+++ b/virtualizarr/tests/test_readers/test_dmrpp.py
@@ -296,13 +296,18 @@ def test_parse_variable(tmp_path):
     assert var.shape == (720, 1440)
     assert var.data.zarray.chunks == (360, 720)
     assert var.data.zarray.fill_value == -32768
-    assert var.encoding == {"add_offset": 298.15, "scale_factor": 0.001}
+    assert var.encoding == {
+        "add_offset": 298.15,
+        "scale_factor": 0.001,
+        "_FillValue": -32768,
+    }
     assert var.attrs == {
         "long_name": "analysed sea surface temperature",
         "items": [1, 2, 3],
         "coordinates": "x y z",
         "add_offset": 298.15,
         "scale_factor": 0.001,
+        "_FillValue": -32768,
     }
 
 

--- a/virtualizarr/tests/test_writers/test_icechunk.py
+++ b/virtualizarr/tests/test_writers/test_icechunk.py
@@ -710,7 +710,9 @@ class TestAppend:
                 "time/c/0", prototype=default_buffer_prototype()
             )
         ) == first_time_chunk_before_append
-        new_ds = open_zarr(icechunk_filestore_append, consolidated=False, zarr_format=3)
+        new_ds = open_zarr(
+            icechunk_filestore_append.store, consolidated=False, zarr_format=3
+        )
 
         expected_ds1, expected_ds2 = open_dataset(filepath1), open_dataset(filepath2)
         expected_ds = concat([expected_ds1, expected_ds2], dim="time")


### PR DESCRIPTION
While [trying to create a virtual icechunk store for MUR SST](https://gist.github.com/abarciauskas-bgse/daa92b4a4a90387afec654597c3509c6), using the dmrpp reader, I noticed that a mean value coming back from the icechunk store was wrong. (To be clear this issue has nothing to do with icechunk, but the data have to be stored to zarr or icechunk). After some trial and error, I found that the issue was a missing fill value in the encoding of the data variables. This PR fixes the issue by replacing `pop` with `get` for the `_FillValue` in attrs, so they can be passed along in the encoding.

I verified this works by making the same code change in the dmrpp.py file VirtualiZarr dependency of my notebook (run on hub.openveda.cloud and using the quay.io/developmentseed/veda-optimized-data-delivery-image:latest image). The mean value returned from the icechunk.

- ~Closes #xxxx~ n/a
- [x] Tests added
- [x] Tests passing
- ~Full type hint coverage~ n/a
- [x] Changes are documented in docs/releases.rst
- ~New functions/methods are listed in api.rst~ n/a
- ~New functionality has documentation~ n/a

Please review @ayushnag 