### PR TITLE
xfail test which times out due to large nisar file

### DIFF
--- a/virtualizarr/tests/test_backend.py
+++ b/virtualizarr/tests/test_backend.py
@@ -284,6 +284,7 @@ class TestReadFromURL:
             vds = open_virtual_dataset(url, indexes={})
             assert isinstance(vds, xr.Dataset)
 
+    @pytest.mark.xfail(reason='often times out, as nisar file is 200MB')
     def test_virtualizarr_vs_local_nisar(self, hdf_backend):
         import fsspec
 


### PR DESCRIPTION
Attempt to prevent failures of test suite on `main`, as discussed in https://github.com/zarr-developers/VirtualiZarr/issues/365.
