### PR TITLE
Bump Xarray to 2025.1.1 and icechunk to 0.1.0a10 in upstream

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - h5py
   - hdf5
   - netcdf4
-  - xarray>=2024.10.0
+  - xarray>=2025.1.1
   - kerchunk>=0.2.5
   - numpy>=2.0.0
   - ujson

--- a/ci/min-deps.yml
+++ b/ci/min-deps.yml
@@ -6,7 +6,7 @@ dependencies:
   - h5py
   - hdf5
   - netcdf4
-  - xarray>=2024.10.0
+  - xarray>=2025.1.1
   - numpy>=2.0.0
   - numcodecs
   - packaging

--- a/ci/upstream.yml
+++ b/ci/upstream.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - xarray>=2024.10.0
+  - xarray>=2025.1.1
   - h5netcdf
   - h5py
   - hdf5
@@ -28,6 +28,6 @@ dependencies:
   - fsspec
   - pip
   - pip:
-      - icechunk>=0.1.0a8 # Installs zarr v3 as dependency
+      - icechunk>=0.1.0a10 # Installs zarr v3 as dependency
       # - git+https://github.com/fsspec/kerchunk@main  # kerchunk is currently incompatible with zarr-python v3 (https://github.com/fsspec/kerchunk/pull/516)
       - imagecodecs-numcodecs==2024.6.1


### PR DESCRIPTION
- [ ] Tests passing

