### PR TITLE
Silence pip root user warnings in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-jobs:
+env:
+  PIP_ROOT_USER_ACTION: ignore
 
+jobs:
   test:
     name: ${{ matrix.python-version }}-build
     runs-on: ubuntu-latest
@@ -41,10 +43,11 @@ jobs:
       - name: Install virtualizarr
         run: |
            python -m pip install -e . --no-deps
+
       - name: Conda list information
         run: |
-          conda env list
-          conda list
+          micromamba env list
+          micromamba list
 
       - name: Running Tests
         run: |

--- a/.github/workflows/min-deps.yml
+++ b/.github/workflows/min-deps.yml
@@ -16,9 +16,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-jobs:
+env:
+  PIP_ROOT_USER_ACTION: ignore
 
-  test:
+jobs:
+  test-min-deps:
     name: ${{ matrix.python-version }}-build
     runs-on: ubuntu-latest
     defaults:
@@ -41,10 +43,11 @@ jobs:
       - name: Install virtualizarr
         run: |
            python -m pip install -e . --no-deps
+
       - name: Conda list information
         run: |
-          conda env list
-          conda list
+          micromamba env list
+          micromamba list
 
       - name: Running Tests
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ on:
 permissions:
   contents: read
 
+env:
+  PIP_ROOT_USER_ACTION: ignore
+
 jobs:
   build-artifacts:
     runs-on: ubuntu-latest

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  PIP_ROOT_USER_ACTION: ignore
+
 jobs:
   mypy:
     name: mypy

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -16,9 +16,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-jobs:
+env:
+  PIP_ROOT_USER_ACTION: ignore
 
-  test:
+jobs:
+  test-upstream:
     name: ${{ matrix.python-version }}-build
     runs-on: ubuntu-latest
     defaults:
@@ -41,10 +43,11 @@ jobs:
       - name: Install virtualizarr
         run: |
            python -m pip install -e . --no-deps
+
       - name: Conda list information
         run: |
-          conda env list
-          conda list
+          micromamba env list
+          micromamba list
 
       - name: Running Tests
         run: |


### PR DESCRIPTION
In addition, to aid in use of [`act`](https://github.com/nektos/act) for locally running GH jobs:

- Uniquely name test jobs
- Use `micromamba` in place of `conda` because, oddly, `act` containers are unable to find `conda`, and fail

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Tests passing