### PR TITLE
Ignore conftest.py in code coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,0 @@
-[run]
-omit =
-    virtualizarr/tests/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+omit =
+    virtualizarr/tests/*

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -15,4 +15,5 @@ comment:
   branches:               # branch names that can post comment
     - "main"
 ignore:
+  - "conftest.py"
   - "virtualizarr/tests"  # ignore folders and all its contents

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -3,7 +3,8 @@ coverage:
     project:
       default:
         target: 75
-        threshold: 0.1
+        # See https://json.schemastore.org/codecov.json
+        threshold: "0.1%"
     patch:
       default:
         target: 75

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Running Tests
         run: |
-          python -m pytest --run-network-tests --cov-report=xml --verbose virtualizarr
+          python -m pytest --run-network-tests --verbose --cov=virtualizarr --cov-report=xml
 
       - name: Upload code coverage to Codecov
         uses: codecov/codecov-action@v3.1.4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Running Tests
         run: |
-          python -m pytest ./virtualizarr --run-network-tests --cov=./ --cov-report=xml --verbose
+          python -m pytest --run-network-tests --cov-report=xml --verbose virtualizarr
 
       - name: Upload code coverage to Codecov
         uses: codecov/codecov-action@v3.1.4

--- a/.github/workflows/min-deps.yml
+++ b/.github/workflows/min-deps.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Running Tests
         run: |
-          python -m pytest --cov-report=xml --verbose virtualizarr
+          python -m pytest --verbose --cov=virtualizarr --cov-report=xml
 
       - name: Upload code coverage to Codecov
         uses: codecov/codecov-action@v3.1.4

--- a/.github/workflows/min-deps.yml
+++ b/.github/workflows/min-deps.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Running Tests
         run: |
-          python -m pytest ./virtualizarr --cov=./ --cov-report=xml --verbose
+          python -m pytest --cov-report=xml --verbose virtualizarr
 
       - name: Upload code coverage to Codecov
         uses: codecov/codecov-action@v3.1.4

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Running Tests
         run: |
-          python -m pytest --cov-report=xml --verbose virtualizarr
+          python -m pytest --verbose --cov=virtualizarr --cov-report=xml
 
       - name: Upload code coverage to Codecov
         uses: codecov/codecov-action@v3.1.4

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Running Tests
         run: |
-          python -m pytest ./virtualizarr --cov=./ --cov-report=xml --verbose
+          python -m pytest --cov-report=xml --verbose virtualizarr
 
       - name: Upload code coverage to Codecov
         uses: codecov/codecov-action@v3.1.4

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -16,7 +16,7 @@ dependencies:
   - hdf5plugin
   - numcodecs
   # Testing
-  - codecov
+  - codecov[toml]
   - pre-commit
   - mypy
   - ruff

--- a/ci/min-deps.yml
+++ b/ci/min-deps.yml
@@ -13,7 +13,7 @@ dependencies:
   - ujson
   - universal_pathlib
   # Testing
-  - codecov
+  - codecov[toml]
   - pre-commit
   - mypy
   - ruff

--- a/ci/upstream.yml
+++ b/ci/upstream.yml
@@ -16,7 +16,7 @@ dependencies:
   - numcodecs
   - imagecodecs>=2024.6.1
   # Testing
-  - codecov
+  - codecov[toml]
   - pre-commit
   - mypy
   - ruff

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -12,10 +12,10 @@ mamba activate virtualizarr-tests
 pre-commit install
 # git checkout -b new-feature
 python -m pip install -e . --no-deps
-python -m pytest ./virtualizarr --run-network-tests --cov=./ --cov-report=xml --verbose
+python -m pytest --run-network-tests
 ```
 
-The `--run-network-tests` argument is optional - it will run additional tests that require downloading files over the network. Skip this if you want the tests to run faster or you have no internet access.
+The `--run-network-tests` argument is optional -- it will run additional tests that require downloading files over the network. Skip this if you want the tests to run faster or you have no internet access.
 
 ## Contributing documentation
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -20,13 +20,20 @@ that require downloading files over the network.  Skip this if you want the test
 faster or you have no internet access:
 
 ```bash
-pytest -m pytest --run-network-tests
+python -m pytest --run-network-tests
 ```
 
-Further, we use the `pytest-cov` plugin to generate a test coverage report.  By default,
-a report showing lines missing coverage will be printed to the terminal.  You may supply
-additional options to `pytest` to generate other outputs, such as an HTML report (via
-`--cov-report=html`).  For all available options added by the `pytest-cov` plugin, run
+Further, the `pytest-cov` plugin is a test dependency, so you can generate a test
+coverage report locally, if you wish (CI will automatically do so).  Here are some
+examples:
+
+```bash
+python -m pytest --cov=.                     # Terminal (text) report (--cov=term)
+python -m pytest --cov=. --cov=term-missing  # Terminal report showing missing coverage
+python -m pytest --cov=. --cov=html          # HTML report written to htmlcov/index.html
+```
+
+To see all available `pytest` options added by the `pytest-cov` plugin, run
 `python -m pytest -h`, or see the
 [pytest-cov documentation](https://pytest-cov.readthedocs.io/en/latest/readme.html).
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -12,10 +12,23 @@ mamba activate virtualizarr-tests
 pre-commit install
 # git checkout -b new-feature
 python -m pip install -e . --no-deps
-python -m pytest --run-network-tests
+python -m pytest
 ```
 
-The `--run-network-tests` argument is optional -- it will run additional tests that require downloading files over the network. Skip this if you want the tests to run faster or you have no internet access.
+You may also add the `--run-network-tests` option, which will run additional tests
+that require downloading files over the network.  Skip this if you want the tests to run
+faster or you have no internet access:
+
+```bash
+pytest -m pytest --run-network-tests
+```
+
+Further, we use the `pytest-cov` plugin to generate a test coverage report.  By default,
+a report showing lines missing coverage will be printed to the terminal.  You may supply
+additional options to `pytest` to generate other outputs, such as an HTML report (via
+`--cov-report=html`).  For all available options added by the `pytest-cov` plugin, run
+`python -m pytest -h`, or see the
+[pytest-cov documentation](https://pytest-cov.readthedocs.io/en/latest/readme.html).
 
 ## Contributing documentation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,10 @@ line-ending = "auto"
 known-first-party = ["virtualizarr"]
 
 [tool.pytest.ini_options]
+addopts = [
+    "--cov=virtualizarr",
+    "--cov-report=term-missing",
+]
 # See https://pytest-asyncio.readthedocs.io/en/latest/concepts.html#asyncio-event-loops
 # Explicitly set asyncio_default_fixture_loop_scope to eliminate the following warning:
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,13 +149,10 @@ line-ending = "auto"
 known-first-party = ["virtualizarr"]
 
 [tool.coverage.run]
-omit = ["virtualizarr/tests/*"]
+include = ["virtualizarr/"]
+omit = ["conftest.py", "virtualizarr/tests/*"]
 
 [tool.pytest.ini_options]
-addopts = [
-    "--cov=virtualizarr",
-    "--cov-report=term-missing",
-]
 # See https://pytest-asyncio.readthedocs.io/en/latest/concepts.html#asyncio-event-loops
 # Explicitly set asyncio_default_fixture_loop_scope to eliminate the following warning:
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,9 @@ line-ending = "auto"
 [tool.ruff.lint.isort]
 known-first-party = ["virtualizarr"]
 
+[tool.coverage.run]
+omit = ["virtualizarr/tests/*"]
+
 [tool.pytest.ini_options]
 addopts = [
     "--cov=virtualizarr",


### PR DESCRIPTION
In addition, make it easier for produce coverage report locally by adding pytest config options to pyproject.toml. This also produces consistent results between local runs and runs in CI, and adds a term-missing report for human readability, both for local runs as well as in CI, so it show up in the logs.

- [x] Closes #387
- [x] Tests passing