### PR TITLE
Add group param to virtualize Dataset accessor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,22 @@ cython_debug/
 virtualizarr/_version.py
 docs/generated/
 examples/
+
+# Created by https://www.toptal.com/developers/gitignore/api/visualstudiocode
+# Edit at https://www.toptal.com/developers/gitignore?templates=visualstudiocode
+
+### VisualStudioCode ###
+.vscode
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+# End of https://www.toptal.com/developers/gitignore/api/visualstudiocode

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -15,9 +15,10 @@ New Features
   for the `to_icechunk` method to add timestamps as checksums when writing virtual references to an icechunk store. This
   is useful for ensuring that virtual references are not stale when reading from an icechunk store, which can happen if the
   underlying data has changed since the virtual references were written.
-- Add ``group=None`` keyword-only parameter to ``dataset_to_icechunk`` function to
-  allow writing to a nested group at the specified path (root group, if not specified).
-  (:issue:`341`) By `Chuck Daniels <https://github.com/chuckwondo>`_.
+- Add ``group=None`` keyword-only parameter to the
+  ``VirtualiZarrDatasetAccessor.to_icechunk`` method to allow writing to a nested group
+  at a specified group path (rather than defaulting to the root group, when no group is
+  specified).  (:issue:`341`) By `Chuck Daniels <https://github.com/chuckwondo>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~
@@ -29,10 +30,11 @@ Breaking changes
   Also a warning is no longer thrown when ``indexes=None`` is passed to ``open_virtual_dataset``, and the recommendations in the docs updated to match.
   This also means that ``xarray.combine_by_coords`` will now work when the necessary dimension coordinates are specified in ``loadable_variables``.
   (:issue:`18`, :pull:`357`, :pull:`358`) By `Tom Nicholas <https://github.com/TomNicholas>`_.
-- For function ``dataset_to_icechunk``, parameters ``append_dim`` and ``last_updated_at``
-  are now keyword-only parameters, rather than positional or keyword.  This change is
-  breaking _only_ where arguments for these parameters are currently given positionally.
-  (:issue:`341`) By `Chuck Daniels <https://github.com/chuckwondo>`_.
+- The ``append_dim`` and ``last_updated_at`` parameters of the
+  ``VirtualiZarrDatasetAccessor.to_icechunk`` method are now keyword-only parameters,
+  rather than positional or keyword.  This change is breaking _only_ where arguments for
+  these parameters are currently given positionally.  (:issue:`341`) By
+  `Chuck Daniels <https://github.com/chuckwondo>`_.
 
 Deprecations
 ~~~~~~~~~~~~


### PR DESCRIPTION
Add optional `group` kw-only parameter to the `to_icechunk` method of the "virtualize" xr.Dataset custom accessor.

- [ ] Closes #341
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functionality has documentation
