### PR TITLE
Fix drop_variables support in kerchunk, dmrpp

### DIFF
--- a/virtualizarr/readers/dmrpp.py
+++ b/virtualizarr/readers/dmrpp.py
@@ -27,7 +27,7 @@ class DMRPPVirtualBackend(VirtualBackend):
         virtual_backend_kwargs: Optional[dict] = None,
         reader_options: Optional[dict] = None,
     ) -> Dataset:
-        loadable_variables, drop_variables = check_for_collisions(
+        drop_variables, loadable_variables = check_for_collisions(
             drop_variables=drop_variables,
             loadable_variables=loadable_variables,
         )

--- a/virtualizarr/readers/kerchunk.py
+++ b/virtualizarr/readers/kerchunk.py
@@ -38,7 +38,7 @@ class KerchunkVirtualBackend(VirtualBackend):
         if group:
             raise NotImplementedError()
 
-        loadable_variables, drop_variables = check_for_collisions(
+        drop_variables, loadable_variables = check_for_collisions(
             drop_variables=drop_variables,
             loadable_variables=loadable_variables,
         )

--- a/virtualizarr/tests/test_readers/test_dmrpp.py
+++ b/virtualizarr/tests/test_readers/test_dmrpp.py
@@ -446,3 +446,15 @@ class TestRelativePaths:
             ".dmrpp"
         )
         assert path == expected_datafile_path_uri
+
+
+@pytest.mark.parametrize("drop_variables", ["mask", ["data", "mask"]])
+def test_drop_variables(basic_dmrpp_temp_filepath: Path, drop_variables):
+    vds = open_virtual_dataset(
+        str(basic_dmrpp_temp_filepath),
+        indexes={},
+        filetype="dmrpp",
+        drop_variables=drop_variables,
+    )
+
+    assert all(var not in vds for var in drop_variables)

--- a/virtualizarr/tests/test_readers/test_kerchunk.py
+++ b/virtualizarr/tests/test_readers/test_kerchunk.py
@@ -248,3 +248,14 @@ def test_notimplemented_read_inline_refs(tmp_path, netcdf4_inlined_ref):
         open_virtual_dataset(
             filepath=ref_filepath.as_posix(), filetype="kerchunk", indexes={}
         )
+
+
+@pytest.mark.parametrize("drop_variables", ["a", ["a"]])
+def test_drop_variables(refs_file_factory, drop_variables):
+    refs_file = refs_file_factory()
+
+    vds = open_virtual_dataset(
+        refs_file, filetype="kerchunk", drop_variables=drop_variables
+    )
+
+    assert all(var not in vds for var in drop_variables)


### PR DESCRIPTION
Fix reversed assignment of results from collision detection that was causing NotImplementedError to be incorrectly raised for loadable_variables when only drop_variables is supplied.

- [ ] Tests added
- [ ] Tests passing
