### PR TITLE
Roundtrip tests kerchunk tests without requiring kerchunk

### DIFF
--- a/virtualizarr/tests/__init__.py
+++ b/virtualizarr/tests/__init__.py
@@ -1,8 +1,10 @@
 import importlib
 import itertools
 
+import fsspec
 import numpy as np
 import pytest
+import xarray as xr
 from packaging.version import Version
 
 from virtualizarr.manifests import ChunkManifest, ManifestArray
@@ -105,3 +107,15 @@ def offset_from_chunk_key(ind: tuple[int, ...]) -> int:
 
 def length_from_chunk_key(ind: tuple[int, ...]) -> int:
     return sum(ind) + 5
+
+
+def open_dataset_kerchunk(
+    filename_or_obj: str, *, storage_options=None, **kwargs
+) -> xr.Dataset:
+    """Equivalent to ``xr.open_dataset(..., engine="kerchunk")`` but without depending on
+    kerchunk library
+    """
+    m = fsspec.filesystem(
+        "reference", fo=filename_or_obj, **(storage_options or {})
+    ).get_mapper()
+    return xr.open_dataset(m, engine="zarr", consolidated=False, **kwargs)

--- a/virtualizarr/tests/test_backend.py
+++ b/virtualizarr/tests/test_backend.py
@@ -15,6 +15,7 @@ from virtualizarr.readers import HDF5VirtualBackend
 from virtualizarr.readers.hdf import HDFVirtualBackend
 from virtualizarr.tests import (
     has_astropy,
+    open_dataset_kerchunk,
     parametrize_over_hdf_backends,
     requires_hdf5plugin,
     requires_imagecodecs,
@@ -321,7 +322,7 @@ class TestReadFromURL:
         )
         tmpref = "/tmp/cmip6.json"
         vds.virtualize.to_kerchunk(tmpref, format="json")
-        dsV = xr.open_dataset(tmpref, engine="kerchunk")
+        dsV = open_dataset_kerchunk(tmpref)
 
         # xrt.assert_identical(dsXR, dsV) #Attribute order changes
         xrt.assert_equal(dsXR, dsV)

--- a/virtualizarr/tests/test_integration.py
+++ b/virtualizarr/tests/test_integration.py
@@ -8,7 +8,12 @@ import xarray.testing as xrt
 
 from virtualizarr import open_virtual_dataset
 from virtualizarr.manifests import ChunkManifest, ManifestArray
-from virtualizarr.tests import parametrize_over_hdf_backends, requires_kerchunk
+from virtualizarr.tests import (
+    has_kerchunk,
+    open_dataset_kerchunk,
+    parametrize_over_hdf_backends,
+    requires_kerchunk,
+)
 from virtualizarr.translators.kerchunk import (
     dataset_from_kerchunk_refs,
 )
@@ -84,8 +89,9 @@ def test_numpy_arrays_to_inlined_kerchunk_refs(
     assert refs["refs"]["time/0"] == expected["refs"]["time/0"]
 
 
-@requires_kerchunk
-@pytest.mark.parametrize("format", ["dict", "json", "parquet"])
+@pytest.mark.parametrize(
+    "format", ["dict", "json", "parquet"] if has_kerchunk else ["dict", "json"]
+)
 class TestKerchunkRoundtrip:
     @parametrize_over_hdf_backends
     def test_kerchunk_roundtrip_no_concat(self, tmpdir, format, hdf_backend):
@@ -103,14 +109,14 @@ class TestKerchunkRoundtrip:
             ds_refs = vds.virtualize.to_kerchunk(format=format)
 
             # use fsspec to read the dataset from the kerchunk references dict
-            roundtrip = xr.open_dataset(ds_refs, engine="kerchunk", decode_times=False)
+            roundtrip = open_dataset_kerchunk(ds_refs, decode_times=False)
         else:
             # write those references to disk as kerchunk references format
             vds.virtualize.to_kerchunk(f"{tmpdir}/refs.{format}", format=format)
 
             # use fsspec to read the dataset from disk via the kerchunk references
-            roundtrip = xr.open_dataset(
-                f"{tmpdir}/refs.{format}", engine="kerchunk", decode_times=False
+            roundtrip = open_dataset_kerchunk(
+                f"{tmpdir}/refs.{format}", decode_times=False
             )
 
         # assert all_close to original dataset
@@ -164,16 +170,14 @@ class TestKerchunkRoundtrip:
             ds_refs = vds.virtualize.to_kerchunk(format=format)
 
             # use fsspec to read the dataset from the kerchunk references dict
-            roundtrip = xr.open_dataset(
-                ds_refs, engine="kerchunk", decode_times=decode_times
-            )
+            roundtrip = open_dataset_kerchunk(ds_refs, decode_times=decode_times)
         else:
             # write those references to disk as kerchunk references format
             vds.virtualize.to_kerchunk(f"{tmpdir}/refs.{format}", format=format)
 
             # use fsspec to read the dataset from disk via the kerchunk references
-            roundtrip = xr.open_dataset(
-                f"{tmpdir}/refs.{format}", engine="kerchunk", decode_times=decode_times
+            roundtrip = open_dataset_kerchunk(
+                f"{tmpdir}/refs.{format}", decode_times=decode_times
             )
 
         if decode_times is False:
@@ -214,14 +218,14 @@ class TestKerchunkRoundtrip:
             ds_refs = vds.virtualize.to_kerchunk(format=format)
 
             # use fsspec to read the dataset from the kerchunk references dict
-            roundtrip = xr.open_dataset(ds_refs, engine="kerchunk", decode_times=False)
+            roundtrip = open_dataset_kerchunk(ds_refs, decode_times=False)
         else:
             # write those references to disk as kerchunk references format
             vds.virtualize.to_kerchunk(f"{tmpdir}/refs.{format}", format=format)
 
             # use fsspec to read the dataset from disk via the kerchunk references
-            roundtrip = xr.open_dataset(
-                f"{tmpdir}/refs.{format}", engine="kerchunk", decode_times=False
+            roundtrip = open_dataset_kerchunk(
+                f"{tmpdir}/refs.{format}", decode_times=False
             )
 
         # assert equal to original dataset
@@ -265,13 +269,13 @@ class TestKerchunkRoundtrip:
             ds_refs = ds.virtualize.to_kerchunk(format=format)
 
             # use fsspec to read the dataset from the kerchunk references dict
-            roundtrip = xr.open_dataset(ds_refs, engine="kerchunk")
+            roundtrip = open_dataset_kerchunk(ds_refs)
         else:
             # write those references to disk as kerchunk references format
             ds.virtualize.to_kerchunk(f"{tmpdir}/refs.{format}", format=format)
 
             # use fsspec to read the dataset from disk via the kerchunk references
-            roundtrip = xr.open_dataset(f"{tmpdir}/refs.{format}", engine="kerchunk")
+            roundtrip = open_dataset_kerchunk(f"{tmpdir}/refs.{format}")
 
         assert roundtrip.a.attrs == ds.a.attrs
 

--- a/virtualizarr/tests/test_integration.py
+++ b/virtualizarr/tests/test_integration.py
@@ -13,6 +13,7 @@ from virtualizarr.tests import (
     open_dataset_kerchunk,
     parametrize_over_hdf_backends,
     requires_kerchunk,
+    requires_zarr_python,
 )
 from virtualizarr.translators.kerchunk import (
     dataset_from_kerchunk_refs,
@@ -89,6 +90,7 @@ def test_numpy_arrays_to_inlined_kerchunk_refs(
     assert refs["refs"]["time/0"] == expected["refs"]["time/0"]
 
 
+@requires_zarr_python
 @pytest.mark.parametrize(
     "format", ["dict", "json", "parquet"] if has_kerchunk else ["dict", "json"]
 )


### PR DESCRIPTION
It benefits this library to run as many tests as possible in as many environments as possible. So it is good to run tests that exercise reading/writing kerchunk-style references _even when kerchunk is not available_ in the testing environment.

That being said. This doesn't currently pass in the upstream env - maybe the xarray zarr 3 reader doesn't do well with fsspec?

- [x] Closes #404
- [x] Tests passing in tests env
- [ ] Tests passing in upstream env
- [ ] Changes are documented in `docs/releases.rst`
