### PR TITLE
Update to zarr-v3-compatible released version of Kerchunk (0.2.8)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
 

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - hdf5
   - netcdf4
   - xarray>=2024.10.0
-  - kerchunk>=0.2.5
+  - kerchunk>=0.2.8
   - numpy>=2.0.0
   - ujson
   - packaging

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -38,6 +38,9 @@ Breaking changes
 - The default backend for netCDF4 and HDF5 is now the custom ``HDFVirtualBackend`` replacing
   the previous default which was a wrapper around the kerchunk backend.
   (:issue:`374`, :pull:`395`) By `Julia Signell <https://github.com/jsignell>`_.
+- Optional dependency on kerchunk is now the newly-released v0.2.8. This release of kerchunk is compatible with zarr-python v3,
+  which means a released version of kerchunk can now be used with both VirtualiZarr and Icechunk.
+  (:issue:`392`, :pull:`406`, :pull:`412``) By `Julia Signell <https://github.com/jsignell>`_ and `Tom Nicholas <https://github.com/TomNicholas>`_.
 
 Deprecations
 ~~~~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,11 +14,10 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dynamic = ["version"]
 dependencies = [
     "xarray>=2025.1.1",
@@ -37,6 +36,14 @@ hdf_reader = [
     "imagecodecs",
     "imagecodecs-numcodecs==2024.6.1",
     "numcodecs"
+]
+netcdf3 = [
+    "kerchunk>=0.2.8",
+    "scipy",
+]
+fits = [
+    "kerchunk>=0.2.8",
+    "astropy",
 ]
 icechunk = [
     "icechunk>=0.1.0a12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ test = [
     "fastparquet",
     "fsspec",
     "h5py",
-    "kerchunk>=0.2.5",
+    "kerchunk>=0.2.8",
     "mypy",
     "netcdf4",
     "numcodecs",


### PR DESCRIPTION
Long-awaited part of #392, as it allows us to pin `zarr-python>=3`!

cc @mpiannucci the warning in the icechunk docs can be updated now (though virtualizarr still needs to be fixed to work with the latest version of icechunk).

- [x] Closes part of #392
- [ ] ~~Tests added~~
- [x] Tests passing
- [ ] ~~Full type hint coverage~~
- [ ] Changes are documented in `docs/releases.rst`
- [ ] ~~New functions/methods are listed in `api.rst`~~
- [ ] ~~New functionality has documentation~~
