### PR TITLE
Add in-memory icechunk tests to existing roundtrip tests

### DIFF
--- a/virtualizarr/tests/test_integration.py
+++ b/virtualizarr/tests/test_integration.py
@@ -10,6 +10,7 @@ from virtualizarr import open_virtual_dataset
 from virtualizarr.manifests import ChunkManifest, ManifestArray
 from virtualizarr.tests import (
     has_fastparquet,
+    has_icechunk,
     has_kerchunk,
     parametrize_over_hdf_backends,
     requires_kerchunk,
@@ -114,6 +115,21 @@ def roundtrip_as_kerchunk_parquet(vds: xr.Dataset, tmpdir, **kwargs):
     return xr.open_dataset(f"{tmpdir}/refs.parquet", engine="kerchunk", **kwargs)
 
 
+def roundtrip_as_in_memory_icechunk(vds: xr.Dataset, tmpdir, **kwargs):
+    from icechunk import Repository, Storage
+
+    # create an in-memory icechunk store
+    storage = Storage.new_in_memory()
+    repo = Repository.create(storage=storage)
+    session = repo.writable_session("main")
+
+    # write those references to an icechunk store
+    vds.virtualize.to_icechunk(session.store)
+
+    # read the dataset from icechunk
+    return xr.open_zarr(session.store, zarr_format=3, consolidated=False, **kwargs)
+
+
 @requires_zarr_python
 @pytest.mark.parametrize(
     "roundtrip_func",
@@ -124,6 +140,7 @@ def roundtrip_as_kerchunk_parquet(vds: xr.Dataset, tmpdir, **kwargs):
             else []
         ),
         *([roundtrip_as_kerchunk_parquet] if has_kerchunk and has_fastparquet else []),
+        *([roundtrip_as_in_memory_icechunk] if has_icechunk else []),
     ],
 )
 class TestRoundtrip:


### PR DESCRIPTION
The `HDFVirtualBackend` has some failures. Probably related to #414 

<details><summary> Click for verbose tracebacks

```python-traceback
virtualizarr/tests/test_integration.py::TestRoundtrip::test_roundtrip_no_concat[HDFVirtualBackend-roundtrip_as_in_memory_icechunk] FAILED                                                                                                 [ 25%]
virtualizarr/tests/test_integration.py::TestRoundtrip::test_kerchunk_roundtrip_concat[False-time_vars0-HDFVirtualBackend-roundtrip_as_in_memory_icechunk] FAILED                                                                          [ 50%]
virtualizarr/tests/test_integration.py::TestRoundtrip::test_kerchunk_roundtrip_concat[True-time_vars1-HDFVirtualBackend-roundtrip_as_in_memory_icechunk] FAILED                                                                           [ 75%]
virtualizarr/tests/test_integration.py::TestRoundtrip::test_datetime64_dtype_fill_value[roundtrip_as_in_memory_icechunk] FAILED                                                                                                           [100%]

```
</summary>

```python-traceback

=================================================================================================================== FAILURES ====================================================================================================================
___________________________________________________________________________ TestRoundtrip.test_roundtrip_no_concat[HDFVirtualBackend-roundtrip_as_in_memory_icechunk] ___________________________________________________________________________

self = <AsyncGroup <icechunk.store.IcechunkStore object at 0x705f43264ec0>>, name = 'air', shape = (2920, 25, 53), dtype = '<f8', exact = False
kwargs = {'chunks': (2920, 25, 53), 'compressors': (FixedScaleOffset(codec_name='numcodecs.fixedscaleoffset', codec_config={'sc...offset': 0, 'dtype': '<f8', 'astype': '<i2'}),), 'dimension_names': ('time', 'lat', 'lon'), 'fill_value': -327.67, ...}

    async def require_array(
        self,
        name: str,
        *,
        shape: ShapeLike,
        dtype: npt.DTypeLike = None,
        exact: bool = False,
        **kwargs: Any,
    ) -> AsyncArray[ArrayV2Metadata] | AsyncArray[ArrayV3Metadata]:
        """Obtain an array, creating if it doesn't exist.
    
        Other `kwargs` are as per :func:`zarr.AsyncGroup.create_dataset`.
    
        Parameters
        ----------
        name : str
            Array name.
        shape : int or tuple of ints
            Array shape.
        dtype : str or dtype, optional
            NumPy dtype.
        exact : bool, optional
            If True, require `dtype` to match exactly. If false, require
            `dtype` can be cast from array dtype.
    
        Returns
        -------
        a : AsyncArray
        """
        try:
>           ds = await self.getitem(name)

../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/group.py:1243: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <AsyncGroup <icechunk.store.IcechunkStore object at 0x705f43264ec0>>, key = 'air'

    async def getitem(
        self,
        key: str,
    ) -> AsyncArray[ArrayV2Metadata] | AsyncArray[ArrayV3Metadata] | AsyncGroup:
        """
        Get a subarray or subgroup from the group.
    
        Parameters
        ----------
        key : str
            Array or group name
    
        Returns
        -------
        AsyncArray or AsyncGroup
        """
        store_path = self.store_path / key
        logger.debug("key=%s, store_path=%s", key, store_path)
        metadata: ArrayV2Metadata | ArrayV3Metadata | GroupMetadata
    
        # Consolidated metadata lets us avoid some I/O operations so try that first.
        if self.metadata.consolidated_metadata is not None:
            return self._getitem_consolidated(store_path, key, prefix=self.name)
    
        # Note:
        # in zarr-python v2, we first check if `key` references an Array, else if `key` references
        # a group,using standalone `contains_array` and `contains_group` functions. These functions
        # are reusable, but for v3 they would perform redundant I/O operations.
        # Not clear how much of that strategy we want to keep here.
        elif self.metadata.zarr_format == 3:
            zarr_json_bytes = await (store_path / ZARR_JSON).get()
            if zarr_json_bytes is None:
>               raise KeyError(key)
E               KeyError: 'air'

../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/group.py:679: KeyError

During handling of the above exception, another exception occurred:

self = <virtualizarr.tests.test_integration.TestRoundtrip object at 0x705f440e2be0>, tmpdir = local('/tmp/pytest-of-jsignell/pytest-11/test_roundtrip_no_concat_HDFVi0')
roundtrip_func = <function roundtrip_as_in_memory_icechunk at 0x705f43f76520>, hdf_backend = <class 'virtualizarr.readers.hdf.hdf.HDFVirtualBackend'>

    @parametrize_over_hdf_backends
    def test_roundtrip_no_concat(self, tmpdir, roundtrip_func, hdf_backend):
        # set up example xarray dataset
        ds = xr.tutorial.open_dataset("air_temperature", decode_times=False)
    
        # save it to disk as netCDF (in temporary directory)
        ds.to_netcdf(f"{tmpdir}/air.nc")
    
        # use open_dataset_via_kerchunk to read it as references
        vds = open_virtual_dataset(f"{tmpdir}/air.nc", indexes={}, backend=hdf_backend)
    
>       roundtrip = roundtrip_func(vds, tmpdir, decode_times=False)

virtualizarr/tests/test_integration.py:158: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
virtualizarr/tests/test_integration.py:127: in roundtrip_as_in_memory_icechunk
    vds.virtualize.to_icechunk(session.store)
virtualizarr/accessor.py:99: in to_icechunk
    dataset_to_icechunk(
virtualizarr/writers/icechunk.py:112: in dataset_to_icechunk
    return write_variables_to_icechunk_group(
virtualizarr/writers/icechunk.py:156: in write_variables_to_icechunk_group
    write_virtual_variable_to_icechunk(
virtualizarr/writers/icechunk.py:246: in write_virtual_variable_to_icechunk
    arr = group.require_array(
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/group.py:2441: in require_array
    return Array(self._sync(self._async_group.require_array(name, shape=shape, **kwargs)))
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/sync.py:187: in _sync
    return sync(
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/sync.py:142: in sync
    raise return_result
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/sync.py:98: in _runner
    return await coro
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/group.py:1259: in require_array
    ds = await self.create_array(name, shape=shape, dtype=dtype, **kwargs)
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/group.py:1120: in create_array
    return await create_array(
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/array.py:4148: in create_array
    meta = await init_array(
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/array.py:3957: in init_array
    array_array, array_bytes, bytes_bytes = _parse_chunk_encoding_v3(
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/array.py:4332: in _parse_chunk_encoding_v3
    out_bytes_bytes = tuple(_parse_bytes_bytes_codec(c) for c in maybe_bytes_bytes)
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/array.py:4332: in <genexpr>
    out_bytes_bytes = tuple(_parse_bytes_bytes_codec(c) for c in maybe_bytes_bytes)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

data = FixedScaleOffset(codec_name='numcodecs.fixedscaleoffset', codec_config={'scale': 100.0, 'offset': 0, 'dtype': '<f8', 'astype': '<i2'})

    def _parse_bytes_bytes_codec(data: dict[str, JSON] | Codec) -> BytesBytesCodec:
        """
        Normalize the input to a ``BytesBytesCodec`` instance.
        If the input is already a ``BytesBytesCodec``, it is returned as is. If the input is a dict, it
        is converted to a ``BytesBytesCodec`` instance via the ``_resolve_codec`` function.
        """
        from zarr.abc.codec import BytesBytesCodec
    
        if isinstance(data, dict):
            result = _resolve_codec(data)
            if not isinstance(result, BytesBytesCodec):
                msg = f"Expected a dict representation of a BytesBytesCodec; got a dict representation of a {type(result)} instead."
                raise TypeError(msg)
        else:
            if not isinstance(data, BytesBytesCodec):
>               raise TypeError(f"Expected a BytesBytesCodec. Got {type(data)} instead.")
E               TypeError: Expected a BytesBytesCodec. Got <class 'numcodecs.zarr3.FixedScaleOffset'> instead.

../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/registry.py:184: TypeError
_______________________________________________________________ TestRoundtrip.test_kerchunk_roundtrip_concat[False-time_vars0-HDFVirtualBackend-roundtrip_as_in_memory_icechunk] ________________________________________________________________

self = <AsyncGroup <icechunk.store.IcechunkStore object at 0x705f43272ad0>>, name = 'air', shape = (2920, 25, 53), dtype = '<f8', exact = False
kwargs = {'chunks': (1460, 25, 53), 'compressors': (FixedScaleOffset(codec_name='numcodecs.fixedscaleoffset', codec_config={'sc...offset': 0, 'dtype': '<f8', 'astype': '<i2'}),), 'dimension_names': ('time', 'lat', 'lon'), 'fill_value': -327.67, ...}

    async def require_array(
        self,
        name: str,
        *,
        shape: ShapeLike,
        dtype: npt.DTypeLike = None,
        exact: bool = False,
        **kwargs: Any,
    ) -> AsyncArray[ArrayV2Metadata] | AsyncArray[ArrayV3Metadata]:
        """Obtain an array, creating if it doesn't exist.
    
        Other `kwargs` are as per :func:`zarr.AsyncGroup.create_dataset`.
    
        Parameters
        ----------
        name : str
            Array name.
        shape : int or tuple of ints
            Array shape.
        dtype : str or dtype, optional
            NumPy dtype.
        exact : bool, optional
            If True, require `dtype` to match exactly. If false, require
            `dtype` can be cast from array dtype.
    
        Returns
        -------
        a : AsyncArray
        """
        try:
>           ds = await self.getitem(name)

../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/group.py:1243: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <AsyncGroup <icechunk.store.IcechunkStore object at 0x705f43272ad0>>, key = 'air'

    async def getitem(
        self,
        key: str,
    ) -> AsyncArray[ArrayV2Metadata] | AsyncArray[ArrayV3Metadata] | AsyncGroup:
        """
        Get a subarray or subgroup from the group.
    
        Parameters
        ----------
        key : str
            Array or group name
    
        Returns
        -------
        AsyncArray or AsyncGroup
        """
        store_path = self.store_path / key
        logger.debug("key=%s, store_path=%s", key, store_path)
        metadata: ArrayV2Metadata | ArrayV3Metadata | GroupMetadata
    
        # Consolidated metadata lets us avoid some I/O operations so try that first.
        if self.metadata.consolidated_metadata is not None:
            return self._getitem_consolidated(store_path, key, prefix=self.name)
    
        # Note:
        # in zarr-python v2, we first check if `key` references an Array, else if `key` references
        # a group,using standalone `contains_array` and `contains_group` functions. These functions
        # are reusable, but for v3 they would perform redundant I/O operations.
        # Not clear how much of that strategy we want to keep here.
        elif self.metadata.zarr_format == 3:
            zarr_json_bytes = await (store_path / ZARR_JSON).get()
            if zarr_json_bytes is None:
>               raise KeyError(key)
E               KeyError: 'air'

../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/group.py:679: KeyError

During handling of the above exception, another exception occurred:

self = <virtualizarr.tests.test_integration.TestRoundtrip object at 0x705f43f82a50>, tmpdir = local('/tmp/pytest-of-jsignell/pytest-11/test_kerchunk_roundtrip_concat0')
roundtrip_func = <function roundtrip_as_in_memory_icechunk at 0x705f43f76520>, hdf_backend = <class 'virtualizarr.readers.hdf.hdf.HDFVirtualBackend'>, decode_times = False, time_vars = []

    @parametrize_over_hdf_backends
    @pytest.mark.parametrize("decode_times,time_vars", [(False, []), (True, ["time"])])
    def test_kerchunk_roundtrip_concat(
        self, tmpdir, roundtrip_func, hdf_backend, decode_times, time_vars
    ):
        # set up example xarray dataset
        ds = xr.tutorial.open_dataset("air_temperature", decode_times=decode_times)
    
        # split into two datasets
        ds1, ds2 = ds.isel(time=slice(None, 1460)), ds.isel(time=slice(1460, None))
    
        # save it to disk as netCDF (in temporary directory)
        ds1.to_netcdf(f"{tmpdir}/air1.nc")
        ds2.to_netcdf(f"{tmpdir}/air2.nc")
    
        # use open_dataset_via_kerchunk to read it as references
        vds1 = open_virtual_dataset(
            f"{tmpdir}/air1.nc",
            indexes={},
            loadable_variables=time_vars,
            backend=hdf_backend,
        )
        vds2 = open_virtual_dataset(
            f"{tmpdir}/air2.nc",
            indexes={},
            loadable_variables=time_vars,
            backend=hdf_backend,
        )
    
        if decode_times is False:
            assert vds1.time.dtype == np.dtype("float32")
        else:
            assert vds1.time.dtype == np.dtype("<M8[ns]")
            assert "units" in vds1.time.encoding
            assert "calendar" in vds1.time.encoding
    
        # concatenate virtually along time
        vds = xr.concat([vds1, vds2], dim="time", coords="minimal", compat="override")
    
>       roundtrip = roundtrip_func(vds, tmpdir, decode_times=decode_times)

virtualizarr/tests/test_integration.py:206: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
virtualizarr/tests/test_integration.py:127: in roundtrip_as_in_memory_icechunk
    vds.virtualize.to_icechunk(session.store)
virtualizarr/accessor.py:99: in to_icechunk
    dataset_to_icechunk(
virtualizarr/writers/icechunk.py:112: in dataset_to_icechunk
    return write_variables_to_icechunk_group(
virtualizarr/writers/icechunk.py:156: in write_variables_to_icechunk_group
    write_virtual_variable_to_icechunk(
virtualizarr/writers/icechunk.py:246: in write_virtual_variable_to_icechunk
    arr = group.require_array(
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/group.py:2441: in require_array
    return Array(self._sync(self._async_group.require_array(name, shape=shape, **kwargs)))
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/sync.py:187: in _sync
    return sync(
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/sync.py:142: in sync
    raise return_result
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/sync.py:98: in _runner
    return await coro
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/group.py:1259: in require_array
    ds = await self.create_array(name, shape=shape, dtype=dtype, **kwargs)
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/group.py:1120: in create_array
    return await create_array(
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/array.py:4148: in create_array
    meta = await init_array(
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/array.py:3957: in init_array
    array_array, array_bytes, bytes_bytes = _parse_chunk_encoding_v3(
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/array.py:4332: in _parse_chunk_encoding_v3
    out_bytes_bytes = tuple(_parse_bytes_bytes_codec(c) for c in maybe_bytes_bytes)
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/array.py:4332: in <genexpr>
    out_bytes_bytes = tuple(_parse_bytes_bytes_codec(c) for c in maybe_bytes_bytes)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

data = FixedScaleOffset(codec_name='numcodecs.fixedscaleoffset', codec_config={'scale': 100.0, 'offset': 0, 'dtype': '<f8', 'astype': '<i2'})

    def _parse_bytes_bytes_codec(data: dict[str, JSON] | Codec) -> BytesBytesCodec:
        """
        Normalize the input to a ``BytesBytesCodec`` instance.
        If the input is already a ``BytesBytesCodec``, it is returned as is. If the input is a dict, it
        is converted to a ``BytesBytesCodec`` instance via the ``_resolve_codec`` function.
        """
        from zarr.abc.codec import BytesBytesCodec
    
        if isinstance(data, dict):
            result = _resolve_codec(data)
            if not isinstance(result, BytesBytesCodec):
                msg = f"Expected a dict representation of a BytesBytesCodec; got a dict representation of a {type(result)} instead."
                raise TypeError(msg)
        else:
            if not isinstance(data, BytesBytesCodec):
>               raise TypeError(f"Expected a BytesBytesCodec. Got {type(data)} instead.")
E               TypeError: Expected a BytesBytesCodec. Got <class 'numcodecs.zarr3.FixedScaleOffset'> instead.

../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/registry.py:184: TypeError
________________________________________________________________ TestRoundtrip.test_kerchunk_roundtrip_concat[True-time_vars1-HDFVirtualBackend-roundtrip_as_in_memory_icechunk] ________________________________________________________________

self = <AsyncGroup <icechunk.store.IcechunkStore object at 0x705f432702d0>>, name = 'air', shape = (2920, 25, 53), dtype = '<f8', exact = False
kwargs = {'chunks': (1460, 25, 53), 'compressors': (FixedScaleOffset(codec_name='numcodecs.fixedscaleoffset', codec_config={'sc...offset': 0, 'dtype': '<f8', 'astype': '<i2'}),), 'dimension_names': ('time', 'lat', 'lon'), 'fill_value': -327.67, ...}

    async def require_array(
        self,
        name: str,
        *,
        shape: ShapeLike,
        dtype: npt.DTypeLike = None,
        exact: bool = False,
        **kwargs: Any,
    ) -> AsyncArray[ArrayV2Metadata] | AsyncArray[ArrayV3Metadata]:
        """Obtain an array, creating if it doesn't exist.
    
        Other `kwargs` are as per :func:`zarr.AsyncGroup.create_dataset`.
    
        Parameters
        ----------
        name : str
            Array name.
        shape : int or tuple of ints
            Array shape.
        dtype : str or dtype, optional
            NumPy dtype.
        exact : bool, optional
            If True, require `dtype` to match exactly. If false, require
            `dtype` can be cast from array dtype.
    
        Returns
        -------
        a : AsyncArray
        """
        try:
>           ds = await self.getitem(name)

../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/group.py:1243: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <AsyncGroup <icechunk.store.IcechunkStore object at 0x705f432702d0>>, key = 'air'

    async def getitem(
        self,
        key: str,
    ) -> AsyncArray[ArrayV2Metadata] | AsyncArray[ArrayV3Metadata] | AsyncGroup:
        """
        Get a subarray or subgroup from the group.
    
        Parameters
        ----------
        key : str
            Array or group name
    
        Returns
        -------
        AsyncArray or AsyncGroup
        """
        store_path = self.store_path / key
        logger.debug("key=%s, store_path=%s", key, store_path)
        metadata: ArrayV2Metadata | ArrayV3Metadata | GroupMetadata
    
        # Consolidated metadata lets us avoid some I/O operations so try that first.
        if self.metadata.consolidated_metadata is not None:
            return self._getitem_consolidated(store_path, key, prefix=self.name)
    
        # Note:
        # in zarr-python v2, we first check if `key` references an Array, else if `key` references
        # a group,using standalone `contains_array` and `contains_group` functions. These functions
        # are reusable, but for v3 they would perform redundant I/O operations.
        # Not clear how much of that strategy we want to keep here.
        elif self.metadata.zarr_format == 3:
            zarr_json_bytes = await (store_path / ZARR_JSON).get()
            if zarr_json_bytes is None:
>               raise KeyError(key)
E               KeyError: 'air'

../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/group.py:679: KeyError

During handling of the above exception, another exception occurred:

self = <virtualizarr.tests.test_integration.TestRoundtrip object at 0x705f43f9c470>, tmpdir = local('/tmp/pytest-of-jsignell/pytest-11/test_kerchunk_roundtrip_concat1')
roundtrip_func = <function roundtrip_as_in_memory_icechunk at 0x705f43f76520>, hdf_backend = <class 'virtualizarr.readers.hdf.hdf.HDFVirtualBackend'>, decode_times = True, time_vars = ['time']

    @parametrize_over_hdf_backends
    @pytest.mark.parametrize("decode_times,time_vars", [(False, []), (True, ["time"])])
    def test_kerchunk_roundtrip_concat(
        self, tmpdir, roundtrip_func, hdf_backend, decode_times, time_vars
    ):
        # set up example xarray dataset
        ds = xr.tutorial.open_dataset("air_temperature", decode_times=decode_times)
    
        # split into two datasets
        ds1, ds2 = ds.isel(time=slice(None, 1460)), ds.isel(time=slice(1460, None))
    
        # save it to disk as netCDF (in temporary directory)
        ds1.to_netcdf(f"{tmpdir}/air1.nc")
        ds2.to_netcdf(f"{tmpdir}/air2.nc")
    
        # use open_dataset_via_kerchunk to read it as references
        vds1 = open_virtual_dataset(
            f"{tmpdir}/air1.nc",
            indexes={},
            loadable_variables=time_vars,
            backend=hdf_backend,
        )
        vds2 = open_virtual_dataset(
            f"{tmpdir}/air2.nc",
            indexes={},
            loadable_variables=time_vars,
            backend=hdf_backend,
        )
    
        if decode_times is False:
            assert vds1.time.dtype == np.dtype("float32")
        else:
            assert vds1.time.dtype == np.dtype("<M8[ns]")
            assert "units" in vds1.time.encoding
            assert "calendar" in vds1.time.encoding
    
        # concatenate virtually along time
        vds = xr.concat([vds1, vds2], dim="time", coords="minimal", compat="override")
    
>       roundtrip = roundtrip_func(vds, tmpdir, decode_times=decode_times)

virtualizarr/tests/test_integration.py:206: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
virtualizarr/tests/test_integration.py:127: in roundtrip_as_in_memory_icechunk
    vds.virtualize.to_icechunk(session.store)
virtualizarr/accessor.py:99: in to_icechunk
    dataset_to_icechunk(
virtualizarr/writers/icechunk.py:112: in dataset_to_icechunk
    return write_variables_to_icechunk_group(
virtualizarr/writers/icechunk.py:156: in write_variables_to_icechunk_group
    write_virtual_variable_to_icechunk(
virtualizarr/writers/icechunk.py:246: in write_virtual_variable_to_icechunk
    arr = group.require_array(
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/group.py:2441: in require_array
    return Array(self._sync(self._async_group.require_array(name, shape=shape, **kwargs)))
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/sync.py:187: in _sync
    return sync(
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/sync.py:142: in sync
    raise return_result
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/sync.py:98: in _runner
    return await coro
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/group.py:1259: in require_array
    ds = await self.create_array(name, shape=shape, dtype=dtype, **kwargs)
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/group.py:1120: in create_array
    return await create_array(
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/array.py:4148: in create_array
    meta = await init_array(
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/array.py:3957: in init_array
    array_array, array_bytes, bytes_bytes = _parse_chunk_encoding_v3(
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/array.py:4332: in _parse_chunk_encoding_v3
    out_bytes_bytes = tuple(_parse_bytes_bytes_codec(c) for c in maybe_bytes_bytes)
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/array.py:4332: in <genexpr>
    out_bytes_bytes = tuple(_parse_bytes_bytes_codec(c) for c in maybe_bytes_bytes)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

data = FixedScaleOffset(codec_name='numcodecs.fixedscaleoffset', codec_config={'scale': 100.0, 'offset': 0, 'dtype': '<f8', 'astype': '<i2'})

    def _parse_bytes_bytes_codec(data: dict[str, JSON] | Codec) -> BytesBytesCodec:
        """
        Normalize the input to a ``BytesBytesCodec`` instance.
        If the input is already a ``BytesBytesCodec``, it is returned as is. If the input is a dict, it
        is converted to a ``BytesBytesCodec`` instance via the ``_resolve_codec`` function.
        """
        from zarr.abc.codec import BytesBytesCodec
    
        if isinstance(data, dict):
            result = _resolve_codec(data)
            if not isinstance(result, BytesBytesCodec):
                msg = f"Expected a dict representation of a BytesBytesCodec; got a dict representation of a {type(result)} instead."
                raise TypeError(msg)
        else:
            if not isinstance(data, BytesBytesCodec):
>               raise TypeError(f"Expected a BytesBytesCodec. Got {type(data)} instead.")
E               TypeError: Expected a BytesBytesCodec. Got <class 'numcodecs.zarr3.FixedScaleOffset'> instead.

../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/registry.py:184: TypeError
________________________________________________________________________________ TestRoundtrip.test_datetime64_dtype_fill_value[roundtrip_as_in_memory_icechunk] ________________________________________________________________________________

self = <AsyncGroup <icechunk.store.IcechunkStore object at 0x705f42f3e520>>, name = 'a', shape = (1, 1, 1), dtype = '<M8[ns]', exact = False
kwargs = {'chunks': (1, 1, 1), 'compressors': (Zlib(codec_name='numcodecs.zlib', codec_config={'level': 1}),), 'dimension_names': ('dim_0', 'dim_1', 'dim_2'), 'fill_value': 0, ...}

    async def require_array(
        self,
        name: str,
        *,
        shape: ShapeLike,
        dtype: npt.DTypeLike = None,
        exact: bool = False,
        **kwargs: Any,
    ) -> AsyncArray[ArrayV2Metadata] | AsyncArray[ArrayV3Metadata]:
        """Obtain an array, creating if it doesn't exist.
    
        Other `kwargs` are as per :func:`zarr.AsyncGroup.create_dataset`.
    
        Parameters
        ----------
        name : str
            Array name.
        shape : int or tuple of ints
            Array shape.
        dtype : str or dtype, optional
            NumPy dtype.
        exact : bool, optional
            If True, require `dtype` to match exactly. If false, require
            `dtype` can be cast from array dtype.
    
        Returns
        -------
        a : AsyncArray
        """
        try:
>           ds = await self.getitem(name)

../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/group.py:1243: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <AsyncGroup <icechunk.store.IcechunkStore object at 0x705f42f3e520>>, key = 'a'

    async def getitem(
        self,
        key: str,
    ) -> AsyncArray[ArrayV2Metadata] | AsyncArray[ArrayV3Metadata] | AsyncGroup:
        """
        Get a subarray or subgroup from the group.
    
        Parameters
        ----------
        key : str
            Array or group name
    
        Returns
        -------
        AsyncArray or AsyncGroup
        """
        store_path = self.store_path / key
        logger.debug("key=%s, store_path=%s", key, store_path)
        metadata: ArrayV2Metadata | ArrayV3Metadata | GroupMetadata
    
        # Consolidated metadata lets us avoid some I/O operations so try that first.
        if self.metadata.consolidated_metadata is not None:
            return self._getitem_consolidated(store_path, key, prefix=self.name)
    
        # Note:
        # in zarr-python v2, we first check if `key` references an Array, else if `key` references
        # a group,using standalone `contains_array` and `contains_group` functions. These functions
        # are reusable, but for v3 they would perform redundant I/O operations.
        # Not clear how much of that strategy we want to keep here.
        elif self.metadata.zarr_format == 3:
            zarr_json_bytes = await (store_path / ZARR_JSON).get()
            if zarr_json_bytes is None:
>               raise KeyError(key)
E               KeyError: 'a'

../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/group.py:679: KeyError

During handling of the above exception, another exception occurred:

self = <virtualizarr.tests.test_integration.TestRoundtrip object at 0x705f43fb01d0>, tmpdir = local('/tmp/pytest-of-jsignell/pytest-11/test_datetime64_dtype_fill_val0')
roundtrip_func = <function roundtrip_as_in_memory_icechunk at 0x705f43f76520>

    def test_datetime64_dtype_fill_value(self, tmpdir, roundtrip_func):
        chunks_dict = {
            "0.0.0": {"path": "/foo.nc", "offset": 100, "length": 100},
        }
        manifest = ChunkManifest(entries=chunks_dict)
        chunks = (1, 1, 1)
        shape = (1, 1, 1)
        zarray = ZArray(
            chunks=chunks,
            compressor={"id": "zlib", "level": 1},
            dtype=np.dtype("<M8[ns]"),
            # fill_value=0.0,
            filters=None,
            order="C",
            shape=shape,
            zarr_format=2,
        )
        marr1 = ManifestArray(zarray=zarray, chunkmanifest=manifest)
        vds = xr.Dataset(
            {
                "a": xr.DataArray(
                    marr1,
                    attrs={
                        "_FillValue": np.datetime64("1970-01-01T00:00:00.000000000")
                    },
                )
            }
        )
    
>       roundtrip = roundtrip_func(vds, tmpdir)

virtualizarr/tests/test_integration.py:279: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
virtualizarr/tests/test_integration.py:127: in roundtrip_as_in_memory_icechunk
    vds.virtualize.to_icechunk(session.store)
virtualizarr/accessor.py:99: in to_icechunk
    dataset_to_icechunk(
virtualizarr/writers/icechunk.py:112: in dataset_to_icechunk
    return write_variables_to_icechunk_group(
virtualizarr/writers/icechunk.py:156: in write_variables_to_icechunk_group
    write_virtual_variable_to_icechunk(
virtualizarr/writers/icechunk.py:246: in write_virtual_variable_to_icechunk
    arr = group.require_array(
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/group.py:2441: in require_array
    return Array(self._sync(self._async_group.require_array(name, shape=shape, **kwargs)))
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/sync.py:187: in _sync
    return sync(
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/sync.py:142: in sync
    raise return_result
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/sync.py:98: in _runner
    return await coro
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/group.py:1259: in require_array
    ds = await self.create_array(name, shape=shape, dtype=dtype, **kwargs)
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/group.py:1120: in create_array
    return await create_array(
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/array.py:4148: in create_array
    meta = await init_array(
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/array.py:3957: in init_array
    array_array, array_bytes, bytes_bytes = _parse_chunk_encoding_v3(
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/array.py:4300: in _parse_chunk_encoding_v3
    default_array_array, default_array_bytes, default_bytes_bytes = _get_default_chunk_encoding_v3(
../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/array.py:4206: in _get_default_chunk_encoding_v3
    dtype = DataType.from_numpy(np_dtype)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

cls = <enum 'DataType'>, dtype = dtype('<M8[ns]')

    @classmethod
    def from_numpy(cls, dtype: np.dtype[Any]) -> DataType:
        if dtype.kind in "UT":
            return DataType.string
        elif dtype.kind == "S":
            return DataType.bytes
        elif not _NUMPY_SUPPORTS_VLEN_STRING and dtype.kind == "O":
            # numpy < 2.0 does not support vlen string dtype
            # so we fall back on object array of strings
            return DataType.string
        dtype_to_data_type = {
            "|b1": "bool",
            "bool": "bool",
            "|i1": "int8",
            "<i2": "int16",
            "<i4": "int32",
            "<i8": "int64",
            "|u1": "uint8",
            "<u2": "uint16",
            "<u4": "uint32",
            "<u8": "uint64",
            "<f2": "float16",
            "<f4": "float32",
            "<f8": "float64",
            "<c8": "complex64",
            "<c16": "complex128",
        }
>       return DataType[dtype_to_data_type[dtype.str]]
E       KeyError: '<M8[ns]'

../micromamba/envs/virtualizarr-upstream/lib/python3.13/site-packages/zarr/core/metadata/v3.py:704: KeyError

```
</details>



- [x] Closes #376 
- [x] Tests added
- [ ] Tests passing - partial
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
