### PR TITLE
Update zarr 3 codec pipeline workflow

### DIFF
--- a/virtualizarr/writers/icechunk.py
+++ b/virtualizarr/writers/icechunk.py
@@ -16,7 +16,12 @@ from virtualizarr.manifests.utils import (
     check_same_ndims,
     check_same_shapes_except_on_concat_axis,
 )
-from virtualizarr.zarr import encode_dtype
+from virtualizarr.zarr import (
+    encode_dtype,
+    v3_codec_pipeline_to_compressors,
+    v3_codec_pipeline_to_filters,
+    v3_codec_pipeline_to_serializer,
+)
 
 if TYPE_CHECKING:
     from icechunk import IcechunkStore  # type: ignore[import-not-found]
@@ -242,14 +247,22 @@ def write_virtual_variable_to_icechunk(
         )
     else:
         append_axis = None
+
+        # Get the codecs and convert them to zarr v3 format
+        codecs = zarray._v3_codec_pipeline()
+        compressors = v3_codec_pipeline_to_compressors(codecs)
+        filters = v3_codec_pipeline_to_filters(codecs)
+        serializer = v3_codec_pipeline_to_serializer(codecs)
+
         # create array if it doesn't already exist
         arr = group.require_array(
             name=name,
             shape=zarray.shape,
             chunks=zarray.chunks,
             dtype=encode_dtype(zarray.dtype),
-            compressors=zarray._v3_codec_pipeline(),  # compressors,
-            serializer=zarray.serializer(),
+            compressors=compressors,
+            serializer=serializer,
+            filters=filters,
             dimension_names=var.dims,
             fill_value=zarray.fill_value,
         )


### PR DESCRIPTION
We need to handle codecs so that they match the zarr 3 `create_array` api

- [ ] Closes #421 
- [ ] Tests added
- [ ] Tests passing
- [x] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
