### PR TITLE
Install Icechunk from Conda in CI

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -15,6 +15,7 @@ dependencies:
   - universal_pathlib
   - hdf5plugin
   - numcodecs
+  - icechunk>=0.1.1
   # Testing
   - codecov[toml]
   - pre-commit
@@ -37,4 +38,3 @@ dependencies:
   - pip
   - pip:
     - imagecodecs-numcodecs==2024.6.1
-    - icechunk>=0.1.1


### PR DESCRIPTION
Icechunk seems to be on conda now, so let's install it from conda instead of pip in the CI

- [ ] ~~Closes #xxxx~~
- [ ] ~~Tests added~~
- [ ] Tests passing
- [ ] ~~Full type hint coverage~~
- [ ] Changes are documented in `docs/releases.rst`
- [ ] ~~New functions/methods are listed in `api.rst`~~
- [ ] ~~New functionality has documentation~~
