### PR TITLE
Mark hanging test as xfail

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11", "3.12"]
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/min-deps.yml
+++ b/.github/workflows/min-deps.yml
@@ -29,6 +29,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.12"]
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -29,6 +29,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.12"]
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 

--- a/virtualizarr/tests/test_readers/test_kerchunk.py
+++ b/virtualizarr/tests/test_readers/test_kerchunk.py
@@ -233,6 +233,9 @@ def test_open_virtual_dataset_existing_kerchunk_refs(
 
 
 @requires_kerchunk
+@pytest.mark.xfail(
+    reason="Test hangs after https://github.com/zarr-developers/VirtualiZarr/pull/420"
+)
 def test_notimplemented_read_inline_refs(tmp_path, netcdf4_inlined_ref):
     # For now, we raise a NotImplementedError if we read existing references that have inlined data
     # https://github.com/zarr-developers/VirtualiZarr/pull/251#pullrequestreview-2361916932


### PR DESCRIPTION
cc @TomNicholas and @sharkinsspatial 

The dependencies are all the same between the passing and hanging workflows, so I think this was actually cause by a change in https://github.com/zarr-developers/VirtualiZarr/pull/420. We should probably revert the PR if it might take a while to fix the issue. 

This is the only test that uses the `netcdf4_inlined_ref` fixture, so I think it's probably something going on there but I haven't looked at all.