### PR TITLE
Add missing pytest-asyncio plugin

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -22,6 +22,7 @@ dependencies:
   - mypy
   - ruff
   - pandas-stubs
+  - pytest-asyncio
   - pytest-mypy
   - pytest-cov
   - pytest


### PR DESCRIPTION
Prevent pytest skipping async tests and eliminate the following warnings issued during unit test execution:

- /root/micromamba/envs/virtualizarr-tests/lib/python3.11/site-packages/_pytest/config/__init__.py:1441: PytestConfigWarning: Unknown config option: asyncio_default_fixture_loop_scope
- .../VirtualiZarr/virtualizarr/tests/test_writers/test_icechunk.py:642: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
- /root/micromamba/envs/virtualizarr-tests/lib/python3.11/site-packages/_pytest/python.py:148: PytestUnhandledCoroutineWarning: async def functions are not natively supported and have been skipped.