### PR TITLE
List all installed libraries in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,8 @@ jobs:
 
       - name: List installed libraries
         run: |
-          pixi run -e ${{ matrix.environment }} pip list
+          pixi install --environment ${{ matrix.environment }}
+          pixi list --environment ${{ matrix.environment }}
 
       - name: Running Tests
         run: |

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -30,7 +30,8 @@ jobs:
           pixi-version: v0.41.4
       - name: List installed libraries
         run: |
-          pixi run -e test pip list
+          pixi install --environment test
+          pixi list --environment test
       - name: Type check
         run: |
           pixi run -e test run-mypy


### PR DESCRIPTION
I realized in debugging https://github.com/zarr-developers/VirtualiZarr/issues/492 that our current strategy for listing installed dependencies in the CI is not comprehensive. This updates the workflows to first install the environment with pixi and then use `pixi list` which gives us a complete list.

- [ ] Tests passing

