### PR TITLE
Chunk aligned indexing using zarr-python v3

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -12,10 +12,11 @@ import pytest
 import xarray as xr
 from xarray.core.variable import Variable
 
+import virtualizarr.manifests.utils as utils
+
 # Local imports
 from virtualizarr.manifests import ChunkManifest, ManifestArray
 from virtualizarr.manifests.manifest import join
-import virtualizarr.manifests.utils as utils
 
 
 # Pytest configuration

--- a/conftest.py
+++ b/conftest.py
@@ -15,8 +15,7 @@ from xarray.core.variable import Variable
 # Local imports
 from virtualizarr.manifests import ChunkManifest, ManifestArray
 from virtualizarr.manifests.manifest import join
-from virtualizarr.manifests.utils import create_v3_array_metadata
-from virtualizarr.utils import ceildiv
+import virtualizarr.manifests.utils as utils
 
 
 # Pytest configuration
@@ -76,7 +75,7 @@ def _generate_chunk_entries(
         Mapping of chunk keys to entry dictionaries
     """
     chunk_grid_shape = tuple(
-        ceildiv(axis_length, chunk_length)
+        utils.ceildiv(axis_length, chunk_length)
         for axis_length, chunk_length in zip(shape, chunks)
     )
 
@@ -261,7 +260,7 @@ def array_v3_metadata():
         fill_value: int | None = None,
     ):
         codecs = codecs or [{"configuration": {"endian": "little"}, "name": "bytes"}]
-        return create_v3_array_metadata(
+        return utils.create_v3_array_metadata(
             shape=shape,
             chunk_shape=chunks,
             data_type=data_type,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "ujson",
     "packaging",
     "zarr>=3.0.2",
+    "icechunk>=0.2.5",
 ]
 
 # Dependency sets under optional-dependencies are available via PyPI
@@ -95,7 +96,6 @@ upstream = [
     'fsspec @ git+https://github.com/fsspec/filesystem_spec',
     's3fs @ git+https://github.com/fsspec/s3fs',
     'kerchunk @ git+https://github.com/fsspec/kerchunk',
-    'icechunk @ git+https://github.com/earth-mover/icechunk#subdirectory=icechunk-python',
 ]
 docs = [
     "sphinx",

--- a/virtualizarr/manifests/array.py
+++ b/virtualizarr/manifests/array.py
@@ -3,17 +3,16 @@ from types import EllipsisType
 from typing import Any, Callable, Union
 
 import numpy as np
-from zarr.core.metadata.v3 import ArrayV3Metadata, RegularChunkGrid
 from zarr.core.indexing import BasicIndexer
+from zarr.core.metadata.v3 import ArrayV3Metadata, RegularChunkGrid
 
+import virtualizarr.manifests.indexing as indexing
+import virtualizarr.manifests.utils as utils
 from virtualizarr.manifests.array_api import (
     MANIFESTARRAY_HANDLED_ARRAY_FUNCTIONS,
     _isnan,
 )
 from virtualizarr.manifests.manifest import ChunkManifest
-import virtualizarr.manifests.utils as utils
-import virtualizarr.manifests.indexing as indexing
-
 
 
 class ManifestArray:
@@ -222,7 +221,7 @@ class ManifestArray:
     ) -> "ManifestArray":
         """
         Slice this ManifestArray by indexing in array element space (as opposed to in chunk grid space).
-        
+
         Only supports indexing where slices are aligned exactly with chunk boundaries.
 
         Effectively, this means that the following indexing modes are supported:
@@ -238,8 +237,8 @@ class ManifestArray:
         # TODO validate the selection, and identify if the selection can't be represented as a BasicIndexer
         # TODO will this expand trailing ellipses?
         indexer = BasicIndexer(
-            selection, 
-            self.shape, 
+            selection,
+            self.shape,
             self.metadata.chunk_grid,
         )
 
@@ -247,7 +246,7 @@ class ManifestArray:
         chunk_grid_indexer = indexing.array_indexer_to_chunk_grid_indexer(indexer)
 
         print(f"{chunk_grid_indexer=}")
-        
+
         # TODO translate new chunk_grid_indexer BasicIndexer into normal Selection that numpy can understand
 
         # do slicing of entries in manifest
@@ -264,9 +263,10 @@ class ManifestArray:
 
         # TODO deduce the new array shape from the new chunk grid shape
 
-
         # chunk sizes are unchanged by slicing that aligns with chunk boundaries
-        new_metadata = utils.copy_and_replace_metadata(self.metadata, new_shape=new_arr_shape)
+        new_metadata = utils.copy_and_replace_metadata(
+            self.metadata, new_shape=new_arr_shape
+        )
 
         return ManifestArray(chunkmanifest=sliced_manifest, metadata=new_metadata)
 

--- a/virtualizarr/manifests/array.py
+++ b/virtualizarr/manifests/array.py
@@ -10,6 +10,8 @@ from virtualizarr.manifests.array_api import (
     _isnan,
 )
 from virtualizarr.manifests.manifest import ChunkManifest
+import virtualizarr.manifests.utils as utils
+import virtualizarr.manifests.indexing as indexing
 
 
 class ManifestArray:
@@ -217,7 +219,9 @@ class ManifestArray:
         /,
     ) -> "ManifestArray":
         """
-        Only supports indexing where slices are aligned with chunk boundaries.
+        Slice this ManifestArray by indexing in array element space (as opposed to in chunk grid space).
+        
+        Only supports indexing where slices are aligned exactly with chunk boundaries.
 
         Follows the array API standard otherwise.
         """
@@ -231,60 +235,30 @@ class ManifestArray:
 
         # _validate_indexer(indexer)
 
-        indexer_nd = _possibly_expand_trailing_ellipses(indexer_nd, self.ndim)
+        indexer_nd = indexing.possibly_expand_trailing_ellipses(indexer_nd, self.ndim)
 
         if len(indexer_nd) != self.ndim:
             raise ValueError(
                 f"Invalid indexer for array with ndim={self.ndim}: {indexer_nd}"
             )
 
-        chunk_slices = []
-        new_arr_shape = []
-        for axis_num, (indexer_1d, arr_length, chunk_length) in enumerate(
-            zip(indexer_nd, self.shape, self.chunks)
-        ):
-            if isinstance(indexer_1d, int):
-                array_slice_1d = slice(indexer_1d, indexer_1d + 1, 1)
-            elif isinstance(indexer_1d, NoneType):
-                array_slice_1d = slice(0, arr_length, 1)
-            elif isinstance(indexer_1d, slice):
-                array_slice_1d = slice(
-                    indexer_1d.start if indexer_1d.start is not None else 0,
-                    indexer_1d.stop if indexer_1d.stop is not None else arr_length,
-                    indexer_1d.step if indexer_1d.step is not None else 1,
-                )
-            else:
-                # TODO we could attempt to also support indexing with numpy arrays
-                raise TypeError(
-                    f"Can only perform indexing with keys of type (int, slice, EllipsisType, NoneType), but got type {type(indexer_1d)} for axis {axis_num}"
-                )
-
-            chunk_slice_1d = _array_slice_to_chunk_slice(
-                array_slice_1d, arr_length, chunk_length
-            )
-            chunk_slices.append(chunk_slice_1d)
-
-            n_elements_in_slice = abs(
-                (array_slice_1d.start - array_slice_1d.stop) / array_slice_1d.step
-            )
-            new_arr_shape.append(n_elements_in_slice)
-
-        print(chunk_slices)
+        chunk_indexer, new_arr_shape = indexing.array_indexer_to_chunk_grid_indexer()
 
         # do slicing of entries in manifest
-        sliced_paths = self.manifest._paths[tuple(chunk_slices)]
-        sliced_offsets = self.manifest._offsets[tuple(chunk_slices)]
-        sliced_lengths = self.manifest._lengths[tuple(chunk_slices)]
+        # TODO add ChunkManifest.__getitem__ for this
+        sliced_paths = self.manifest._paths[chunk_indexer]
+        sliced_offsets = self.manifest._offsets[chunk_indexer]
+        sliced_lengths = self.manifest._lengths[chunk_indexer]
         sliced_manifest = ChunkManifest.from_arrays(
             paths=sliced_paths,
             offsets=sliced_offsets,
             lengths=sliced_lengths,
         )
 
-        # chunk sizes are unchanged by slicing that aligns with chunks
-        new_zarray = self.zarray.replace(shape=tuple(new_arr_shape))
+        # chunk sizes are unchanged by slicing that aligns with chunk boundaries
+        new_metadata = utils.copy_and_replace_metadata(self.metadata, new_shape=new_arr_shape)
 
-        return ManifestArray(chunkmanifest=sliced_manifest, zarray=new_zarray)
+        return ManifestArray(chunkmanifest=sliced_manifest, metadata=new_metadata)
 
     def rename_paths(
         self,
@@ -325,49 +299,3 @@ class ManifestArray:
         """
         renamed_manifest = self.manifest.rename_paths(new)
         return ManifestArray(metadata=self.metadata, chunkmanifest=renamed_manifest)
-
-
-def _array_slice_to_chunk_slice(
-    array_slice: slice,
-    arr_length: int,
-    chunk_length: int,
-) -> slice:
-    """
-    Translate a slice into an array into a corresponding slice into the underlying chunk grid.
-
-    Will raise on any array slices that require slicing within individual chunks.
-    """
-
-    if chunk_length == 1:
-        # alot of indexing is possible only in this case, because this is basically just a normal array along that axis
-        chunk_slice = array_slice
-        return chunk_slice
-
-    # Check that start of slice aligns with start of a chunk
-    if array_slice.start % chunk_length != 0:
-        raise NotImplementedError(
-            f"Cannot index ManifestArray axis of length {arr_length} and chunk length {chunk_length} with {array_slice} as slice would split individual chunks"
-        )
-
-    # Check that slice spans integer number of chunks
-    slice_length = array_slice.stop - array_slice.start
-    if slice_length % chunk_length != 0:
-        raise NotImplementedError(
-            f"Cannot index ManifestArray axis of length {arr_length} and chunk length {chunk_length} with {array_slice} as slice would split individual chunks"
-        )
-
-    index_of_first_chunk = int(array_slice.start / chunk_length)
-    n_chunks = int(slice_length / chunk_length)
-
-    chunk_slice = slice(index_of_first_chunk, index_of_first_chunk + n_chunks, 1)
-
-    return chunk_slice
-
-
-def _possibly_expand_trailing_ellipses(indexer, ndim: int):
-    if indexer[-1] == ...:
-        extra_slices_needed = ndim - (len(indexer) - 1)
-        *indexer_1d, ellipsis = indexer
-        return tuple(tuple(indexer_1d) + (slice(None),) * extra_slices_needed)
-    else:
-        return indexer

--- a/virtualizarr/manifests/array.py
+++ b/virtualizarr/manifests/array.py
@@ -1,4 +1,5 @@
 import warnings
+from types import EllipsisType, NoneType
 from typing import Any, Callable, Union
 
 import numpy as np
@@ -205,36 +206,85 @@ class ManifestArray:
 
     def __getitem__(
         self,
-        key,
+        key: Union[
+            int,
+            slice,
+            EllipsisType,
+            None,
+            tuple[Union[int, slice, EllipsisType, None], ...],
+            np.ndarray,
+        ],
         /,
     ) -> "ManifestArray":
         """
-        Only supports extremely limited indexing.
+        Only supports indexing where slices are aligned with chunk boundaries.
 
-        Only here because xarray will apparently attempt to index into its lazy indexing classes even if the operation would be a no-op anyway.
+        Follows the array API standard otherwise.
         """
-        from xarray.core.indexing import BasicIndexer
+        indexer = key
 
-        if isinstance(key, BasicIndexer):
-            indexer = key.tuple
+        indexer_nd: tuple[Union[int, slice, EllipsisType, None, np.ndarray], ...]
+        if isinstance(indexer, (int, slice, EllipsisType, NoneType, np.ndarray)):
+            indexer_nd = (indexer,)
         else:
-            indexer = key
+            indexer_nd = indexer
 
-        indexer = _possibly_expand_trailing_ellipsis(key, self.ndim)
+        # _validate_indexer(indexer)
 
-        if len(indexer) != self.ndim:
+        indexer_nd = _possibly_expand_trailing_ellipses(indexer_nd, self.ndim)
+
+        if len(indexer_nd) != self.ndim:
             raise ValueError(
-                f"Invalid indexer for array with ndim={self.ndim}: {indexer}"
+                f"Invalid indexer for array with ndim={self.ndim}: {indexer_nd}"
             )
 
-        if all(
-            isinstance(axis_indexer, slice) and axis_indexer == slice(None)
-            for axis_indexer in indexer
+        chunk_slices = []
+        new_arr_shape = []
+        for axis_num, (indexer_1d, arr_length, chunk_length) in enumerate(
+            zip(indexer_nd, self.shape, self.chunks)
         ):
-            # indexer is all slice(None)'s, so this is a no-op
-            return self
-        else:
-            raise NotImplementedError(f"Doesn't support slicing with {indexer}")
+            if isinstance(indexer_1d, int):
+                array_slice_1d = slice(indexer_1d, indexer_1d + 1, 1)
+            elif isinstance(indexer_1d, NoneType):
+                array_slice_1d = slice(0, arr_length, 1)
+            elif isinstance(indexer_1d, slice):
+                array_slice_1d = slice(
+                    indexer_1d.start if indexer_1d.start is not None else 0,
+                    indexer_1d.stop if indexer_1d.stop is not None else arr_length,
+                    indexer_1d.step if indexer_1d.step is not None else 1,
+                )
+            else:
+                # TODO we could attempt to also support indexing with numpy arrays
+                raise TypeError(
+                    f"Can only perform indexing with keys of type (int, slice, EllipsisType, NoneType), but got type {type(indexer_1d)} for axis {axis_num}"
+                )
+
+            chunk_slice_1d = _array_slice_to_chunk_slice(
+                array_slice_1d, arr_length, chunk_length
+            )
+            chunk_slices.append(chunk_slice_1d)
+
+            n_elements_in_slice = abs(
+                (array_slice_1d.start - array_slice_1d.stop) / array_slice_1d.step
+            )
+            new_arr_shape.append(n_elements_in_slice)
+
+        print(chunk_slices)
+
+        # do slicing of entries in manifest
+        sliced_paths = self.manifest._paths[tuple(chunk_slices)]
+        sliced_offsets = self.manifest._offsets[tuple(chunk_slices)]
+        sliced_lengths = self.manifest._lengths[tuple(chunk_slices)]
+        sliced_manifest = ChunkManifest.from_arrays(
+            paths=sliced_paths,
+            offsets=sliced_offsets,
+            lengths=sliced_lengths,
+        )
+
+        # chunk sizes are unchanged by slicing that aligns with chunks
+        new_zarray = self.zarray.replace(shape=tuple(new_arr_shape))
+
+        return ManifestArray(chunkmanifest=sliced_manifest, zarray=new_zarray)
 
     def rename_paths(
         self,
@@ -277,10 +327,47 @@ class ManifestArray:
         return ManifestArray(metadata=self.metadata, chunkmanifest=renamed_manifest)
 
 
-def _possibly_expand_trailing_ellipsis(key, ndim: int):
-    if key[-1] == ...:
-        extra_slices_needed = ndim - (len(key) - 1)
-        *indexer, ellipsis = key
-        return tuple(tuple(indexer) + (slice(None),) * extra_slices_needed)
+def _array_slice_to_chunk_slice(
+    array_slice: slice,
+    arr_length: int,
+    chunk_length: int,
+) -> slice:
+    """
+    Translate a slice into an array into a corresponding slice into the underlying chunk grid.
+
+    Will raise on any array slices that require slicing within individual chunks.
+    """
+
+    if chunk_length == 1:
+        # alot of indexing is possible only in this case, because this is basically just a normal array along that axis
+        chunk_slice = array_slice
+        return chunk_slice
+
+    # Check that start of slice aligns with start of a chunk
+    if array_slice.start % chunk_length != 0:
+        raise NotImplementedError(
+            f"Cannot index ManifestArray axis of length {arr_length} and chunk length {chunk_length} with {array_slice} as slice would split individual chunks"
+        )
+
+    # Check that slice spans integer number of chunks
+    slice_length = array_slice.stop - array_slice.start
+    if slice_length % chunk_length != 0:
+        raise NotImplementedError(
+            f"Cannot index ManifestArray axis of length {arr_length} and chunk length {chunk_length} with {array_slice} as slice would split individual chunks"
+        )
+
+    index_of_first_chunk = int(array_slice.start / chunk_length)
+    n_chunks = int(slice_length / chunk_length)
+
+    chunk_slice = slice(index_of_first_chunk, index_of_first_chunk + n_chunks, 1)
+
+    return chunk_slice
+
+
+def _possibly_expand_trailing_ellipses(indexer, ndim: int):
+    if indexer[-1] == ...:
+        extra_slices_needed = ndim - (len(indexer) - 1)
+        *indexer_1d, ellipsis = indexer
+        return tuple(tuple(indexer_1d) + (slice(None),) * extra_slices_needed)
     else:
-        return key
+        return indexer

--- a/virtualizarr/manifests/array.py
+++ b/virtualizarr/manifests/array.py
@@ -235,7 +235,7 @@ class ManifestArray:
         print(f"{selection=}")
 
         # TODO validate the selection, and identify if the selection can't be represented as a BasicIndexer
-        # TODO will this expand trailing ellipses?
+        # TODO will this expand trailing ellipses? (it should)
         indexer = BasicIndexer(
             selection,
             self.shape,

--- a/virtualizarr/manifests/array_api.py
+++ b/virtualizarr/manifests/array_api.py
@@ -2,8 +2,8 @@ from typing import TYPE_CHECKING, Any, Callable, cast
 
 import numpy as np
 
-from virtualizarr.manifests.manifest import ChunkManifest
 import virtualizarr.manifests.utils as utils
+from virtualizarr.manifests.manifest import ChunkManifest
 
 if TYPE_CHECKING:
     from .array import ManifestArray

--- a/virtualizarr/manifests/indexing.py
+++ b/virtualizarr/manifests/indexing.py
@@ -1,17 +1,79 @@
 from types import NoneType, EllipsisType
 from typing import Union
 
+from virtualizarr.utils import determine_chunk_grid_shape
 
-def array_slice_to_chunk_slice(
-    array_slice: slice,
-    arr_length: int,
-    chunk_length: int,
-) -> slice:
+from zarr.core.indexing import BasicIndexer, IntDimIndexer, SliceDimIndexer
+
+
+
+# TODO write a custom message for this
+class SubChunkIndexingError(IndexError):
+    ...
+
+
+def array_indexer_to_chunk_grid_indexer(
+    indexer: BasicIndexer,
+) -> BasicIndexer:
+    """
+    Translate an indexer into an array into a corresponding indexer into the underlying chunk grid.
+
+    As compressed chunks cannot be subdivided, this will raise on any array slices that require slicing within individual chunks.
+    """
+
+    print(f"{indexer=}")
+
+    [
+        print(chunk_coords, chunk_selection, out_selection, is_complete_chunk)
+        for chunk_coords, chunk_selection, out_selection, is_complete_chunk in indexer
+    ]
+
+    # TODO move this check outside? Because we can arbitrarily index into uncompressed arrays...
+    if not all(is_complete_chunk for _, _, _, is_complete_chunk in indexer):
+        raise SubChunkIndexingError()
+    
+    array_shape = indexer.shape
+    chunk_shape = indexer.chunk_grid.chunk_shape
+    chunk_grid_shape = determine_chunk_grid_shape(array_shape, chunk_shape)
+
+    chunk_grid_dim_indexers: list[IntDimIndexer | SliceDimIndexer] = []
+    for dim_indexer, dim_len, dim_chunk_len in zip(
+        indexer.dim_indexers,
+        indexer.shape,
+        chunk_grid_shape,
+        strict=True,
+    ):
+        chunk_grid_dim_indexer: IntDimIndexer | SliceDimIndexer
+        if isinstance(dim_indexer, IntDimIndexer):
+            if dim_len == 1:
+                chunk_grid_dim_indexer = dim_indexer
+            else:
+                raise SubChunkIndexingError
+        
+        elif isinstance(dim_indexer, SliceDimIndexer):
+            dim_indexer = array_slice_to_chunk_grid_slice(dim_indexer)
+
+        chunk_grid_dim_indexers.append(chunk_grid_dim_indexer)
+
+    obj = BasicIndexer.__new__()
+    obj.dim_indexers = chunk_grid_dim_indexers
+    obj.shape = tuple(s.nitems for s in chunk_grid_dim_indexers if not isinstance(s, IntDimIndexer))
+    obj.drop_axes = ()
+
+    return obj
+
+
+def array_slice_to_chunk_grid_slice(
+    array_slice: SliceDimIndexer,
+) -> SliceDimIndexer:
     """
     Translate a slice into an array into a corresponding slice into the underlying chunk grid.
 
-    Will raise on any array slices that require slicing within individual chunks.
+    Will raise on any array slices that would require slicing within individual chunks.
     """
+
+    arr_length = array_slice.dim_len
+    chunk_length = array_slice.dim_chunk_len
 
     if chunk_length == 1:
         # alot of indexing is possible only in this case, because this is basically just a normal array along that axis
@@ -20,14 +82,14 @@ def array_slice_to_chunk_slice(
 
     # Check that start of slice aligns with start of a chunk
     if array_slice.start % chunk_length != 0:
-        raise NotImplementedError(
+        raise IndexError(
             f"Cannot index ManifestArray axis of length {arr_length} and chunk length {chunk_length} with {array_slice} as slice would split individual chunks"
         )
 
     # Check that slice spans integer number of chunks
     slice_length = array_slice.stop - array_slice.start
     if slice_length % chunk_length != 0:
-        raise NotImplementedError(
+        raise IndexError(
             f"Cannot index ManifestArray axis of length {arr_length} and chunk length {chunk_length} with {array_slice} as slice would split individual chunks"
         )
 
@@ -36,54 +98,9 @@ def array_slice_to_chunk_slice(
 
     chunk_slice = slice(index_of_first_chunk, index_of_first_chunk + n_chunks, 1)
 
-    return chunk_slice
-
-
-def possibly_expand_trailing_ellipses(indexer, ndim: int) -> tuple[Union[int, slice, EllipsisType, None], ...]:
-    if indexer[-1] == ...:
-        extra_slices_needed = ndim - (len(indexer) - 1)
-        *indexer_1d, ellipsis = indexer
-        return tuple(tuple(indexer_1d) + (slice(None),) * extra_slices_needed)
-    else:
-        return indexer
-
-
-def array_indexer_to_chunk_grid_indexer(
-    indexer_nd,
-    shape: tuple[int, ...],
-    chunks: tuple[int, ...],
-) -> tuple[tuple[slice, ...], tuple[int, ...]]:
-    """Convert an indexer in array element space into the corresponding indexer in chunk grid space."""
-
-    chunk_slices = []
-    new_arr_shape = []
-    for axis_num, (indexer_1d, arr_length, chunk_length) in enumerate(
-        zip(indexer_nd, shape, chunks)
-    ):
-        if isinstance(indexer_1d, int):
-            array_slice_1d = slice(indexer_1d, indexer_1d + 1, 1)
-        elif isinstance(indexer_1d, NoneType):
-            array_slice_1d = slice(0, arr_length, 1)
-        elif isinstance(indexer_1d, slice):
-            array_slice_1d = slice(
-                indexer_1d.start if indexer_1d.start is not None else 0,
-                indexer_1d.stop if indexer_1d.stop is not None else arr_length,
-                indexer_1d.step if indexer_1d.step is not None else 1,
-            )
-        else:
-            # TODO we could attempt to also support indexing with numpy arrays
-            raise TypeError(
-                f"Can only perform indexing with keys of type (int, slice, EllipsisType, NoneType), but got type {type(indexer_1d)} for axis {axis_num}"
-            )
-
-        chunk_slice_1d = array_slice_to_chunk_slice(
-            array_slice_1d, arr_length, chunk_length
-        )
-        chunk_slices.append(chunk_slice_1d)
-
-        n_elements_in_slice = abs(
-            (array_slice_1d.start - array_slice_1d.stop) / array_slice_1d.step
-        )
-        new_arr_shape.append(n_elements_in_slice)
-
-        return tuple(chunk_slices), tuple(new_arr_shape)
+    return SliceDimIndexer(
+        dim_sel=chunk_slice, 
+        # TODO which dim does this refer to? That of the chunk grid?
+        dim_len=...,
+        dim_chunk_len=...,
+    )

--- a/virtualizarr/manifests/indexing.py
+++ b/virtualizarr/manifests/indexing.py
@@ -58,10 +58,14 @@ def array_indexer_to_chunk_grid_indexer(
     ):
         chunk_grid_dim_indexer: IntDimIndexer | SliceDimIndexer
         if isinstance(dim_indexer, IntDimIndexer):
-            chunk_grid_dim_indexer = array_int_indexer_to_chunk_grid_int_indexer(dim_indexer)
+            chunk_grid_dim_indexer = array_int_indexer_to_chunk_grid_int_indexer(
+                dim_indexer
+            )
 
         elif isinstance(dim_indexer, SliceDimIndexer):
-            chunk_grid_dim_indexer = array_slice_indexer_to_chunk_grid_slice_indexer(dim_indexer)
+            chunk_grid_dim_indexer = array_slice_indexer_to_chunk_grid_slice_indexer(
+                dim_indexer
+            )
 
         chunk_grid_dim_indexers.append(chunk_grid_dim_indexer)
 
@@ -95,7 +99,7 @@ def array_int_indexer_to_chunk_grid_int_indexer(
     else:
         # TODO what about case of array of integers that don't split up chunks?
         raise SubChunkIndexingError
-    
+
     return chunk_grid_dim_indexer
 
 

--- a/virtualizarr/manifests/indexing.py
+++ b/virtualizarr/manifests/indexing.py
@@ -1,24 +1,31 @@
-from types import NoneType, EllipsisType
-from typing import Union
-
-from virtualizarr.utils import determine_chunk_grid_shape
-
-from zarr.core.indexing import BasicIndexer, IntDimIndexer, SliceDimIndexer
-
+from zarr.core.indexing import (
+    BasicIndexer,
+    BasicSelection,
+    BasicSelector,
+    IntDimIndexer,
+    SliceDimIndexer,
+)
 
 
 # TODO write a custom message for this
-class SubChunkIndexingError(IndexError):
-    ...
+class SubChunkIndexingError(IndexError): ...
 
 
 def array_indexer_to_chunk_grid_indexer(
     indexer: BasicIndexer,
+    arr_shape: tuple[int, ...],
+    chunk_shape: tuple[int, ...],
 ) -> BasicIndexer:
     """
     Translate an indexer into an array into a corresponding indexer into the underlying chunk grid.
 
     As compressed chunks cannot be subdivided, this will raise on any array slices that require slicing within individual chunks.
+
+    Parameters
+    ----------
+    indexer
+    arr_shape : tuple[int, ...]
+        Shape of the ManifestArray we are trying to index into.
     """
 
     print(f"{indexer=}")
@@ -29,38 +36,49 @@ def array_indexer_to_chunk_grid_indexer(
     ]
 
     # TODO move this check outside? Because we can arbitrarily index into uncompressed arrays...
+    # TODO or is that unrelated? Uncompressed arrays allow us to choose arbitrary chunking at reference generation time
     if not all(is_complete_chunk for _, _, _, is_complete_chunk in indexer):
         raise SubChunkIndexingError()
-    
-    array_shape = indexer.shape
-    chunk_shape = indexer.chunk_grid.chunk_shape
-    chunk_grid_shape = determine_chunk_grid_shape(array_shape, chunk_shape)
 
+    # TODO does the array shape have to match the indexer shape? Should this have been checked already?
     chunk_grid_dim_indexers: list[IntDimIndexer | SliceDimIndexer] = []
-    for dim_indexer, dim_len, dim_chunk_len in zip(
+    for (
+        dim_indexer,
+        dim_len,
+        dim_chunk_len,
+    ) in zip(
         indexer.dim_indexers,
-        indexer.shape,
-        chunk_grid_shape,
+        arr_shape,
+        chunk_shape,
+        # chunk_grid_shape,  # TODO do we really not need this??
         strict=True,
     ):
         chunk_grid_dim_indexer: IntDimIndexer | SliceDimIndexer
         if isinstance(dim_indexer, IntDimIndexer):
-            if dim_len == 1:
+            print(f"{dim_len=}")
+            if dim_chunk_len == 1:
                 chunk_grid_dim_indexer = dim_indexer
             else:
                 raise SubChunkIndexingError
-        
+
         elif isinstance(dim_indexer, SliceDimIndexer):
             dim_indexer = array_slice_to_chunk_grid_slice(dim_indexer)
 
         chunk_grid_dim_indexers.append(chunk_grid_dim_indexer)
 
-    obj = BasicIndexer.__new__()
-    obj.dim_indexers = chunk_grid_dim_indexers
-    obj.shape = tuple(s.nitems for s in chunk_grid_dim_indexers if not isinstance(s, IntDimIndexer))
-    obj.drop_axes = ()
+    # TODO check this - I'm not sure if I've understood the "shape" of an indexer correctly
+    chunk_grid_dim_indexer_shape = tuple(
+        s.nitems for s in chunk_grid_dim_indexers if not isinstance(s, IntDimIndexer)
+    )
 
-    return obj
+    # The BasicIndexer constructor doesn't allow us to set the attributes we want to
+    # Also BasicIndexer is a frozen dataclass so we have to use .__setattr__()
+    chunk_grid_indexer = object.__new__(BasicIndexer)
+    object.__setattr__(chunk_grid_indexer, "dim_indexers", chunk_grid_dim_indexers)
+    object.__setattr__(chunk_grid_indexer, "shape", chunk_grid_dim_indexer_shape)
+    object.__setattr__(chunk_grid_indexer, "drop_axes", ())
+
+    return chunk_grid_indexer
 
 
 def array_slice_to_chunk_grid_slice(
@@ -99,8 +117,33 @@ def array_slice_to_chunk_grid_slice(
     chunk_slice = slice(index_of_first_chunk, index_of_first_chunk + n_chunks, 1)
 
     return SliceDimIndexer(
-        dim_sel=chunk_slice, 
+        dim_sel=chunk_slice,
         # TODO which dim does this refer to? That of the chunk grid?
         dim_len=...,
         dim_chunk_len=...,
     )
+
+
+def indexer_to_selection(indexer: BasicIndexer) -> BasicSelection:
+    """Translate an indexer into a selection that numpy can understand."""
+    selection = []
+    for dim_indexer in indexer.dim_indexers:
+        dim_selection: BasicSelector
+        if isinstance(dim_indexer, IntDimIndexer):
+            # avoid numpy returning a scalar value instead of np.ndarray
+            dim_selection = slice(
+                dim_indexer.dim_sel,
+                dim_indexer.dim_sel + 1,
+            )
+        elif isinstance(dim_indexer, SliceDimIndexer):
+            dim_selection = slice(
+                dim_indexer.start,
+                dim_indexer.stop,
+                dim_indexer.step,
+            )
+        else:
+            raise NotImplementedError
+
+        selection.append(dim_selection)
+
+    return tuple(selection)

--- a/virtualizarr/manifests/indexing.py
+++ b/virtualizarr/manifests/indexing.py
@@ -1,15 +1,10 @@
-from types import NoneType, EllipsisType
-from typing import Union
+from zarr.core.indexing import BasicIndexer, IntDimIndexer, SliceDimIndexer
 
 from virtualizarr.utils import determine_chunk_grid_shape
 
-from zarr.core.indexing import BasicIndexer, IntDimIndexer, SliceDimIndexer
-
-
 
 # TODO write a custom message for this
-class SubChunkIndexingError(IndexError):
-    ...
+class SubChunkIndexingError(IndexError): ...
 
 
 def array_indexer_to_chunk_grid_indexer(
@@ -31,7 +26,7 @@ def array_indexer_to_chunk_grid_indexer(
     # TODO move this check outside? Because we can arbitrarily index into uncompressed arrays...
     if not all(is_complete_chunk for _, _, _, is_complete_chunk in indexer):
         raise SubChunkIndexingError()
-    
+
     array_shape = indexer.shape
     chunk_shape = indexer.chunk_grid.chunk_shape
     chunk_grid_shape = determine_chunk_grid_shape(array_shape, chunk_shape)
@@ -49,7 +44,7 @@ def array_indexer_to_chunk_grid_indexer(
                 chunk_grid_dim_indexer = dim_indexer
             else:
                 raise SubChunkIndexingError
-        
+
         elif isinstance(dim_indexer, SliceDimIndexer):
             dim_indexer = array_slice_to_chunk_grid_slice(dim_indexer)
 
@@ -57,7 +52,9 @@ def array_indexer_to_chunk_grid_indexer(
 
     obj = BasicIndexer.__new__()
     obj.dim_indexers = chunk_grid_dim_indexers
-    obj.shape = tuple(s.nitems for s in chunk_grid_dim_indexers if not isinstance(s, IntDimIndexer))
+    obj.shape = tuple(
+        s.nitems for s in chunk_grid_dim_indexers if not isinstance(s, IntDimIndexer)
+    )
     obj.drop_axes = ()
 
     return obj
@@ -99,7 +96,7 @@ def array_slice_to_chunk_grid_slice(
     chunk_slice = slice(index_of_first_chunk, index_of_first_chunk + n_chunks, 1)
 
     return SliceDimIndexer(
-        dim_sel=chunk_slice, 
+        dim_sel=chunk_slice,
         # TODO which dim does this refer to? That of the chunk grid?
         dim_len=...,
         dim_chunk_len=...,

--- a/virtualizarr/manifests/indexing.py
+++ b/virtualizarr/manifests/indexing.py
@@ -1,0 +1,89 @@
+from types import NoneType, EllipsisType
+from typing import Union
+
+
+def array_slice_to_chunk_slice(
+    array_slice: slice,
+    arr_length: int,
+    chunk_length: int,
+) -> slice:
+    """
+    Translate a slice into an array into a corresponding slice into the underlying chunk grid.
+
+    Will raise on any array slices that require slicing within individual chunks.
+    """
+
+    if chunk_length == 1:
+        # alot of indexing is possible only in this case, because this is basically just a normal array along that axis
+        chunk_slice = array_slice
+        return chunk_slice
+
+    # Check that start of slice aligns with start of a chunk
+    if array_slice.start % chunk_length != 0:
+        raise NotImplementedError(
+            f"Cannot index ManifestArray axis of length {arr_length} and chunk length {chunk_length} with {array_slice} as slice would split individual chunks"
+        )
+
+    # Check that slice spans integer number of chunks
+    slice_length = array_slice.stop - array_slice.start
+    if slice_length % chunk_length != 0:
+        raise NotImplementedError(
+            f"Cannot index ManifestArray axis of length {arr_length} and chunk length {chunk_length} with {array_slice} as slice would split individual chunks"
+        )
+
+    index_of_first_chunk = int(array_slice.start / chunk_length)
+    n_chunks = int(slice_length / chunk_length)
+
+    chunk_slice = slice(index_of_first_chunk, index_of_first_chunk + n_chunks, 1)
+
+    return chunk_slice
+
+
+def possibly_expand_trailing_ellipses(indexer, ndim: int) -> tuple[Union[int, slice, EllipsisType, None], ...]:
+    if indexer[-1] == ...:
+        extra_slices_needed = ndim - (len(indexer) - 1)
+        *indexer_1d, ellipsis = indexer
+        return tuple(tuple(indexer_1d) + (slice(None),) * extra_slices_needed)
+    else:
+        return indexer
+
+
+def array_indexer_to_chunk_grid_indexer(
+    indexer_nd,
+    shape: tuple[int, ...],
+    chunks: tuple[int, ...],
+) -> tuple[tuple[slice, ...], tuple[int, ...]]:
+    """Convert an indexer in array element space into the corresponding indexer in chunk grid space."""
+
+    chunk_slices = []
+    new_arr_shape = []
+    for axis_num, (indexer_1d, arr_length, chunk_length) in enumerate(
+        zip(indexer_nd, shape, chunks)
+    ):
+        if isinstance(indexer_1d, int):
+            array_slice_1d = slice(indexer_1d, indexer_1d + 1, 1)
+        elif isinstance(indexer_1d, NoneType):
+            array_slice_1d = slice(0, arr_length, 1)
+        elif isinstance(indexer_1d, slice):
+            array_slice_1d = slice(
+                indexer_1d.start if indexer_1d.start is not None else 0,
+                indexer_1d.stop if indexer_1d.stop is not None else arr_length,
+                indexer_1d.step if indexer_1d.step is not None else 1,
+            )
+        else:
+            # TODO we could attempt to also support indexing with numpy arrays
+            raise TypeError(
+                f"Can only perform indexing with keys of type (int, slice, EllipsisType, NoneType), but got type {type(indexer_1d)} for axis {axis_num}"
+            )
+
+        chunk_slice_1d = array_slice_to_chunk_slice(
+            array_slice_1d, arr_length, chunk_length
+        )
+        chunk_slices.append(chunk_slice_1d)
+
+        n_elements_in_slice = abs(
+            (array_slice_1d.start - array_slice_1d.stop) / array_slice_1d.step
+        )
+        new_arr_shape.append(n_elements_in_slice)
+
+        return tuple(chunk_slices), tuple(new_arr_shape)

--- a/virtualizarr/manifests/utils.py
+++ b/virtualizarr/manifests/utils.py
@@ -187,3 +187,29 @@ def copy_and_replace_metadata(
     # ArrayV3Metadata.from_dict removes extra keys zarr_format and node_type
     new_metadata = ArrayV3Metadata.from_dict(metadata_copy)
     return new_metadata
+
+
+def ceildiv(a: int, b: int) -> int:
+    """
+    Ceiling division operator for integers.
+
+    See https://stackoverflow.com/questions/14822184/is-there-a-ceiling-equivalent-of-operator-in-python
+    """
+    return -(a // -b)
+
+
+def determine_chunk_grid_shape(
+    shape: tuple[int, ...], chunks: tuple[int, ...]
+) -> tuple[int, ...]:
+    """Calculate the shape of the chunk grid based on array shape and chunk size."""
+    return tuple(ceildiv(length, chunksize) for length, chunksize in zip(shape, chunks))
+
+
+def determine_array_shape(
+    chunk_grid_shape: tuple[int, ...],
+    chunk_shape: tuple[int, ...],
+) -> tuple[int, ...]:
+    return tuple(
+        dim_chunk_grid * dim_chunk_len
+        for dim_chunk_grid, dim_chunk_len in zip(chunk_grid_shape, chunk_shape)
+    )

--- a/virtualizarr/tests/test_manifests/test_array.py
+++ b/virtualizarr/tests/test_manifests/test_array.py
@@ -366,3 +366,26 @@ def test_refuse_combine(array_v3_metadata):
     for func in [np.concatenate, np.stack]:
         with pytest.raises(ValueError, match="inconsistent dtypes"):
             func([marr1, marr2], axis=0)
+
+
+class TestIndexing:
+    def test_slice_aligned_with_chunks(self):
+        marr = create_manifestarray(shape=(4,), chunks=(2,))
+        marr[0:2]
+        marr[2:4]
+        marr[0:4]
+
+        with pytest.raises(
+            NotImplementedError, match="slice would split individual chunks"
+        ):
+            marr[0]
+
+        with pytest.raises(
+            NotImplementedError, match="slice would split individual chunks"
+        ):
+            marr[0:1]
+
+        with pytest.raises(
+            NotImplementedError, match="slice would split individual chunks"
+        ):
+            marr[0:3]

--- a/virtualizarr/tests/test_manifests/test_array.py
+++ b/virtualizarr/tests/test_manifests/test_array.py
@@ -381,7 +381,7 @@ class TestIndexing:
 
         subarr = marr[0:6]
         subarr = marr[2:4]
-        
+
     def test_slice_misaligned_with_chunks(self, manifest_array):
         marr = manifest_array(shape=(4,), chunks=(2,))
 

--- a/virtualizarr/tests/test_manifests/test_array.py
+++ b/virtualizarr/tests/test_manifests/test_array.py
@@ -369,11 +369,20 @@ def test_refuse_combine(array_v3_metadata):
 
 
 class TestIndexing:
-    def test_slice_aligned_with_chunks(self):
-        marr = create_manifestarray(shape=(4,), chunks=(2,))
-        marr[0:2]
-        marr[2:4]
-        marr[0:4]
+    def test_slice_aligned_with_chunks(self, manifest_array):
+        marr = manifest_array(shape=(4,), chunks=(2,))
+
+        subarr = marr[0:4]
+        assert isinstance(subarr, ManifestArray)
+        assert subarr.metadata == marr.metadata
+        assert subarr.chunks == marr.chunks
+        assert subarr.shape == (4,)
+
+        subarr = marr[0:2]
+        subarr = marr[2:4]
+        
+    def test_slice_misaligned_with_chunks(self, manifest_array):
+        marr = manifest_array(shape=(4,), chunks=(2,))
 
         with pytest.raises(
             NotImplementedError, match="slice would split individual chunks"

--- a/virtualizarr/tests/test_manifests/test_array.py
+++ b/virtualizarr/tests/test_manifests/test_array.py
@@ -369,16 +369,17 @@ def test_refuse_combine(array_v3_metadata):
 
 
 class TestIndexing:
+    # TODO parametrize over a bunch of valid options here
     def test_slice_aligned_with_chunks(self, manifest_array):
-        marr = manifest_array(shape=(4,), chunks=(2,))
+        marr = manifest_array(shape=(8,), chunks=(2,))
 
-        subarr = marr[0:4]
-        assert isinstance(subarr, ManifestArray)
-        assert subarr.metadata == marr.metadata
-        assert subarr.chunks == marr.chunks
-        assert subarr.shape == (4,)
+        # subarr = marr[0:4]
+        # assert isinstance(subarr, ManifestArray)
+        # assert subarr.metadata == marr.metadata
+        # assert subarr.chunks == marr.chunks
+        # assert subarr.shape == (4,)
 
-        subarr = marr[0:2]
+        subarr = marr[0:6]
         subarr = marr[2:4]
         
     def test_slice_misaligned_with_chunks(self, manifest_array):

--- a/virtualizarr/tests/test_manifests/test_array.py
+++ b/virtualizarr/tests/test_manifests/test_array.py
@@ -374,10 +374,24 @@ class TestIndexing:
     @pytest.mark.parametrize(
         "in_shape, in_chunks, selection, out_shape, out_chunks",
         [
+            # single-dim integer selection
             ((2,), (1,), 0, (1,), (1,)),
             ((2,), (1,), 1, (1,), (1,)),
+            # multi-dim integer selection
+            ((2, 2), (1, 1), (0, 0), (1, 1), (1, 1)),
+            # drop axes
+            ((2, 2), (1, 2), (0,), (2,), (2,)),
+            ((2, 2), (1, 2), (1,), (2,), (2,)),
+            # single-dim slicing selection
+            ((2,), (1,), ..., (2,), (1,)),
+            # TODO: drop axes
+            ((2,), (1,), slice(0, 1), (1,), (1,)),
+            ((2,), (1,), slice(1, 2), (1,), (1,)),
+            ((2,), (1,), slice(0, 2), (2,), (1,)),
             ((8,), (2,), slice(0, 4), (4,), (2,)),
             ((2,), (2,), slice(2, 4), (2,), (2,)),
+            # TODO: multi-dim slicing selection
+            # TODO: mixed integer and slicing selection
         ],
     )
     def test_slice_aligned_with_chunks(

--- a/virtualizarr/translators/kerchunk.py
+++ b/virtualizarr/translators/kerchunk.py
@@ -1,18 +1,18 @@
 from typing import Any, Mapping, MutableMapping, cast
 
 import numpy as np
-from xarray.core.indexes import Index
 from xarray import Dataset, Variable
+from xarray.core.indexes import Index
 from zarr.core.common import JSON
 from zarr.core.metadata import ArrayV3Metadata
 from zarr.core.metadata.v2 import ArrayV2Metadata
 
+import virtualizarr.manifests.utils as utils
 from virtualizarr.codecs import (
     numcodec_config_to_configurable,
 )
 from virtualizarr.manifests import ChunkManifest, ManifestArray
 from virtualizarr.manifests.manifest import ChunkEntry, ChunkKey
-import virtualizarr.manifests.utils as utils
 from virtualizarr.readers.common import separate_coords
 from virtualizarr.types.kerchunk import (
     KerchunkArrRefs,

--- a/virtualizarr/translators/kerchunk.py
+++ b/virtualizarr/translators/kerchunk.py
@@ -1,9 +1,8 @@
 from typing import Any, Mapping, MutableMapping, cast
 
 import numpy as np
-from xarray import Dataset
 from xarray.core.indexes import Index
-from xarray.core.variable import Variable
+from xarray import Dataset, Variable
 from zarr.core.common import JSON
 from zarr.core.metadata import ArrayV3Metadata
 from zarr.core.metadata.v2 import ArrayV2Metadata
@@ -13,13 +12,12 @@ from virtualizarr.codecs import (
 )
 from virtualizarr.manifests import ChunkManifest, ManifestArray
 from virtualizarr.manifests.manifest import ChunkEntry, ChunkKey
-from virtualizarr.manifests.utils import create_v3_array_metadata
+import virtualizarr.manifests.utils as utils
 from virtualizarr.readers.common import separate_coords
 from virtualizarr.types.kerchunk import (
     KerchunkArrRefs,
     KerchunkStoreRefs,
 )
-from virtualizarr.utils import determine_chunk_grid_shape
 
 
 def to_kerchunk_json(v2_metadata: ArrayV2Metadata) -> str:
@@ -84,7 +82,7 @@ def from_kerchunk_refs(decoded_arr_refs_zarray) -> "ArrayV3Metadata":
     numcodec_configs = [
         numcodec_config_to_configurable(config) for config in codec_configs
     ]
-    return create_v3_array_metadata(
+    return utils.create_v3_array_metadata(
         chunk_shape=tuple(decoded_arr_refs_zarray["chunks"]),
         data_type=dtype,
         codecs=numcodec_configs,
@@ -236,7 +234,7 @@ def variable_from_kerchunk_refs(
         # empty variables don't have physical chunks, but zarray shows that the variable
         # is at least 1D
 
-        shape = determine_chunk_grid_shape(
+        shape = utils.determine_chunk_grid_shape(
             metadata.shape,
             metadata.chunks,
         )

--- a/virtualizarr/utils.py
+++ b/virtualizarr/utils.py
@@ -106,6 +106,7 @@ def soft_import(name: str, reason: str, strict: Optional[bool] = True):
         else:
             return None
 
+
 # TODO move this and determine_chunk_grid_shape to manifests.utils.py
 def ceildiv(a: int, b: int) -> int:
     """

--- a/virtualizarr/utils.py
+++ b/virtualizarr/utils.py
@@ -106,22 +106,6 @@ def soft_import(name: str, reason: str, strict: Optional[bool] = True):
         else:
             return None
 
-# TODO move this and determine_chunk_grid_shape to manifests.utils.py
-def ceildiv(a: int, b: int) -> int:
-    """
-    Ceiling division operator for integers.
-
-    See https://stackoverflow.com/questions/14822184/is-there-a-ceiling-equivalent-of-operator-in-python
-    """
-    return -(a // -b)
-
-
-def determine_chunk_grid_shape(
-    shape: tuple[int, ...], chunks: tuple[int, ...]
-) -> tuple[int, ...]:
-    """Calculate the shape of the chunk grid based on array shape and chunk size."""
-    return tuple(ceildiv(length, chunksize) for length, chunksize in zip(shape, chunks))
-
 
 def convert_v3_to_v2_metadata(
     v3_metadata: ArrayV3Metadata, fill_value: Any = None

--- a/virtualizarr/utils.py
+++ b/virtualizarr/utils.py
@@ -106,7 +106,7 @@ def soft_import(name: str, reason: str, strict: Optional[bool] = True):
         else:
             return None
 
-
+# TODO move this and determine_chunk_grid_shape to manifests.utils.py
 def ceildiv(a: int, b: int) -> int:
     """
     Ceiling division operator for integers.


### PR DESCRIPTION
Replacement for #183, but this PR takes advantage of indexing internals from zarr-python v3 

- [ ] Closes #51
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
