### PR TITLE
Fix metadata equality for nan fill value

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -258,7 +258,7 @@ def array_v3_metadata():
         chunks: tuple = (5, 5),
         data_type: np.dtype = np.dtype("int32"),
         codecs: list[dict] | None = None,
-        fill_value: int | None = None,
+        fill_value: int | float | None = None,
     ):
         codecs = codecs or [{"configuration": {"endian": "little"}, "name": "bytes"}]
         return create_v3_array_metadata(

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -18,6 +18,9 @@ Deprecations
 Bug fixes
 ~~~~~~~~~
 
+- Fixed bug causing ManifestArrays to compare as not equal when they were actually identical (:issue:`501`, :pull:`502`)
+  By `Tom Nicholas <https://github.com/TomNicholas>`_.
+
 Documentation
 ~~~~~~~~~~~~~
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 requires-python = ">=3.11"
 dynamic = ["version"]
 dependencies = [
-    "xarray>=2025.1.1",
+    #"xarray>=2025.3.0",
     "numpy>=2.0.0",
     "universal-pathlib",
     "numcodecs>=0.15.1",
@@ -85,7 +85,7 @@ all_writers = [
 # Dependency sets under dependencies-groups are NOT available via PyPI
 [dependency-groups]
 upstream = [
-    'xarray @ git+https://github.com/pydata/xarray',
+    #'xarray @ git+https://github.com/pydata/xarray',
     'universal_pathlib @ git+https://github.com/fsspec/universal_pathlib',
     'numcodecs @ git+https://github.com/zarr-developers/numcodecs',
     'ujson @ git+https://github.com/ultrajson/ultrajson',
@@ -95,7 +95,7 @@ upstream = [
     'fsspec @ git+https://github.com/fsspec/filesystem_spec',
     's3fs @ git+https://github.com/fsspec/s3fs',
     'kerchunk @ git+https://github.com/fsspec/kerchunk',
-    'icechunk @ git+https://github.com/earth-mover/icechunk#subdirectory=icechunk-python',
+    #'icechunk @ git+https://github.com/earth-mover/icechunk#subdirectory=icechunk-python',
 ]
 docs = [
     "sphinx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ upstream = [
     'fsspec @ git+https://github.com/fsspec/filesystem_spec',
     's3fs @ git+https://github.com/fsspec/s3fs',
     'kerchunk @ git+https://github.com/fsspec/kerchunk',
-    'icechunk @ git+https://github.com/earth-mover/icechunk#subdirectory=icechunk-python',
+    #'icechunk @ git+https://github.com/earth-mover/icechunk#subdirectory=icechunk-python',
 ]
 docs = [
     "sphinx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 requires-python = ">=3.11"
 dynamic = ["version"]
 dependencies = [
-    #"xarray>=2025.3.0",
+    "xarray>=2025.1.1",
     "numpy>=2.0.0",
     "universal-pathlib",
     "numcodecs>=0.15.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ all_writers = [
 # Dependency sets under dependencies-groups are NOT available via PyPI
 [dependency-groups]
 upstream = [
-    #'xarray @ git+https://github.com/pydata/xarray',
+    'xarray @ git+https://github.com/pydata/xarray',
     'universal_pathlib @ git+https://github.com/fsspec/universal_pathlib',
     'numcodecs @ git+https://github.com/zarr-developers/numcodecs',
     'ujson @ git+https://github.com/ultrajson/ultrajson',
@@ -95,7 +95,7 @@ upstream = [
     'fsspec @ git+https://github.com/fsspec/filesystem_spec',
     's3fs @ git+https://github.com/fsspec/s3fs',
     'kerchunk @ git+https://github.com/fsspec/kerchunk',
-    #'icechunk @ git+https://github.com/earth-mover/icechunk#subdirectory=icechunk-python',
+    'icechunk @ git+https://github.com/earth-mover/icechunk#subdirectory=icechunk-python',
 ]
 docs = [
     "sphinx",

--- a/virtualizarr/manifests/array.py
+++ b/virtualizarr/manifests/array.py
@@ -3,6 +3,7 @@ from typing import Any, Callable, Union
 
 import numpy as np
 from zarr.core.metadata.v3 import ArrayV3Metadata, RegularChunkGrid
+import virtualizarr.manifests.utils as utils
 
 from virtualizarr.manifests.array_api import (
     MANIFESTARRAY_HANDLED_ARRAY_FUNCTIONS,
@@ -166,7 +167,7 @@ class ManifestArray:
         if self.shape != other.shape:
             raise NotImplementedError("Unsure how to handle broadcasting like this")
 
-        if self.metadata != other.metadata:
+        if not utils.metadata_identical(self.metadata, other.metadata):
             return np.full(shape=self.shape, fill_value=False, dtype=np.dtype(bool))
         else:
             if self.manifest == other.manifest:

--- a/virtualizarr/manifests/array.py
+++ b/virtualizarr/manifests/array.py
@@ -3,8 +3,8 @@ from typing import Any, Callable, Union
 
 import numpy as np
 from zarr.core.metadata.v3 import ArrayV3Metadata, RegularChunkGrid
-import virtualizarr.manifests.utils as utils
 
+import virtualizarr.manifests.utils as utils
 from virtualizarr.manifests.array_api import (
     MANIFESTARRAY_HANDLED_ARRAY_FUNCTIONS,
     _isnan,

--- a/virtualizarr/manifests/utils.py
+++ b/virtualizarr/manifests/utils.py
@@ -122,7 +122,7 @@ def check_same_shapes(shapes: list[tuple[int, ...]]) -> None:
             )
 
 
-# TODO upstream this into zarr-python?
+# TODO remove this once https://github.com/zarr-developers/zarr-python/issues/2929 is solved upstream
 def metadata_identical(metadata1: ArrayV3Metadata, metadata2: ArrayV3Metadata) -> bool:
     """Checks the metadata of two zarr arrays are identical, including special treatment for NaN fill_values."""
     metadata_dict1 = metadata1.to_dict()

--- a/virtualizarr/manifests/utils.py
+++ b/virtualizarr/manifests/utils.py
@@ -122,6 +122,24 @@ def check_same_shapes(shapes: list[tuple[int, ...]]) -> None:
             )
 
 
+# TODO upstream this into zarr-python?
+def metadata_identical(metadata1: ArrayV3Metadata, metadata2: ArrayV3Metadata) -> bool:
+    """Checks the metadata of two zarr arrays are identical, including special treatment for NaN fill_values."""
+    metadata_dict1 = metadata1.to_dict()
+    metadata_dict2 = metadata2.to_dict()
+
+    # fill_value is a special case because numpy NaNs cannot be compared using __eq__, see https://stackoverflow.com/a/10059796
+    fill_value1 = metadata_dict1.pop("fill_value")
+    fill_value2 = metadata_dict2.pop("fill_value")
+    if np.isnan(fill_value1) and np.isnan(fill_value2):
+        fill_values_equal = fill_value1.dtype == fill_value2.dtype
+    else:
+        fill_values_equal = fill_value1 == fill_value2
+
+    # everything else in ArrayV3Metadata is a string, Enum, or Dataclass
+    return fill_values_equal and metadata_dict1 == metadata_dict2
+
+
 def _remove_element_at_position(t: tuple[int, ...], pos: int) -> tuple[int, ...]:
     new_l = list(t)
     new_l.pop(pos)

--- a/virtualizarr/manifests/utils.py
+++ b/virtualizarr/manifests/utils.py
@@ -131,8 +131,8 @@ def metadata_identical(metadata1: ArrayV3Metadata, metadata2: ArrayV3Metadata) -
     # fill_value is a special case because numpy NaNs cannot be compared using __eq__, see https://stackoverflow.com/a/10059796
     fill_value1 = metadata_dict1.pop("fill_value")
     fill_value2 = metadata_dict2.pop("fill_value")
-    if np.isnan(fill_value1) and np.isnan(fill_value2):
-        fill_values_equal = fill_value1.dtype == fill_value2.dtype
+    if np.isnan(fill_value1) and np.isnan(fill_value2):  # type: ignore[arg-type]
+        fill_values_equal = fill_value1.dtype == fill_value2.dtype  # type: ignore[union-attr]
     else:
         fill_values_equal = fill_value1 == fill_value2
 

--- a/virtualizarr/tests/test_manifests/test_array.py
+++ b/virtualizarr/tests/test_manifests/test_array.py
@@ -101,8 +101,12 @@ class TestEquals:
             "0.0.0": {"path": "s3://bucket/foo.nc", "offset": 100, "length": 100},
         }
         manifest = ChunkManifest(entries=chunks_dict)
-        metadata1 = array_v3_metadata(shape=(2,), chunks=(2,), data_type=np.float32, fill_value=np.float32('nan'))
-        metadata2 = array_v3_metadata(shape=(2,), chunks=(2,), data_type=np.float32, fill_value=np.float32('nan'))
+        metadata1 = array_v3_metadata(
+            shape=(2,), chunks=(2,), data_type=np.float32, fill_value=np.float32("nan")
+        )
+        metadata2 = array_v3_metadata(
+            shape=(2,), chunks=(2,), data_type=np.float32, fill_value=np.float32("nan")
+        )
         marr1 = ManifestArray(metadata=metadata1, chunkmanifest=manifest)
         marr2 = ManifestArray(metadata=metadata2, chunkmanifest=manifest)
 

--- a/virtualizarr/tests/test_manifests/test_array.py
+++ b/virtualizarr/tests/test_manifests/test_array.py
@@ -95,6 +95,20 @@ class TestEquals:
     @pytest.mark.skip(reason="Not Implemented")
     def test_partly_equals(self): ...
 
+    def test_equals_nan_fill_value(self, array_v3_metadata):
+        # regression test for https://github.com/zarr-developers/VirtualiZarr/issues/501
+        chunks_dict = {
+            "0.0.0": {"path": "s3://bucket/foo.nc", "offset": 100, "length": 100},
+        }
+        manifest = ChunkManifest(entries=chunks_dict)
+        metadata1 = array_v3_metadata(shape=(2,), chunks=(2,), data_type=np.float32, fill_value=np.float32('nan'))
+        metadata2 = array_v3_metadata(shape=(2,), chunks=(2,), data_type=np.float32, fill_value=np.float32('nan'))
+        marr1 = ManifestArray(metadata=metadata1, chunkmanifest=manifest)
+        marr2 = ManifestArray(metadata=metadata2, chunkmanifest=manifest)
+
+        result = marr1 == marr2
+        assert result.all()
+
 
 class TestBroadcast:
     def test_broadcast_existing_axis(self, manifest_array):


### PR DESCRIPTION
This is a stopgap until https://github.com/zarr-developers/zarr-python/issues/2929 is fixed upstream. We will want the regression test regardless though.

- [x] Closes #501
- [x] Tests added
- [x] Tests passing
- [x] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] ~~New functions/methods are listed in `api.rst`~~
- [ ] ~~New functionality has documentation~~
