### PR TITLE
Setup intersphinx mapping for docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.extlinks",
+    "sphinx.ext.intersphinx",
     "sphinx_copybutton",
     "sphinx_togglebutton",
     "sphinx_design",
@@ -29,6 +30,17 @@ extlinks = {
     "issue": ("https://github.com/zarr-developers/virtualizarr/issues/%s", "GH%s"),
     "pull": ("https://github.com/zarr-developers/virtualizarr/pull/%s", "PR%s"),
     "discussion": ("https://github.com/zarr-developers/virtualizarr/discussions/%s", "D%s"),
+}
+
+# Example configuration for intersphinx: refer to the Python standard library.
+# use in refs e.g:
+# :ref:`comparison manual <python:comparisons>`
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3/", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
+    "zarr": ("https://zarr.readthedocs.io/en/stable/", None),
+    "xarray": ("https://docs.xarray.dev/en/stable/", None),
+    "obstore": ("https://developmentseed.org/obstore/latest/", None),
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,7 +40,6 @@ intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable/", None),
     "zarr": ("https://zarr.readthedocs.io/en/stable/", None),
     "xarray": ("https://docs.xarray.dev/en/stable/", None),
-    "obstore": ("https://developmentseed.org/obstore/latest/", None),
 }
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
@kylebarron made a great suggestion in https://github.com/zarr-developers/VirtualiZarr/pull/490#discussion_r2010683170 to use intersphinx references. This basically makes all the types in the function signatures clickable to get to the relevant documentation in NumPy, Zarr, Python, and Xarray, which is pretty great.