### PR TITLE
Use pytest-xdist to distribute tests across CPUs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,7 +166,7 @@ run-tests = { cmd = "pytest -n auto --run-network-tests --verbose" }
 run-tests-no-network = { cmd = "pytest -n auto" }
 run-tests-cov = { cmd = "pytest -n auto --run-network-tests --verbose --cov=virtualizarr --cov=term-missing" }
 run-tests-xml-cov = { cmd = "pytest -n auto --run-network-tests --verbose --cov=virtualizarr --cov-report=xml" }
-run-tests-html-cov = { cmd = "pytest -n auto--run-network-tests --verbose --cov=virtualizarr --cov-report=html" }
+run-tests-html-cov = { cmd = "pytest -n auto --run-network-tests --verbose --cov=virtualizarr --cov-report=html" }
 
 # Define which features and groups to include in different pixi (similar to conda) environments)
 [tool.pixi.environments]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,10 +113,11 @@ dev = [
     "pandas-stubs",
     "pooch",
     "pre-commit",
-    "pytest-cov",
-    "pytest-mypy",
     "pytest",
     "pytest-asyncio",
+    "pytest-cov",
+    "pytest-mypy",
+    "pytest-xdist",
     "ruff",
     "s3fs",
 ]
@@ -161,11 +162,11 @@ rust = "*"
 # Define commands to run within the test environments
 [tool.pixi.feature.dev.tasks]
 run-mypy = { cmd = "mypy virtualizarr" }
-run-tests = { cmd = "pytest --run-network-tests --verbose" }
-run-tests-no-network = { cmd = "pytest" }
-run-tests-cov = { cmd = "pytest --run-network-tests --verbose --cov=virtualizarr --cov=term-missing" }
-run-tests-xml-cov = { cmd = "pytest --run-network-tests --verbose --cov=virtualizarr --cov-report=xml" }
-run-tests-html-cov = { cmd = "pytest --run-network-tests --verbose --cov=virtualizarr --cov-report=html" }
+run-tests = { cmd = "pytest -n auto --run-network-tests --verbose" }
+run-tests-no-network = { cmd = "pytest -n auto" }
+run-tests-cov = { cmd = "pytest -n auto --run-network-tests --verbose --cov=virtualizarr --cov=term-missing" }
+run-tests-xml-cov = { cmd = "pytest -n auto --run-network-tests --verbose --cov=virtualizarr --cov-report=xml" }
+run-tests-html-cov = { cmd = "pytest -n auto--run-network-tests --verbose --cov=virtualizarr --cov-report=html" }
 
 # Define which features and groups to include in different pixi (similar to conda) environments)
 [tool.pixi.environments]


### PR DESCRIPTION
This reduces the testing time for me from 44s to 31s. It doesn't impact the number of passing tests, but increases the number of warnings from 423 to 444. I think we can resolve those warnings separately.

Thanks goes to Anthony Lukach for pointing out this great pytest plugin..

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
