### PR TITLE
Simplify hdf5 typing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,9 +171,9 @@ rust = "*"
 run-mypy = { cmd = "mypy virtualizarr" }
 run-tests = { cmd = "pytest -n auto --run-network-tests --verbose" }
 run-tests-no-network = { cmd = "pytest -n auto" }
-run-tests-cov = { cmd = "pytest -n auto --run-network-tests --verbose --cov=virtualizarr --cov=term-missing" }
-run-tests-xml-cov = { cmd = "pytest -n auto --run-network-tests --verbose --cov=virtualizarr --cov-report=xml" }
-run-tests-html-cov = { cmd = "pytest -n auto --run-network-tests --verbose --cov=virtualizarr --cov-report=html" }
+run-tests-cov = { cmd = "pytest -n auto --run-network-tests --verbose --cov=term-missing" }
+run-tests-xml-cov = { cmd = "pytest -n auto --run-network-tests --verbose--cov-report=xml" }
+run-tests-html-cov = { cmd = "pytest -n auto --run-network-tests --verbose --cov-report=html" }
 
 # Define which features and groups to include in different pixi (similar to conda) environments)
 [tool.pixi.environments]
@@ -196,7 +196,7 @@ readthedocs = "rm -rf $READTHEDOCS_OUTPUT/html && cp -r docs/_build/html $READTH
 # Define commands to run within the docs environment
 [tool.pixi.feature.minio.tasks]
 run-tests = { cmd = "pytest virtualizarr/tests/test_manifests/test_store.py --run-minio-tests --verbose" }
-run-tests-xml-cov = { cmd = "pytest virtualizarr/tests/test_manifests/test_store.py --run-minio-tests --verbose --cov=virtualizarr --cov-report=xml" }
+run-tests-xml-cov = { cmd = "pytest virtualizarr/tests/test_manifests/test_store.py --run-minio-tests --verbose --cov-report=xml" }
 
 [tool.setuptools_scm]
 fallback_version = "9999"
@@ -270,6 +270,11 @@ known-first-party = ["virtualizarr"]
 [tool.coverage.run]
 include = ["virtualizarr/"]
 omit = ["conftest.py", "virtualizarr/tests/*"]
+
+[tool.coverage.report]
+exclude_lines = [
+    "if TYPE_CHECKING:",
+]
 
 [tool.pytest.ini_options]
 # See https://pytest-asyncio.readthedocs.io/en/latest/concepts.html#asyncio-event-loops

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,7 +172,7 @@ run-mypy = { cmd = "mypy virtualizarr" }
 run-tests = { cmd = "pytest -n auto --run-network-tests --verbose" }
 run-tests-no-network = { cmd = "pytest -n auto" }
 run-tests-cov = { cmd = "pytest -n auto --run-network-tests --verbose --cov=term-missing" }
-run-tests-xml-cov = { cmd = "pytest -n auto --run-network-tests --verbose--cov-report=xml" }
+run-tests-xml-cov = { cmd = "pytest -n auto --run-network-tests --verbose --cov-report=xml" }
 run-tests-html-cov = { cmd = "pytest -n auto --run-network-tests --verbose --cov-report=html" }
 
 # Define which features and groups to include in different pixi (similar to conda) environments)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,32 +212,19 @@ files = "virtualizarr/**/*.py"
 show_error_codes = true
 
 [[tool.mypy.overrides]]
-module = "fsspec.*"
+module = [
+    "docker",
+    "fsspec.*",
+    "h5py",
+    "kerchunk.*",
+    "minio",
+    "numcodecs.*",
+    "ujson",
+    "zarr",
+]
 ignore_missing_imports = true
 
-[[tool.mypy.overrides]]
-module = "numcodecs.*"
-ignore_missing_imports = true
 
-[[tool.mypy.overrides]]
-module = "kerchunk.*"
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = "ujson.*"
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = "zarr.*"
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = "docker.*"
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = "minio.*"
-ignore_missing_imports = true
 
 [tool.ruff]
 # Same as Black.

--- a/virtualizarr/readers/hdf/hdf.py
+++ b/virtualizarr/readers/hdf/hdf.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 import math
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
-    Any,
     Dict,
     Hashable,
     Iterable,
@@ -38,11 +39,8 @@ h5py = soft_import("h5py", "For reading hdf files", strict=False)
 
 
 if TYPE_CHECKING:
-    from h5py import Dataset as H5Dataset  # type: ignore[import-untyped]
-    from h5py import Group as H5Group  # type: ignore[import-untyped]
-else:
-    H5Dataset: Any = None
-    H5Group: Any = None
+    from h5py import Dataset as H5Dataset
+    from h5py import Group as H5Group
 
 FillValueType = Union[
     int,


### PR DESCRIPTION
`from __future__ import annotations` allows type checking optional dependencies. Also simplified the pyproject.toml a bit.

