### PR TITLE
Run upstream tests nightly, commits to main/dev, and on labeled PRs

### DIFF
--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -20,7 +20,10 @@ concurrency:
 jobs:
   test-upstream:
     name: ${{ matrix.environment }}-build
-    if: ${{ github.event.label.name == 'test-upstream' }}
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'schedule' ||
+      (github.event_name == 'pull_request' && github.event.label.name == 'test-upstream')
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Upstream
 
 on:
   push:

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -7,6 +7,7 @@ on:
     - 'docs/**'
   pull_request:
     branches: [ "main" , "develop"]
+    types: [ labeled ]
     paths-ignore:
     - 'docs/**'
   schedule:
@@ -17,15 +18,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  test-upstream:
     name: ${{ matrix.environment }}-build
+    if: ${{ github.event.label.name == 'test-upstream' }}
     runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash -l {0}
     strategy:
       matrix:
-        environment: [test-py311, test-py312, min-deps, minio]
+        environment: [upstream]
     steps:
       - uses: actions/checkout@v4
       - uses: prefix-dev/setup-pixi@v0.8.3


### PR DESCRIPTION
The upstream build takes a while and IMO doesn't need to be run on every commit to PRs. This separates out the upstream tests so that they only get run on a commit to main/develop, on the nightly chron job, and when a PR is labeled with 'test-upstream'.