### PR TITLE
Properly extract chunk keys for arrays with a single chunk

### DIFF
--- a/virtualizarr/manifests/store.py
+++ b/virtualizarr/manifests/store.py
@@ -108,17 +108,12 @@ def get_zarr_metadata(manifest_group: ManifestGroup, key: str) -> Buffer:
         return dict_to_buffer(metadata, prototype=default_buffer_prototype())
 
 
-def parse_manifest_index(
-    key: str, chunk_key_encoding: str = "."
-) -> tuple[str, tuple[int, ...]]:
+def parse_manifest_index(key: str, chunk_key_encoding: str = ".") -> tuple[int, ...]:
     """
     Splits `key` provided to a zarr store into the variable indicated
     by the first part and the chunk index from the 3rd through last parts,
     which can be used to index into the ndarrays containing paths, offsets,
     and lengths in ManifestArrays.
-
-    Currently only works for 1d+ arrays with a tree depth of one from the
-    root Zarr group.
 
     Parameters
     ----------
@@ -127,17 +122,15 @@ def parse_manifest_index(
 
     Returns
     -------
-    ManifestIndex
+    tuple containing chunk indexes
     """
-    parts = key.split("/")
-    var = parts[0]
-    # Assume "c" is the second part
-    # TODO: Handle scalar array case with "c" holds the data
-    if chunk_key_encoding == "/":
-        indexes = tuple(int(ind) for ind in parts[2:])
-    else:
-        indexes = tuple(int(ind) for ind in parts[2].split(chunk_key_encoding))
-    return var, indexes
+    if key.endswith("c"):
+        # Scalar arrays hold the data in the "c" key
+        return (0,)
+    parts = key.split(
+        "c/"
+    )  # TODO: Open an issue upstream about the Zarr spec indicating this should be f"c{chunk_key_encoding}" rather than always "c/"
+    return tuple(int(ind) for ind in parts[1].split(chunk_key_encoding))
 
 
 def find_matching_store(stores: StoreDict, request_key: str) -> StoreRequest:
@@ -263,13 +256,16 @@ class ManifestStore(Store):
 
         if key.endswith("zarr.json"):
             return get_zarr_metadata(self._group, key)
-        var, chunk_key = parse_manifest_index(key)
+        var = key.split("/")[0]
         marr = self._group.arrays[var]
         manifest = marr.manifest
 
-        path = manifest._paths[*chunk_key]
-        offset = manifest._offsets[*chunk_key]
-        length = manifest._lengths[*chunk_key]
+        chunk_indexes = parse_manifest_index(
+            key, marr.metadata.chunk_key_encoding.separator
+        )
+        path = manifest._paths[*chunk_indexes]
+        offset = manifest._offsets[*chunk_indexes]
+        length = manifest._lengths[*chunk_indexes]
         # Get the  configured object store instance that matches the path
         store_request = find_matching_store(stores=self._stores, request_key=path)
         # Transform the input byte range to account for the chunk location in the file

--- a/virtualizarr/manifests/store.py
+++ b/virtualizarr/manifests/store.py
@@ -126,7 +126,9 @@ def parse_manifest_index(key: str, chunk_key_encoding: str = ".") -> tuple[int, 
     """
     if key.endswith("c"):
         # Scalar arrays hold the data in the "c" key
-        return (0,)
+        raise NotImplementedError(
+            "Scalar arrays are not yet supported by ManifestStore"
+        )
     parts = key.split(
         "c/"
     )  # TODO: Open an issue upstream about the Zarr spec indicating this should be f"c{chunk_key_encoding}" rather than always "c/"

--- a/virtualizarr/manifests/utils.py
+++ b/virtualizarr/manifests/utils.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, Dict, Iterable, Optional, Union
 
 import numpy as np
 from zarr import Array
+from zarr.core.chunk_key_encodings import ChunkKeyEncodingLike
 from zarr.core.metadata.v3 import ArrayV3Metadata
 
 from virtualizarr.codecs import convert_to_codec_pipeline, get_codecs
@@ -14,9 +15,11 @@ def create_v3_array_metadata(
     shape: tuple[int, ...],
     data_type: np.dtype,
     chunk_shape: tuple[int, ...],
+    chunk_key_encoding: ChunkKeyEncodingLike = {"name": "default"},
     fill_value: Any = None,
     codecs: Optional[list[Dict[str, Any]]] = None,
     attributes: Optional[Dict[str, Any]] = None,
+    dimension_names: Optional[tuple[str, ...]] = None,
 ) -> ArrayV3Metadata:
     """
     Create an ArrayV3Metadata instance with standard configuration.
@@ -30,12 +33,16 @@ def create_v3_array_metadata(
         The numpy dtype of the array
     chunk_shape : tuple[int, ...]
         The shape of each chunk
+    chunk_key_encoding : ChunkKeyEncodingLike
+        The mapping from chunk grid cell coordinates to keys.
     fill_value : Any, optional
         The fill value for the array
     codecs : list[Dict[str, Any]], optional
         List of codec configurations
     attributes : Dict[str, Any], optional
         Additional attributes for the array
+    dimension_names : tuple[str], optional
+         Names of the dimensions
 
     Returns
     -------
@@ -49,14 +56,14 @@ def create_v3_array_metadata(
             "name": "regular",
             "configuration": {"chunk_shape": chunk_shape},
         },
-        chunk_key_encoding={"name": "default"},
+        chunk_key_encoding=chunk_key_encoding,
         fill_value=fill_value,
         codecs=convert_to_codec_pipeline(
             codecs=codecs or [],
             dtype=data_type,
         ),
         attributes=attributes or {},
-        dimension_names=None,
+        dimension_names=dimension_names,
         storage_transformers=None,
     )
 

--- a/virtualizarr/manifests/utils.py
+++ b/virtualizarr/manifests/utils.py
@@ -42,7 +42,7 @@ def create_v3_array_metadata(
     attributes : Dict[str, Any], optional
         Additional attributes for the array
     dimension_names : tuple[str], optional
-         Names of the dimensions
+        Names of the dimensions
 
     Returns
     -------


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
This PR improves ManifestStore to support ManifestArrays that only contain a single entry in paths, offsets, and lengths. It was originally included in https://github.com/zarr-developers/VirtualiZarr/pull/516 but I've pulled these changes out because they are also needed for the TIFF reader.

