### PR TITLE
fix filetypes in doc of `open_virtual_dataset`

### DIFF
--- a/virtualizarr/backend.py
+++ b/virtualizarr/backend.py
@@ -146,7 +146,7 @@ def open_virtual_dataset(
         File path to open as a set of virtualized zarr arrays.
     filetype : FileType or str, default None
         Type of file to be opened. Used to determine which kerchunk file format backend to use.
-        Can be one of {'netCDF3', 'netCDF4', 'HDF', 'TIFF', 'GRIB', 'FITS', 'dmrpp', 'kerchunk'}.
+        Can be one of {'netcdf3', 'netcdf4', 'hdf4', 'hdf5', 'tiff', 'grib', 'fits', 'dmrpp', 'kerchunk'}.
         If not provided will attempt to automatically infer the correct filetype from header bytes.
     group : str, default is None
         Path to the HDF5/netCDF4 group in the given file to open. Given as a str, supported by filetypes “netcdf4”, “hdf5”, and "dmrpp".


### PR DESCRIPTION
Hi everyone. While playing out with the repo I've noticed that the doc was off for `open_virtual_dataset` and its `filetype` parameter: 
https://github.com/zarr-developers/VirtualiZarr/blob/bd5ce89aa496783e9198f41c8fa85ae2edb80f8a/virtualizarr/backend.py#L149

The doc uses capitalized filetypes while the enum uses lowercase. This PR fixes the doc.

Example:
```
enum: {'tiff', 'hdf5', 'hdf4', 'kerchunk', 'fits', 'netcdf3', 'grib', 'dmrpp', 'netcdf4'}
doc: {'HDF', 'netCDF3', 'netCDF4', 'TIFF', 'GRIB', 'kerchunk', 'dmrpp', 'FITS'}
```

Let me know if this needs further work.