### PR TITLE
Add loadable_variables kwarg to ManifestStore.to_virtual_dataset()

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,6 +2,27 @@
 
 ## Usage questions
 
+### Can my specific data be virtualized?
+
+Depends on some details of your data.
+
+VirtualiZarr works by mapping your data to the zarr data model from whatever data model is used by the format it was saved in.
+This means that if your data contains anything that cannot be represented within the zarr data model, it cannot be virtualized.
+
+When virtualizing multi-file datasets, it is sometimes the case that it is possible to virtualize one file, but not possible to virtualize all the files together as part of one datacube, because of inconsistencies _between_ the files. The following restrictions apply across every file in the datacube you wish to create!
+
+The main restrictions of the zarr data model are:
+- **Recognized format** - Firstly, there must be a virtualizarr reader that understands how to parse the file format that your data is in. The VirtualiZarr package ships with readers for a number of common formats, if your data is not supported you may first have to write your own dedicated virtualizarr reader which understands your format.
+- **Rectilinear arrays** - The zarr data model is one of a set of rectilinear arrays, so your data must be decodable as a set of rectilinear arrays, each of which will map to single zarr array (via the `ManifestArray` class). If your data cannot be directly mapped to a rectilinear array, for example because it has inconsistent lengths along a common dimension (known as "ragged data"), then it cannot be virtualized.
+- **Homogeneous chunking** - The zarr data model assumes that every chunk of data in a single array has the same chunk shape. For multi-file datasets each chunk often corresponds to (part of) one file, so if all your files do not have consistent chunking your data cannot be virtualized. This is a big restriction, and there are plans to relax it in future, by adding support for variable-length chunks to the zarr data model.
+- **Homogenous codecs** - The zarr data model assumes that every chunk of data in a single array uses the same set of codecs for compression etc. or multi-file datasets each chunk often corresponds to (part of) one file, so if all your files do not have consistent compression or other codecs your data cannot be virtualized. This is another big restriction, and there are also plans to relax it in the future.
+- **Registered codecs** - The codecs needed to decompress and deserialize your data must be known to zarr. This might require defining and registering a new zarr codec.
+- **Registered data types** - The dtype of your data must be known to zarr. This might require registering a new zarr data type.
+
+If you attempt to use virtualizarr to create virtual references for data which violates any of these restrictions, it should raise an informative error telling you why it's not possible.
+
+Sometimes you can get around some of these restrictions for specific variables by loading them into memory instead of virtualizing them - see the section in the usage docs about loadable variables.
+
 ### I'm an Xarray user but unfamiliar with Zarr/Cloud - might I still want this?
 
 Potentially yes.

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -60,6 +60,8 @@ Internal Changes
     - zarr-python 3.0 does not yet support the big endian data type. This means that FITS and NetCDF-3 are not currently supported (`zarr-python issue #2324 <https://github.com/zarr-developers/zarr-python/issues/2324>`_).
     - zarr-python 3.0 does not yet support datetime and timedelta data types (`zarr-python issue #2616 <https://github.com/zarr-developers/zarr-python/issues/2616>`_).
 - The continuous integration workflows and developer environment now use `pixi <https://pixi.sh/latest/>`_ (:pull:`407`).
+- Added `loadable_variables` kwarg to :py:meth:`ManifestStore.to_virtual_dataset`.
+  (:pull:`543`) By `Tom Nicholas <https://github.com/TomNicholas>`_.
 
 .. _v1.3.2:
 

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -42,6 +42,8 @@ Documentation
 
 - Added MUR SST virtual and zarr icechunk store generation using lithops example.
   (:pull:`475`) by `Aimee Barciauskas <https://github.com/abarciauskas-bgse>`_.
+- Added FAQ answer about what data can be virtualized (:issue:`430`, :pull:`532`)
+  By `Tom Nicholas <https://github.com/TomNicholas>`_.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/virtualizarr/manifests/group.py
+++ b/virtualizarr/manifests/group.py
@@ -114,7 +114,7 @@ class ManifestGroup(
         All variables in the returned Dataset will be "virtual", i.e. they will wrap ManifestArray objects.
         """
 
-        from virtualizarr.common import construct_fully_virtual_dataset
+        from virtualizarr.xarray import construct_fully_virtual_dataset
 
         # The xarray data model stores coordinate names outside of the arbitrary extra metadata it can store on a Dataset,
         # so to avoid that information being duplicated we strip it from the zarr group attributes before storing it.

--- a/virtualizarr/manifests/store.py
+++ b/virtualizarr/manifests/store.py
@@ -18,6 +18,7 @@ from zarr.core.buffer.core import BufferPrototype
 from virtualizarr.manifests.array import ManifestArray
 from virtualizarr.manifests.group import ManifestGroup
 
+
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Iterable
     from typing import Any
@@ -357,6 +358,8 @@ class ManifestStore(Store):
         self, 
         group="",
         loadable_variables: Iterable[str] | None = None,
+        decode_times: bool | None = None,
+        indexes: Mapping[str, xr.Index] | None = None,
     ) -> "xr.Dataset":
         """
         Create a "virtual" xarray dataset containing the contents of one zarr group.
@@ -376,30 +379,13 @@ class ManifestStore(Store):
         -------
         vds : xarray.Dataset
         """
+        
+        from virtualizarr.xarray import construct_virtual_dataset
 
-        import xarray as xr
-
-        if group:
-            raise NotImplementedError(
-                "ManifestStore does not yet support nested groups"
-            )
-        else:
-            manifestgroup = self._group
-
-        fully_virtual_ds = manifestgroup.to_virtual_dataset()
-
-        # TODO drop the non-loadable variables here
-        loadable_ds = xr.open_zarr(
-            self,
+        return construct_virtual_dataset(
+            manifest_store=self,
             group=group,
-            zarr_version=3,
-            consolidated=False,
-            drop_variables=...,
-        )
-
-        return xr.merge(
-            fully_virtual_ds.drop_vars(loadable_variables), 
-            loadable_ds,
+            loadable_variables=loadable_variables,
         )
 
 

--- a/virtualizarr/manifests/store.py
+++ b/virtualizarr/manifests/store.py
@@ -18,7 +18,6 @@ from zarr.core.buffer.core import BufferPrototype
 from virtualizarr.manifests.array import ManifestArray
 from virtualizarr.manifests.group import ManifestGroup
 
-
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Iterable
     from typing import Any
@@ -355,7 +354,7 @@ class ManifestStore(Store):
             yield k
 
     def to_virtual_dataset(
-        self, 
+        self,
         group="",
         loadable_variables: Iterable[str] | None = None,
         decode_times: bool | None = None,
@@ -363,8 +362,6 @@ class ManifestStore(Store):
     ) -> "xr.Dataset":
         """
         Create a "virtual" xarray dataset containing the contents of one zarr group.
-
-        All variables in the returned Dataset will be "virtual", i.e. they will wrap ManifestArray objects.
 
         Will ignore the contents of any other groups in the store.
 
@@ -379,13 +376,15 @@ class ManifestStore(Store):
         -------
         vds : xarray.Dataset
         """
-        
+
         from virtualizarr.xarray import construct_virtual_dataset
 
         return construct_virtual_dataset(
             manifest_store=self,
             group=group,
             loadable_variables=loadable_variables,
+            indexes=indexes,
+            decode_times=decode_times,
         )
 
 

--- a/virtualizarr/readers/fits.py
+++ b/virtualizarr/readers/fits.py
@@ -3,7 +3,6 @@ from typing import Hashable, Iterable, Mapping, Optional
 
 from xarray import Dataset, Index
 
-from virtualizarr.common import construct_fully_virtual_dataset
 from virtualizarr.readers.api import (
     VirtualBackend,
 )
@@ -12,6 +11,7 @@ from virtualizarr.translators.kerchunk import (
     virtual_vars_and_metadata_from_kerchunk_refs,
 )
 from virtualizarr.types.kerchunk import KerchunkStoreRefs
+from virtualizarr.xarray import construct_fully_virtual_dataset
 
 
 class FITSVirtualBackend(VirtualBackend):

--- a/virtualizarr/readers/hdf/hdf.py
+++ b/virtualizarr/readers/hdf/hdf.py
@@ -20,10 +20,6 @@ import xarray as xr
 from xarray.backends.zarr import FillValueCoder
 
 from virtualizarr.codecs import numcodec_config_to_configurable
-from virtualizarr.common import (
-    construct_fully_virtual_dataset,
-    replace_virtual_with_loadable_vars,
-)
 from virtualizarr.manifests import (
     ChunkEntry,
     ChunkManifest,
@@ -37,6 +33,10 @@ from virtualizarr.readers.api import VirtualBackend
 from virtualizarr.readers.hdf.filters import cfcodec_from_dataset, codecs_from_dataset
 from virtualizarr.types import ChunkKey
 from virtualizarr.utils import _FsspecFSFromFilepath, soft_import
+from virtualizarr.xarray import (
+    construct_fully_virtual_dataset,
+    construct_virtual_dataset,
+)
 
 h5py = soft_import("h5py", "For reading hdf files", strict=False)
 
@@ -212,9 +212,9 @@ class HDFVirtualBackend(VirtualBackend):
             attrs=attrs,
         )
 
-        vds = replace_virtual_with_loadable_vars(
-            fully_virtual_dataset,
-            filepath,
+        vds = construct_virtual_dataset(
+            fully_virtual_ds=fully_virtual_dataset,
+            filepath=filepath,
             group=group,
             loadable_variables=loadable_variables,
             reader_options=reader_options,

--- a/virtualizarr/readers/hdf5.py
+++ b/virtualizarr/readers/hdf5.py
@@ -3,14 +3,14 @@ from typing import Hashable, Iterable, Mapping, Optional
 
 from xarray import Dataset, Index
 
-from virtualizarr.common import (
-    construct_fully_virtual_dataset,
-    replace_virtual_with_loadable_vars,
-)
 from virtualizarr.readers.api import VirtualBackend
 from virtualizarr.translators.kerchunk import (
     extract_group,
     virtual_vars_and_metadata_from_kerchunk_refs,
+)
+from virtualizarr.xarray import (
+    construct_fully_virtual_dataset,
+    construct_virtual_dataset,
 )
 
 
@@ -56,9 +56,9 @@ class HDF5VirtualBackend(VirtualBackend):
             attrs=attrs,
         )
 
-        vds = replace_virtual_with_loadable_vars(
-            fully_virtual_dataset,
-            filepath,
+        vds = construct_virtual_dataset(
+            fully_virtual_ds=fully_virtual_dataset,
+            filepath=filepath,
             group=group,
             loadable_variables=loadable_variables,
             reader_options=reader_options,

--- a/virtualizarr/readers/netcdf3.py
+++ b/virtualizarr/readers/netcdf3.py
@@ -3,13 +3,13 @@ from typing import Hashable, Iterable, Mapping, Optional
 
 from xarray import Dataset, Index
 
-from virtualizarr.common import (
-    construct_fully_virtual_dataset,
-    replace_virtual_with_loadable_vars,
-)
 from virtualizarr.readers.api import VirtualBackend
 from virtualizarr.translators.kerchunk import (
     virtual_vars_and_metadata_from_kerchunk_refs,
+)
+from virtualizarr.xarray import (
+    construct_fully_virtual_dataset,
+    construct_virtual_dataset,
 )
 
 
@@ -55,9 +55,9 @@ class NetCDF3VirtualBackend(VirtualBackend):
             attrs=attrs,
         )
 
-        vds = replace_virtual_with_loadable_vars(
-            fully_virtual_dataset,
-            filepath,
+        vds = construct_virtual_dataset(
+            fully_virtual_ds=fully_virtual_dataset,
+            filepath=filepath,
             group=group,
             loadable_variables=loadable_variables,
             reader_options=reader_options,

--- a/virtualizarr/readers/tiff.py
+++ b/virtualizarr/readers/tiff.py
@@ -4,16 +4,16 @@ from typing import Hashable, Iterable, Mapping, Optional
 
 from xarray import Dataset, Index
 
-from virtualizarr.common import (
-    construct_fully_virtual_dataset,
-    replace_virtual_with_loadable_vars,
-)
 from virtualizarr.readers.api import VirtualBackend
 from virtualizarr.translators.kerchunk import (
     extract_group,
     virtual_vars_and_metadata_from_kerchunk_refs,
 )
 from virtualizarr.types.kerchunk import KerchunkStoreRefs
+from virtualizarr.xarray import (
+    construct_fully_virtual_dataset,
+    construct_virtual_dataset,
+)
 
 
 class TIFFVirtualBackend(VirtualBackend):
@@ -66,9 +66,9 @@ class TIFFVirtualBackend(VirtualBackend):
             attrs=attrs,
         )
 
-        vds = replace_virtual_with_loadable_vars(
-            fully_virtual_dataset,
-            filepath,
+        vds = construct_virtual_dataset(
+            fully_virtual_ds=fully_virtual_dataset,
+            filepath=filepath,
             group=group,
             loadable_variables=loadable_variables,
             reader_options=reader_options,

--- a/virtualizarr/tests/test_manifests/test_store.py
+++ b/virtualizarr/tests/test_manifests/test_store.py
@@ -21,10 +21,11 @@ from virtualizarr.manifests import (
     ManifestStore,
 )
 from virtualizarr.manifests.utils import create_v3_array_metadata
-from virtualizarr.tests import requires_minio, requires_obstore
 from virtualizarr.tests import (
     requires_hdf5plugin,
     requires_imagecodecs,
+    requires_minio,
+    requires_obstore,
 )
 
 if TYPE_CHECKING:
@@ -233,7 +234,9 @@ class TestToVirtualXarray:
             (None, ["t"]),
         ],
     )
-    def test_single_group_to_dataset(self, manifest_array, loadable_variables, expected_loadable_variables):
+    def test_single_group_to_dataset(
+        self, manifest_array, loadable_variables, expected_loadable_variables
+    ):
         import obstore as obs
 
         marr1 = manifest_array(
@@ -253,7 +256,6 @@ class TestToVirtualXarray:
 
         local_store = obs.store.LocalStore()
         manifest_store = ManifestStore(manifest_group, stores={"file://": local_store})
-
 
         vds = manifest_store.to_virtual_dataset(loadable_variables=loadable_variables)
         assert set(vds.variables) == set(["T", "elevation", "t"])

--- a/virtualizarr/tests/test_writers/test_icechunk.py
+++ b/virtualizarr/tests/test_writers/test_icechunk.py
@@ -13,7 +13,7 @@ import xarray as xr
 import zarr
 from zarr.core.metadata import ArrayV3Metadata
 
-from virtualizarr.common import separate_coords
+from virtualizarr.xarray import separate_coords
 from virtualizarr.manifests import ChunkManifest, ManifestArray
 from virtualizarr.writers.icechunk import generate_chunk_key
 

--- a/virtualizarr/tests/test_writers/test_icechunk.py
+++ b/virtualizarr/tests/test_writers/test_icechunk.py
@@ -13,9 +13,9 @@ import xarray as xr
 import zarr
 from zarr.core.metadata import ArrayV3Metadata
 
-from virtualizarr.xarray import separate_coords
 from virtualizarr.manifests import ChunkManifest, ManifestArray
 from virtualizarr.writers.icechunk import generate_chunk_key
+from virtualizarr.xarray import separate_coords
 
 if TYPE_CHECKING:
     from icechunk import (  # type: ignore[import-not-found]

--- a/virtualizarr/translators/kerchunk.py
+++ b/virtualizarr/translators/kerchunk.py
@@ -11,7 +11,6 @@ from zarr.core.metadata.v2 import ArrayV2Metadata
 from virtualizarr.codecs import (
     numcodec_config_to_configurable,
 )
-from virtualizarr.common import separate_coords
 from virtualizarr.manifests import ChunkManifest, ManifestArray
 from virtualizarr.manifests.manifest import ChunkEntry, ChunkKey
 from virtualizarr.manifests.utils import create_v3_array_metadata
@@ -20,6 +19,7 @@ from virtualizarr.types.kerchunk import (
     KerchunkStoreRefs,
 )
 from virtualizarr.utils import determine_chunk_grid_shape
+from virtualizarr.xarray import separate_coords
 
 
 def to_kerchunk_json(v2_metadata: ArrayV2Metadata) -> str:

--- a/virtualizarr/xarray.py
+++ b/virtualizarr/xarray.py
@@ -33,21 +33,22 @@ def construct_fully_virtual_dataset(
     return vds
 
 
-def replace_virtual_with_loadable_vars(
+def construct_virtual_dataset(
     manifest_store: ManifestStore,
     group: str | None = None,
     loadable_variables: Iterable[Hashable] | None = None,
     decode_times: bool | None = None,
     indexes: Mapping[str, xr.Index] | None = None,
 ) -> xr.Dataset:
-    
+    """
+    Construct a fully or partly virtual dataset from a ManifestStore, containing the contents of one group.
+    """
+
     if group:
-        raise NotImplementedError(
-            "ManifestStore does not yet support nested groups"
-        )
+        raise NotImplementedError("ManifestStore does not yet support nested groups")
     else:
         manifestgroup = manifest_store._group
-    
+
     fully_virtual_ds = manifestgroup.to_virtual_dataset()
 
     if indexes is not None:
@@ -88,7 +89,7 @@ def replace_virtual_with_loadable_vars(
             loadable_var_names_to_drop, errors="ignore"
         )
 
-        ds_virtual_to_keep = fully_virtual_dataset.drop_vars(
+        ds_virtual_to_keep = fully_virtual_ds.drop_vars(
             var_names_to_load, errors="ignore"
         )
 

--- a/virtualizarr/xarray.py
+++ b/virtualizarr/xarray.py
@@ -82,7 +82,8 @@ def construct_virtual_dataset(
         # TODO pre-ManifestStore codepath, remove once all readers use ManifestStore approach
 
         fpath = _FsspecFSFromFilepath(
-            filepath=filepath, reader_options=reader_options
+            filepath=filepath,  # type: ignore[arg-type]
+            reader_options=reader_options,
         ).open_file()
 
         with xr.open_dataset(
@@ -91,7 +92,9 @@ def construct_virtual_dataset(
             decode_times=decode_times,
         ) as loadable_ds:
             return replace_virtual_with_loadable_vars(
-                fully_virtual_ds, loadable_ds, loadable_variables
+                fully_virtual_ds,  # type: ignore[arg-type]
+                loadable_ds,
+                loadable_variables,
             )
 
 

--- a/virtualizarr/xarray.py
+++ b/virtualizarr/xarray.py
@@ -69,9 +69,10 @@ def construct_virtual_dataset(
         with xr.open_zarr(
             manifest_store,
             group=group,
-            decode_times=decode_times,
             consolidated=False,
             zarr_format=3,
+            chunks=None,
+            decode_times=decode_times,
         ) as loadable_ds:
             return replace_virtual_with_loadable_vars(
                 fully_virtual_ds, loadable_ds, loadable_variables


### PR DESCRIPTION
Adds `loadable_variables` kwarg to `ManifestStore.to_virtual_dataset()` method, which will makes reader implementations simpler. 

Also refactors `common.py` (to now be called `xarray.py`), such that we can use the same `construct_virtual_dataset` function from it in every reader, regardless of whether or not that reader yet uses `ManifestStore`.

cc @sharkinsspatial 

- [x] Tests added
- [x] Tests passing
- [x] Full type hint coverage
- [x] Changes are documented in `docs/releases.rst`