### PR TITLE
Test endianess support against zarr-python data types refactor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ upstream = [
     'universal_pathlib @ git+https://github.com/fsspec/universal_pathlib',
     'numcodecs @ git+https://github.com/zarr-developers/numcodecs',
     'ujson @ git+https://github.com/ultrajson/ultrajson',
-    'zarr @ git+https://github.com/zarr-developers/zarr-python',
+    'zarr @ git+https://github.com/d-v-b/zarr-python@feat/fixed-length-strings',
     # optional dependencies
     'astropy @ git+https://github.com/astropy/astropy',
     'fsspec @ git+https://github.com/fsspec/filesystem_spec',


### PR DESCRIPTION
This PR is for testing support for @d-v-b's unmerged zarr data types refactor in https://github.com/zarr-developers/zarr-python/pull/2874. Particularly we care about supporting big-endian data.

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
