### PR TITLE
Refactor kerchunk readers to use manifest store

### DIFF
--- a/virtualizarr/manifests/store.py
+++ b/virtualizarr/manifests/store.py
@@ -344,13 +344,33 @@ class ManifestStore(Store):
             yield k
 
     @classmethod
-    def _from_kerchunk_refs(cls, refs: KerchunkStoreRefs) -> ManifestStore:
-        """Construct a ManifestStore from a dictionary of kerchunk references."""
-        # TODO change this to a public method which understands kerchunk json/parquet filepaths?
+    def from_kerchunk_refs(
+        cls,
+        refs: KerchunkStoreRefs,
+        group: str | None = None,
+        fs_root: str | None = None,
+    ) -> ManifestStore:
+        """
+        Construct a ManifestStore from a dictionary of kerchunk references.
+
+        Parameters
+        ----------
+        refs: dict
+            The Kerchunk references, as a dictionary.
+        group: string, optional
+        fs_root: string, optional
+            The root of the fsspec filesystem on which these references were generated.
+            Required if any paths are relative in order to turn them into absolute paths (which virtualizarr requires).
+        """
+        # TODO teach this method to understand kerchunk json/parquet filepaths too?
 
         from virtualizarr.translators.kerchunk import manifeststore_from_kerchunk_refs
 
-        return manifeststore_from_kerchunk_refs(refs)
+        return manifeststore_from_kerchunk_refs(
+            refs,
+            group=group,
+            fs_root=fs_root,
+        )
 
     def to_virtual_dataset(
         self,

--- a/virtualizarr/manifests/store.py
+++ b/virtualizarr/manifests/store.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import pickle
-from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, Mapping
+from collections.abc import AsyncGenerator, Iterable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Mapping, TypeAlias
 from urllib.parse import urlparse
 
 from zarr.abc.store import (
@@ -12,36 +13,12 @@ from zarr.abc.store import (
     Store,
     SuffixByteRequest,
 )
-from zarr.core.buffer import Buffer
+from zarr.core.buffer import Buffer, BufferPrototype, default_buffer_prototype
 from zarr.core.buffer.core import BufferPrototype
+from zarr.core.common import BytesLike
 
 from virtualizarr.manifests.array import ManifestArray
 from virtualizarr.manifests.group import ManifestGroup
-
-
-if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, Iterable
-    from typing import Any
-
-    from zarr.core.buffer import BufferPrototype
-    from zarr.core.common import BytesLike
-
-
-__all__ = ["ManifestStore"]
-
-
-_ALLOWED_EXCEPTIONS: tuple[type[Exception], ...] = (
-    FileNotFoundError,
-    IsADirectoryError,
-    NotADirectoryError,
-)
-
-from collections.abc import AsyncGenerator
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, TypeAlias
-
-from zarr.core.buffer import default_buffer_prototype
-
 from virtualizarr.vendor.zarr.metadata import dict_to_buffer
 
 if TYPE_CHECKING:
@@ -52,6 +29,16 @@ if TYPE_CHECKING:
     import xarray as xr
 
     from virtualizarr.translators.kerchunk import KerchunkStoreRefs
+
+
+__all__ = ["ManifestStore"]
+
+
+_ALLOWED_EXCEPTIONS: tuple[type[Exception], ...] = (
+    FileNotFoundError,
+    IsADirectoryError,
+    NotADirectoryError,
+)
 
 
 @dataclass
@@ -357,13 +344,10 @@ class ManifestStore(Store):
             yield k
 
     @classmethod
-    def _from_kerchunk_refs(
-        cls,
-        refs: KerchunkStoreRefs
-    ) -> ManifestStore:
+    def _from_kerchunk_refs(cls, refs: KerchunkStoreRefs) -> ManifestStore:
         """Construct a ManifestStore from a dictionary of kerchunk references."""
         # TODO change this to a public method which understands kerchunk json/parquet filepaths?
-        
+
         from virtualizarr.translators.kerchunk import manifeststore_from_kerchunk_refs
 
         return manifeststore_from_kerchunk_refs(refs)

--- a/virtualizarr/manifests/store.py
+++ b/virtualizarr/manifests/store.py
@@ -18,6 +18,7 @@ from zarr.core.buffer.core import BufferPrototype
 from virtualizarr.manifests.array import ManifestArray
 from virtualizarr.manifests.group import ManifestGroup
 
+
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Iterable
     from typing import Any
@@ -49,6 +50,8 @@ if TYPE_CHECKING:
     StoreDict: TypeAlias = dict[str, ObjectStore]
 
     import xarray as xr
+
+    from virtualizarr.translators.kerchunk import KerchunkStoreRefs
 
 
 @dataclass
@@ -352,6 +355,18 @@ class ManifestStore(Store):
         yield "zarr.json"
         for k in self._group.arrays.keys():
             yield k
+
+    @classmethod
+    def _from_kerchunk_refs(
+        cls,
+        refs: KerchunkStoreRefs
+    ) -> ManifestStore:
+        """Construct a ManifestStore from a dictionary of kerchunk references."""
+        # TODO change this to a public method which understands kerchunk json/parquet filepaths?
+        
+        from virtualizarr.translators.kerchunk import manifeststore_from_kerchunk_refs
+
+        return manifeststore_from_kerchunk_refs(refs)
 
     def to_virtual_dataset(
         self,

--- a/virtualizarr/readers/fits.py
+++ b/virtualizarr/readers/fits.py
@@ -6,12 +6,8 @@ from xarray import Dataset, Index
 from virtualizarr.readers.api import (
     VirtualBackend,
 )
-from virtualizarr.translators.kerchunk import (
-    extract_group,
-    virtual_vars_and_metadata_from_kerchunk_refs,
-)
 from virtualizarr.types.kerchunk import KerchunkStoreRefs
-from virtualizarr.xarray import construct_fully_virtual_dataset
+from virtualizarr.manifests import ManifestStore
 
 
 class FITSVirtualBackend(VirtualBackend):
@@ -50,15 +46,12 @@ class FITSVirtualBackend(VirtualBackend):
                 "Cannot load variables or indexes from FITS files as there is no xarray backend engine for FITS"
             )
 
-        virtual_vars, attrs, coord_names = virtual_vars_and_metadata_from_kerchunk_refs(
+        manifeststore = ManifestStore._from_kerchunk_refs(
             refs,
             fs_root=Path.cwd().as_uri(),
         )
 
-        vds = construct_fully_virtual_dataset(
-            virtual_vars=virtual_vars,
-            coord_names=coord_names,
-            attrs=attrs,
-        )
+        # TODO pass indexes={}?
+        vds = manifeststore.to_virtual_dataset(group=group)
 
         return vds.drop_vars(_drop_vars)


### PR DESCRIPTION
Aims to refactor all the kerchunk-based readers to use `ManifestStore`, but to do that this PR first adds a `ManifestStore.from_kerchunk_refs()` method.

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
