### PR TITLE
Add ObjectStoreRegistry to support default stores

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,3 +22,13 @@ repos:
     rev: ebf0b5e44d67f8beaa1cd13a0d0393ea04c6058d
     hooks:
       - id: validate-cff
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.15.0
+    hooks:
+      - id: mypy
+        files: src|tests
+        additional_dependencies:
+          # Package dependencies
+          - obstore>=0.5.1
+          # Tests
+          - pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,13 +22,3 @@ repos:
     rev: ebf0b5e44d67f8beaa1cd13a0d0393ea04c6058d
     hooks:
       - id: validate-cff
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.15.0
-    hooks:
-      - id: mypy
-        files: src|tests
-        additional_dependencies:
-          # Package dependencies
-          - obstore>=0.5.1
-          # Tests
-          - pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,9 +177,9 @@ run-mypy = { cmd = "mypy virtualizarr" }
 # is used), reduces test hangs that appear to be macOS-related.
 run-tests = { cmd = "pytest -n auto --dist loadscope --run-network-tests --verbose" }
 run-tests-no-network = { cmd = "pytest -n auto --verbose" }
-run-tests-cov = { cmd = "pytest -n 1 --run-network-tests --verbose --cov=virtualizarr --cov=term-missing" }
-run-tests-xml-cov = { cmd = "pytest -n 1 --run-network-tests --verbose --cov=virtualizarr --cov-report=xml" }
-run-tests-html-cov = { cmd = "pytest -n 1 --run-network-tests --verbose --cov=virtualizarr --cov-report=html" }
+run-tests-cov = { cmd = "pytest -n auto --run-network-tests --verbose --cov=term-missing" }
+run-tests-xml-cov = { cmd = "pytest -n auto --run-network-tests --verbose --cov-report=xml" }
+run-tests-html-cov = { cmd = "pytest -n auto --run-network-tests --verbose --cov-report=html" }
 
 # Define which features and groups to include in different pixi (similar to conda) environments)
 [tool.pixi.environments]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,6 +227,7 @@ module = [
     "numcodecs.*",
     "ujson",
     "zarr",
+    "requests",
 ]
 ignore_missing_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,9 +177,9 @@ run-mypy = { cmd = "mypy virtualizarr" }
 # is used), reduces test hangs that appear to be macOS-related.
 run-tests = { cmd = "pytest -n auto --dist loadscope --run-network-tests --verbose" }
 run-tests-no-network = { cmd = "pytest -n auto --verbose" }
-run-tests-cov = { cmd = "pytest -n auto --run-network-tests --verbose --cov=term-missing" }
-run-tests-xml-cov = { cmd = "pytest -n auto --run-network-tests --verbose --cov-report=xml" }
-run-tests-html-cov = { cmd = "pytest -n auto --run-network-tests --verbose --cov-report=html" }
+run-tests-cov = { cmd = "pytest -n 1 --run-network-tests --verbose --cov=virtualizarr --cov=term-missing" }
+run-tests-xml-cov = { cmd = "pytest -n 1 --run-network-tests --verbose --cov=virtualizarr --cov-report=xml" }
+run-tests-html-cov = { cmd = "pytest -n 1 --run-network-tests --verbose --cov=virtualizarr --cov-report=html" }
 
 # Define which features and groups to include in different pixi (similar to conda) environments)
 [tool.pixi.environments]
@@ -272,7 +272,6 @@ line-ending = "auto"
 known-first-party = ["virtualizarr"]
 
 [tool.coverage.run]
-include = ["virtualizarr/"]
 omit = ["conftest.py", "virtualizarr/tests/*"]
 
 [tool.coverage.report]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,8 +201,8 @@ readthedocs = "rm -rf $READTHEDOCS_OUTPUT/html && cp -r docs/_build/html $READTH
 
 # Define commands to run within the docs environment
 [tool.pixi.feature.minio.tasks]
-run-tests = { cmd = "pytest virtualizarr/tests/test_manifests/test_store.py --run-minio-tests --verbose" }
-run-tests-xml-cov = { cmd = "pytest virtualizarr/tests/test_manifests/test_store.py --run-minio-tests --verbose --cov-report=xml" }
+run-tests = { cmd = "pytest virtualizarr/tests/test_manifests/test_store.py virtualizarr/tests/test_readers/test_hdf/test_hdf_manifest_store.py --run-minio-tests --run-network-tests --verbose" }
+run-tests-xml-cov = { cmd = "pytest virtualizarr/tests/test_manifests/test_store.py virtualizarr/tests/test_readers/test_hdf/test_hdf_manifest_store.py --run-minio-tests --run-network-tests --verbose --cov-report=xml" }
 
 [tool.setuptools_scm]
 fallback_version = "9999"

--- a/virtualizarr/manifests/__init__.py
+++ b/virtualizarr/manifests/__init__.py
@@ -4,4 +4,4 @@
 from virtualizarr.manifests.array import ManifestArray  # type: ignore # noqa
 from virtualizarr.manifests.group import ManifestGroup  # type: ignore # noqa
 from virtualizarr.manifests.manifest import ChunkEntry, ChunkManifest  # type: ignore # noqa
-from virtualizarr.manifests.store import ManifestStore  # type: ignore # noqa
+from virtualizarr.manifests.store import ManifestStore, ObjectStoreRegistry  # type: ignore # noqa

--- a/virtualizarr/manifests/store.py
+++ b/virtualizarr/manifests/store.py
@@ -156,7 +156,8 @@ def default_object_store(filepath: str) -> ObjectStore:
 
 class ObjectStoreRegistry:
     """
-    ObjectStoreRegistry maps the URL scheme and netloc to ObjectStore instances, and allows ManifestStores to read from different ObjectStore instances.
+    ObjectStoreRegistry maps the URL scheme and netloc to ObjectStore instances. This register allows
+    Zarr Store implementations (e.g., ManifestStore) to read from different ObjectStore instances.
     """
 
     _stores: dict[str, ObjectStore]

--- a/virtualizarr/manifests/store.py
+++ b/virtualizarr/manifests/store.py
@@ -147,12 +147,14 @@ def _default_object_store(
 
     parsed = urlparse(filepath)
     if parsed.scheme == "s3":
+        if not config:
+            config["skip_signature"] = True
+        config["virtual_hosted_style_request"] = True
+        config["client_options"] = {"allow_http": True}
+        config["virtual_hosted_style_request"] = False
         bucket = parsed.netloc
         return f"s3://{bucket}", obs.store.S3Store(
             bucket=bucket,
-            skip_signature=True,
-            virtual_hosted_style_request=False,
-            client_options={"allow_http": True},
             **config,
         )
     elif parsed.scheme == "":

--- a/virtualizarr/manifests/store.py
+++ b/virtualizarr/manifests/store.py
@@ -222,7 +222,7 @@ class ManifestStore(Store):
         self,
         group: ManifestGroup,
         *,
-        stores: StoreDict,  # TODO: Consider using a sequence of tuples rather than a dict (see https://github.com/zarr-developers/VirtualiZarr/pull/490#discussion_r2010717898).
+        stores: StoreDict,
     ) -> None:
         """Instantiate a new ManifestStore
 

--- a/virtualizarr/manifests/store.py
+++ b/virtualizarr/manifests/store.py
@@ -163,7 +163,7 @@ def _sort_stores_by_prefix_length(input_dict):
 
 class ObjectStoreRegistry:
     """
-    ObjectStoreRegistry maps a URL to an ObjectStore instance, and allows ManifestStores to read from different ObjectStore instances.
+    ObjectStoreRegistry maps URLs to ObjectStore instances, and allows ManifestStores to read from different ObjectStore instances.
     """
 
     _stores: dict[str, ObjectStore]
@@ -178,6 +178,8 @@ class ObjectStoreRegistry:
 
     def register_store(self, url: str, store: ObjectStore):
         """
+        Register a store using the given url
+
         If a store with the same key existed before, it is replaced
         """
         self._stores[url] = store
@@ -189,6 +191,9 @@ class ObjectStoreRegistry:
 
             - URL with scheme file:/// or no scheme will return the default LocalFS store
             - URL with scheme s3://bucket/ will return the S3 store
+
+        If no `ObjectStore` is found for the `url`, ad-hoc discovery may be executed depending on the
+        `url`. An `ObjectStore` may be lazily created and registered.
 
         Parameters:
         -----------

--- a/virtualizarr/manifests/store.py
+++ b/virtualizarr/manifests/store.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import pickle
-from collections.abc import Iterable
-from typing import TYPE_CHECKING
+from collections.abc import AsyncGenerator, Iterable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
 from zarr.abc.store import (
@@ -12,11 +13,12 @@ from zarr.abc.store import (
     Store,
     SuffixByteRequest,
 )
-from zarr.core.buffer import Buffer
+from zarr.core.buffer import Buffer, default_buffer_prototype
 from zarr.core.buffer.core import BufferPrototype
 
 from virtualizarr.manifests.array import ManifestArray
 from virtualizarr.manifests.group import ManifestGroup
+from virtualizarr.vendor.zarr.metadata import dict_to_buffer
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Iterable, Mapping
@@ -37,14 +39,6 @@ _ALLOWED_EXCEPTIONS: tuple[type[Exception], ...] = (
     IsADirectoryError,
     NotADirectoryError,
 )
-
-from collections.abc import AsyncGenerator
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
-
-from zarr.core.buffer import default_buffer_prototype
-
-from virtualizarr.vendor.zarr.metadata import dict_to_buffer
 
 
 @dataclass

--- a/virtualizarr/manifests/store.py
+++ b/virtualizarr/manifests/store.py
@@ -160,11 +160,6 @@ def default_object_store(filepath: str) -> ObjectStore:
     raise NotImplementedError(f"{parsed.scheme} is not yet supported")
 
 
-def _sort_stores_by_prefix_length(input_dict):
-    sorted_items = sorted(input_dict.items(), key=lambda x: len(x[0]), reverse=True)
-    return dict(sorted_items)
-
-
 class ObjectStoreRegistry:
     """
     ObjectStoreRegistry maps the URL scheme and netloc to ObjectStore instances, and allows ManifestStores to read from different ObjectStore instances.
@@ -253,13 +248,13 @@ class ManifestStore(Store):
     def __init__(
         self, group: ManifestGroup, *, store_registry: ObjectStoreRegistry | None = None
     ) -> None:
-        """Instantiate a new ManifestStore
+        """Instantiate a new ManifestStore.
 
         Parameters
         ----------
         manifest_group : ManifestGroup
             Manifest Group containing Group metadata and mapping variable names to ManifestArrays
-        stores : dict[prefix, :class:`obstore.store.ObjectStore`]
+        stores : ObjectStoreRegistry
             A mapping of url prefixes to obstore Store instances set up with the proper credentials.
 
             The prefixes are matched to the URIs in the ManifestArrays to determine which store to

--- a/virtualizarr/manifests/store.py
+++ b/virtualizarr/manifests/store.py
@@ -53,18 +53,19 @@ if TYPE_CHECKING:
     import xarray as xr
 
 
-def _default_object_store(filepath: str, **kwargs) -> tuple[str, ObjectStore]:
-    # TODO: Replace **kwargs with S3Config | GCSConfig (e.g., https://developmentseed.org/obstore/latest/api/store/aws/#obstore.store.S3Config)
+def _default_object_store(filepath: str) -> tuple[str, ObjectStore]:
+    # TODO: Support storage configuration
     import obstore as obs
 
     parsed = urlparse(filepath)
     if parsed.scheme == "s3":
         bucket = parsed.netloc
-        if not kwargs:
-            kwargs = {"skip_signature": True}
-        kwargs["virtual_hosted_style_request"] = False
-        kwargs["client_options"] = {"allow_http": True}
-        return f"s3://{bucket}", obs.store.S3Store(bucket=bucket, **kwargs)
+        return f"s3://{bucket}", obs.store.S3Store(
+            bucket=bucket,
+            skip_signature=True,
+            virtual_hosted_style_request=False,
+            client_options={"allow_http": True},
+        )
     elif parsed.scheme == "":
         return "file://", obs.store.LocalStore()
 

--- a/virtualizarr/manifests/store.py
+++ b/virtualizarr/manifests/store.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pickle
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, Mapping, Optional
+from typing import TYPE_CHECKING, Any, Mapping
 from urllib.parse import urlparse
 
 from zarr.abc.store import (

--- a/virtualizarr/manifests/store.py
+++ b/virtualizarr/manifests/store.py
@@ -318,8 +318,8 @@ class ManifestStore(Store):
         length = manifest._lengths[*chunk_indexes]
         # Get the configured object store instance that matches the path
         store = self._store_registry.get_store(path)
-        # Truncate key to match ManifestArray expectations
-        key = urlparse(key).path
+        # Truncate path to match Obstore expectations
+        key = urlparse(path).path
         # Transform the input byte range to account for the chunk location in the file
         chunk_end_exclusive = offset + length
         byte_range = _transform_byte_range(

--- a/virtualizarr/manifests/store.py
+++ b/virtualizarr/manifests/store.py
@@ -53,23 +53,6 @@ if TYPE_CHECKING:
     import xarray as xr
 
 
-def _default_object_store(filepath: str) -> tuple[str, ObjectStore]:
-    # TODO: Support storage configuration
-    import obstore as obs
-
-    parsed = urlparse(filepath)
-    if parsed.scheme == "s3":
-        bucket = parsed.netloc
-        return f"s3://{bucket}", obs.store.S3Store(
-            bucket=bucket,
-            skip_signature=True,
-            virtual_hosted_style_request=False,
-            client_options={"allow_http": True},
-        )
-    elif parsed.scheme == "":
-        return "file://", obs.store.LocalStore()
-
-
 @dataclass
 class StoreRequest:
     """Dataclass for matching a key to the store instance"""
@@ -156,34 +139,26 @@ def parse_manifest_index(key: str, chunk_key_encoding: str = ".") -> tuple[int, 
     return tuple(int(ind) for ind in parts[1].split(chunk_key_encoding))
 
 
-def find_matching_store(stores: StoreDict, request_key: str) -> StoreRequest:
-    """
-    Find the matching store based on the store keys and the beginning of the URI strings,
-    to fetch data from the appropriately configured ObjectStore.
+def _default_object_store(filepath: str) -> tuple[str, ObjectStore]:
+    # TODO: Maybe support storage configuration
+    import obstore as obs
 
-    Parameters:
-    -----------
-    stores : StoreDict
-        A dictionary with URI prefixes for different stores as keys
-    request_key : str
-        A string to match against the dictionary keys
+    parsed = urlparse(filepath)
+    if parsed.scheme == "s3":
+        bucket = parsed.netloc
+        return f"s3://{bucket}", obs.store.S3Store(
+            bucket=bucket,
+            skip_signature=True,
+            virtual_hosted_style_request=False,
+            client_options={"allow_http": True},
+        )
+    elif parsed.scheme == "":
+        return "file://", obs.store.LocalStore()
 
-    Returns:
-    --------
-    StoreRequest
-    """
-    # Sort keys by length in descending order to ensure longer, more specific matches take precedence
-    sorted_keys = sorted(stores.keys(), key=len, reverse=True)
 
-    # Check each key to see if it's a prefix of the uri_string
-    for key in sorted_keys:
-        if request_key.startswith(key):
-            parsed_key = urlparse(request_key)
-            return StoreRequest(store=stores[key], key=parsed_key.path)
-    # if no match is found, raise an error
-    raise ValueError(
-        f"Expected the one of stores.keys() to match the data prefix, got {stores.keys()} and {request_key}"
-    )
+def _sort_stores_by_prefix_length(input_dict):
+    sorted_items = sorted(input_dict.items(), key=lambda x: len(x[0]), reverse=True)
+    return dict(sorted_items)
 
 
 class ManifestStore(Store):
@@ -247,7 +222,7 @@ class ManifestStore(Store):
             raise TypeError
 
         super().__init__(read_only=True)
-        self._stores = stores
+        self._stores = _sort_stores_by_prefix_length(stores)
         self._group = group
 
     def __str__(self) -> str:
@@ -290,7 +265,7 @@ class ManifestStore(Store):
         offset = manifest._offsets[*chunk_indexes]
         length = manifest._lengths[*chunk_indexes]
         # Get the  configured object store instance that matches the path
-        store_request = find_matching_store(stores=self._stores, request_key=path)
+        store_request = self._find_matching_store(request_key=path)
         # Transform the input byte range to account for the chunk location in the file
         chunk_end_exclusive = offset + length
         byte_range = _transform_byte_range(
@@ -405,6 +380,39 @@ class ManifestStore(Store):
             indexes=indexes,
             decode_times=decode_times,
         )
+
+    def _find_matching_store(self, request_key: str) -> StoreRequest:
+        """
+        Find the matching store based on the store keys and the beginning of the URI strings,
+        to fetch data from the appropriately configured ObjectStore.
+
+        Parameters:
+        -----------
+        stores : StoreDict
+            A dictionary with URI prefixes for different stores as keys
+        request_key : str
+            A string to match against the dictionary keys
+
+        Returns:
+        --------
+        StoreRequest
+        """
+
+        # Check each key to see if it's a prefix of the uri_string
+        parsed_request_key = urlparse(request_key)
+        for prefix in self._stores.keys():
+            if request_key.startswith(prefix):
+                # Return an existing configured store and parsed request path
+                return StoreRequest(
+                    store=self._stores[prefix], key=parsed_request_key.path
+                )
+        # Use anonymous default stores if not in pre-configured stores
+        prefix, store = _default_object_store(request_key)
+        # Add to stores for future use
+        self._stores[prefix] = store
+        self._stores = _sort_stores_by_prefix_length(self._stores)
+        # Return the new store and and parsed request path
+        return StoreRequest(store=store, key=parsed_request_key.path)
 
 
 def _transform_byte_range(

--- a/virtualizarr/manifests/store.py
+++ b/virtualizarr/manifests/store.py
@@ -223,11 +223,9 @@ class ManifestStore(Store):
     group : ManifestGroup
         Root group of the store.
         Contains group metadata, ManifestArrays, and any subgroups.
-    stores : dict[prefix, :class:`obstore.store.ObjectStore`]
-        A mapping of url prefixes to obstore Store instances set up with the proper credentials.
-
-        The prefixes are matched to the URIs in the ManifestArrays to determine which store to
-        use for making requests.
+    store_registry : ObjectStoreRegistry
+        ObjectStoreRegistry that maps the URL scheme and netloc to ObjectStore instances,
+        allowing ManifestStores to read from different ObjectStore instances.
 
     Warnings
     --------
@@ -254,11 +252,9 @@ class ManifestStore(Store):
         ----------
         manifest_group : ManifestGroup
             Manifest Group containing Group metadata and mapping variable names to ManifestArrays
-        stores : ObjectStoreRegistry
-            A mapping of url prefixes to obstore Store instances set up with the proper credentials.
-
-            The prefixes are matched to the URIs in the ManifestArrays to determine which store to
-            use for making requests.
+        store_registry : ObjectStoreRegistry
+            A registry mapping the URL scheme and netloc to ObjectStore instances,
+            allowing ManifestStores to read from different ObjectStore instances.
         """
 
         # TODO: Don't allow stores with prefix

--- a/virtualizarr/manifests/store.py
+++ b/virtualizarr/manifests/store.py
@@ -173,7 +173,7 @@ class ObjectStoreRegistry:
     _stores: dict[str, ObjectStore]
 
     @classmethod
-    def __init__(self, stores: dict | None = None):
+    def __init__(self, stores: dict[str, ObjectStore] | None = None):
         stores = stores or {}
         for store in stores.values():
             if not store.__class__.__module__.startswith("obstore"):

--- a/virtualizarr/manifests/store.py
+++ b/virtualizarr/manifests/store.py
@@ -159,6 +159,8 @@ def _default_object_store(
         )
     elif parsed.scheme == "":
         return "file://", obs.store.LocalStore()
+    else:
+        raise NotImplementedError(f"{parsed.scheme} is not yet supported")
 
 
 def _sort_stores_by_prefix_length(input_dict):

--- a/virtualizarr/readers/hdf/hdf.py
+++ b/virtualizarr/readers/hdf/hdf.py
@@ -29,7 +29,7 @@ from virtualizarr.manifests import (
     ManifestStore,
 )
 from virtualizarr.manifests.manifest import validate_and_normalize_path_to_uri
-from virtualizarr.manifests.store import _default_object_store
+from virtualizarr.manifests.store import ObjectStoreRegistry, _default_object_store
 from virtualizarr.manifests.utils import create_v3_array_metadata
 from virtualizarr.readers.api import VirtualBackend
 from virtualizarr.readers.hdf.filters import cfcodec_from_dataset, codecs_from_dataset
@@ -188,8 +188,9 @@ class HDFVirtualBackend(VirtualBackend):
         manifest_group = HDFVirtualBackend._construct_manifest_group(
             store=store, filepath=filepath, group=group
         )
+        registry = ObjectStoreRegistry({prefix: store})
         # Convert to a manifest store
-        return ManifestStore(stores={prefix: store}, group=manifest_group)  # type: ignore
+        return ManifestStore(store_registry=registry, group=manifest_group)  # type: ignore
 
     @staticmethod
     def open_virtual_dataset(

--- a/virtualizarr/readers/hdf/hdf.py
+++ b/virtualizarr/readers/hdf/hdf.py
@@ -155,39 +155,41 @@ class HDFVirtualBackend(VirtualBackend):
         return ManifestGroup(arrays=manifest_dict, attributes=attrs)
 
     @overload
+    @staticmethod
     def _create_manifest_store(
         filepath: str,
         *,
         prefix: str,
-        store: ObjectStore,
-        group: Optional[str] = None,
+        store: ObjectStore | None = None,
+        group: str | None = None,
     ) -> ManifestStore: ...
 
     @overload
+    @staticmethod
     def _create_manifest_store(
         filepath: str,
         *,
-        config: Optional[S3Config] = {},
-        group: Optional[str] = None,
+        config: S3Config | None = None,
+        group: str | None = None,
     ) -> ManifestStore: ...
 
     @staticmethod
     def _create_manifest_store(
         filepath: str,
         *,
-        prefix: Optional[str] = None,
-        store: Optional[ObjectStore] = None,
-        config: Optional[S3Config] = {},
-        group: Optional[str] = None,
+        prefix: str | None = None,
+        store: ObjectStore | None = None,
+        config: S3Config | None = None,
+        group: str | None = None,
     ) -> ManifestStore:
         # Create a group containing dataset level metadata and all the manifest arrays
         if not store:
-            prefix, store = _default_object_store(filepath, config=config)
+            prefix, store = _default_object_store(filepath, config=config)  # type: ignore
         manifest_group = HDFVirtualBackend._construct_manifest_group(
             store=store, filepath=filepath, group=group
         )
         # Convert to a manifest store
-        return ManifestStore(stores={prefix: store}, group=manifest_group)
+        return ManifestStore(stores={prefix: store}, group=manifest_group)  # type: ignore
 
     @staticmethod
     def open_virtual_dataset(

--- a/virtualizarr/readers/hdf/hdf.py
+++ b/virtualizarr/readers/hdf/hdf.py
@@ -46,7 +46,7 @@ h5py = soft_import("h5py", "For reading hdf files", strict=False)
 if TYPE_CHECKING:
     from h5py import Dataset as H5Dataset
     from h5py import Group as H5Group
-    from obstore.store import ObjectStore, S3Config
+    from obstore.store import ObjectStore
 
 FillValueType = Union[
     int,
@@ -169,7 +169,6 @@ class HDFVirtualBackend(VirtualBackend):
     def _create_manifest_store(
         filepath: str,
         *,
-        config: S3Config | None = None,
         group: str | None = None,
     ) -> ManifestStore: ...
 
@@ -179,12 +178,11 @@ class HDFVirtualBackend(VirtualBackend):
         *,
         prefix: str | None = None,
         store: ObjectStore | None = None,
-        config: S3Config | None = None,
         group: str | None = None,
     ) -> ManifestStore:
         # Create a group containing dataset level metadata and all the manifest arrays
         if not store:
-            prefix, store = _default_object_store(filepath, config=config)  # type: ignore
+            prefix, store = _default_object_store(filepath)  # type: ignore
         manifest_group = HDFVirtualBackend._construct_manifest_group(
             store=store, filepath=filepath, group=group
         )

--- a/virtualizarr/readers/hdf/hdf.py
+++ b/virtualizarr/readers/hdf/hdf.py
@@ -13,7 +13,6 @@ from typing import (
     Optional,
     Tuple,
     Union,
-    overload,
 )
 
 import numpy as np
@@ -29,7 +28,7 @@ from virtualizarr.manifests import (
     ManifestStore,
 )
 from virtualizarr.manifests.manifest import validate_and_normalize_path_to_uri
-from virtualizarr.manifests.store import ObjectStoreRegistry, _default_object_store
+from virtualizarr.manifests.store import ObjectStoreRegistry, default_object_store
 from virtualizarr.manifests.utils import create_v3_array_metadata
 from virtualizarr.readers.api import VirtualBackend
 from virtualizarr.readers.hdf.filters import cfcodec_from_dataset, codecs_from_dataset
@@ -154,39 +153,20 @@ class HDFVirtualBackend(VirtualBackend):
                         manifest_dict[key] = variable
         return ManifestGroup(arrays=manifest_dict, attributes=attrs)
 
-    @overload
     @staticmethod
     def _create_manifest_store(
         filepath: str,
         *,
-        prefix: str,
-        store: ObjectStore | None = None,
-        group: str | None = None,
-    ) -> ManifestStore: ...
-
-    @overload
-    @staticmethod
-    def _create_manifest_store(
-        filepath: str,
-        *,
-        group: str | None = None,
-    ) -> ManifestStore: ...
-
-    @staticmethod
-    def _create_manifest_store(
-        filepath: str,
-        *,
-        prefix: str | None = None,
         store: ObjectStore | None = None,
         group: str | None = None,
     ) -> ManifestStore:
         # Create a group containing dataset level metadata and all the manifest arrays
         if not store:
-            prefix, store = _default_object_store(filepath)  # type: ignore
+            store = default_object_store(filepath)  # type: ignore
         manifest_group = HDFVirtualBackend._construct_manifest_group(
             store=store, filepath=filepath, group=group
         )
-        registry = ObjectStoreRegistry({prefix: store})
+        registry = ObjectStoreRegistry({filepath: store})
         # Convert to a manifest store
         return ManifestStore(store_registry=registry, group=manifest_group)  # type: ignore
 

--- a/virtualizarr/readers/hdf/hdf.py
+++ b/virtualizarr/readers/hdf/hdf.py
@@ -13,6 +13,7 @@ from typing import (
     Optional,
     Tuple,
     Union,
+    overload,
 )
 
 import numpy as np
@@ -153,13 +154,28 @@ class HDFVirtualBackend(VirtualBackend):
                         manifest_dict[key] = variable
         return ManifestGroup(arrays=manifest_dict, attributes=attrs)
 
+    @overload
+    def _create_manifest_store(
+        filepath: str,
+        *,
+        prefix: str,
+        store: ObjectStore,
+        group: Optional[str] = None,
+    ) -> ManifestStore: ...
+
+    @overload
+    def _create_manifest_store(
+        filepath: str,
+        *,
+        config: Optional[S3Config] = {},
+        group: Optional[str] = None,
+    ) -> ManifestStore: ...
+
     @staticmethod
     def _create_manifest_store(
         filepath: str,
         *,
-        prefix: Optional[
-            str
-        ] = None,  # TODO: Improve typing to specify the prefix and store must both be provided or None
+        prefix: Optional[str] = None,
         store: Optional[ObjectStore] = None,
         config: Optional[S3Config] = {},
         group: Optional[str] = None,

--- a/virtualizarr/readers/hdf/hdf.py
+++ b/virtualizarr/readers/hdf/hdf.py
@@ -168,7 +168,7 @@ class HDFVirtualBackend(VirtualBackend):
         )
         registry = ObjectStoreRegistry({filepath: store})
         # Convert to a manifest store
-        return ManifestStore(store_registry=registry, group=manifest_group)  # type: ignore
+        return ManifestStore(store_registry=registry, group=manifest_group)
 
     @staticmethod
     def open_virtual_dataset(

--- a/virtualizarr/tests/conftest.py
+++ b/virtualizarr/tests/conftest.py
@@ -1,3 +1,4 @@
+import json
 import time
 
 import pytest
@@ -37,7 +38,7 @@ def minio_bucket(container):
     # Setup with guidance from https://medium.com/@sant1/using-minio-with-docker-and-python-cbbad397cb5d
     from minio import Minio
 
-    bucket = "mybucket"
+    bucket = "my-bucket"
     filename = "test.nc"
     # Initialize MinIO client
     client = Minio(
@@ -47,6 +48,28 @@ def minio_bucket(container):
         secure=False,
     )
     client.make_bucket(bucket)
+    policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {"AWS": "*"},
+                "Action": ["s3:GetBucketLocation", "s3:ListBucket"],
+                "Resource": "arn:aws:s3:::my-bucket",
+            },
+            {
+                "Effect": "Allow",
+                "Principal": {"AWS": "*"},
+                "Action": [
+                    "s3:GetObject",
+                    "s3:GetObjectRetention",
+                    "s3:GetObjectLegalHold",
+                ],
+                "Resource": "arn:aws:s3:::my-bucket/*",
+            },
+        ],
+    }
+    client.set_bucket_policy(bucket, json.dumps(policy))
     yield {
         "port": container["port"],
         "endpoint": container["endpoint"],

--- a/virtualizarr/tests/test_integration.py
+++ b/virtualizarr/tests/test_integration.py
@@ -1,7 +1,7 @@
 from collections.abc import Mapping
 from os.path import relpath
 from pathlib import Path
-from typing import Any, Callable, Concatenate, TypeAlias, overload
+from typing import Any, Callable, Concatenate, TypeAlias
 
 import numpy as np
 import pytest
@@ -112,16 +112,6 @@ def roundtrip_as_kerchunk_parquet(vds: xr.Dataset, tmpdir, **kwargs):
 
     # use fsspec to read the dataset from disk via the kerchunk references
     return xr.open_dataset(f"{tmpdir}/refs.parquet", engine="kerchunk", **kwargs)
-
-
-@overload
-def roundtrip_as_in_memory_icechunk(
-    vdata: xr.Dataset, tmp_path: Path, **kwargs
-) -> xr.Dataset: ...
-@overload
-def roundtrip_as_in_memory_icechunk(
-    vdata: xr.DataTree, tmp_path: Path, **kwargs
-) -> xr.DataTree: ...
 
 
 def roundtrip_as_in_memory_icechunk(

--- a/virtualizarr/tests/test_manifests/test_store.py
+++ b/virtualizarr/tests/test_manifests/test_store.py
@@ -118,7 +118,7 @@ def s3_store(minio_bucket):
         client_options={"allow_http": True},
     )
     filepath = "data.tmp"
-    prefix = f"s3://{minio_bucket['bucket']}/data/"
+    prefix = f"s3://{minio_bucket['bucket']}"
     return _generate_manifest_store(
         store=store,
         prefix=prefix,

--- a/virtualizarr/tests/test_manifests/test_store.py
+++ b/virtualizarr/tests/test_manifests/test_store.py
@@ -127,6 +127,7 @@ def s3_store(minio_bucket):
 
 
 @requires_obstore
+@requires_minio
 def test_default_object_store_s3(minio_bucket):
     from obstore.store import S3Store
 

--- a/virtualizarr/tests/test_manifests/test_store.py
+++ b/virtualizarr/tests/test_manifests/test_store.py
@@ -133,8 +133,6 @@ def test_default_object_store_s3(minio_bucket):
     filepath = f"s3://{minio_bucket['bucket']}/data/data.tmp"
     prefix, store = _default_object_store(
         filepath,
-        access_key_id=minio_bucket["username"],
-        secret_access_key=minio_bucket["password"],
     )
     assert prefix == f"s3://{minio_bucket['bucket']}"
     assert isinstance(store, S3Store)

--- a/virtualizarr/tests/test_manifests/test_store.py
+++ b/virtualizarr/tests/test_manifests/test_store.py
@@ -21,7 +21,7 @@ from virtualizarr.manifests import (
     ManifestStore,
     ObjectStoreRegistry,
 )
-from virtualizarr.manifests.store import _default_object_store
+from virtualizarr.manifests.store import default_object_store
 from virtualizarr.manifests.utils import create_v3_array_metadata
 from virtualizarr.tests import (
     requires_hdf5plugin,
@@ -134,10 +134,9 @@ def test_default_object_store_s3(minio_bucket):
     from obstore.store import S3Store
 
     filepath = f"s3://{minio_bucket['bucket']}/data/data.tmp"
-    prefix, store = _default_object_store(
+    store = default_object_store(
         filepath,
     )
-    assert prefix == f"s3://{minio_bucket['bucket']}"
     assert isinstance(store, S3Store)
 
 
@@ -146,8 +145,7 @@ def test_default_object_store_local(tmpdir):
     from obstore.store import LocalStore
 
     filepath = f"{tmpdir}/data.tmp"
-    prefix, store = _default_object_store(filepath)
-    assert prefix == "file://"
+    store = default_object_store(filepath)
     assert isinstance(store, LocalStore)
 
 

--- a/virtualizarr/tests/test_manifests/test_store.py
+++ b/virtualizarr/tests/test_manifests/test_store.py
@@ -20,6 +20,7 @@ from virtualizarr.manifests import (
     ManifestGroup,
     ManifestStore,
 )
+from virtualizarr.manifests.store import _default_object_store
 from virtualizarr.manifests.utils import create_v3_array_metadata
 from virtualizarr.tests import (
     requires_hdf5plugin,
@@ -117,12 +118,34 @@ def s3_store(minio_bucket):
         client_options={"allow_http": True},
     )
     filepath = "data.tmp"
-    prefix = f"s3://{minio_bucket['bucket']}"
+    prefix = f"s3://{minio_bucket['bucket']}/data/"
     return _generate_manifest_store(
         store=store,
         prefix=prefix,
         filepath=filepath,
     )
+
+
+@requires_obstore
+def test_default_object_store_s3(minio_bucket):
+    from obstore.store import S3Store
+
+    filepath = f"s3://{minio_bucket['bucket']}/data/data.tmp"
+    store = _default_object_store(
+        filepath,
+        access_key_id=minio_bucket["username"],
+        secret_access_key=minio_bucket["password"],
+    )
+    assert isinstance(store, S3Store)
+
+
+@requires_obstore
+def test_default_object_store_local(tmpdir):
+    from obstore.store import LocalStore
+
+    filepath = f"{tmpdir}/data.tmp"
+    store = _default_object_store(filepath)
+    assert isinstance(store, LocalStore)
 
 
 @requires_obstore

--- a/virtualizarr/tests/test_manifests/test_store.py
+++ b/virtualizarr/tests/test_manifests/test_store.py
@@ -131,11 +131,12 @@ def test_default_object_store_s3(minio_bucket):
     from obstore.store import S3Store
 
     filepath = f"s3://{minio_bucket['bucket']}/data/data.tmp"
-    store = _default_object_store(
+    prefix, store = _default_object_store(
         filepath,
         access_key_id=minio_bucket["username"],
         secret_access_key=minio_bucket["password"],
     )
+    assert prefix == f"s3://{minio_bucket['bucket']}"
     assert isinstance(store, S3Store)
 
 
@@ -144,7 +145,8 @@ def test_default_object_store_local(tmpdir):
     from obstore.store import LocalStore
 
     filepath = f"{tmpdir}/data.tmp"
-    store = _default_object_store(filepath)
+    prefix, store = _default_object_store(filepath)
+    assert prefix == "file://"
     assert isinstance(store, LocalStore)
 
 

--- a/virtualizarr/tests/test_readers/conftest.py
+++ b/virtualizarr/tests/test_readers/conftest.py
@@ -433,3 +433,20 @@ def cf_array_fill_value_hdf5_file(tmp_path: Path) -> str:
         dset.attrs["_FillValue"] = np.array([np.nan])
 
     return filepath
+
+
+@pytest.fixture()
+def chunked_roundtrip_hdf5_s3_file(minio_bucket, cf_array_fill_value_hdf5_file):
+    import obstore as obs
+
+    store = obs.store.S3Store(
+        minio_bucket["bucket"],
+        aws_endpoint=minio_bucket["endpoint"],
+        access_key_id=minio_bucket["username"],
+        secret_access_key=minio_bucket["password"],
+        virtual_hosted_style_request=False,
+        client_options={"allow_http": True},
+    )
+    filepath = "data/cf_array_fill_value.nc"
+    obs.put(store, filepath, cf_array_fill_value_hdf5_file)
+    return f"s3://{minio_bucket['bucket']}/{filepath}"

--- a/virtualizarr/tests/test_readers/test_hdf/test_hdf_manifest_store.py
+++ b/virtualizarr/tests/test_readers/test_hdf/test_hdf_manifest_store.py
@@ -67,7 +67,6 @@ class TestHDFManifestStore:
         store = HDFVirtualBackend._create_manifest_store(
             filepath=chunked_roundtrip_hdf5_s3_file,
             store=s3store,
-            prefix=f"s3://{minio_bucket}",
         )
         vds = store.to_virtual_dataset()
         assert vds.dims == {"phony_dim_0": 5}

--- a/virtualizarr/tests/test_readers/test_hdf/test_hdf_manifest_store.py
+++ b/virtualizarr/tests/test_readers/test_hdf/test_hdf_manifest_store.py
@@ -6,6 +6,7 @@ from virtualizarr.manifests import ManifestArray
 from virtualizarr.readers.hdf import HDFVirtualBackend
 from virtualizarr.tests import (
     requires_hdf5plugin,
+    requires_minio,
     requires_obstore,
 )
 
@@ -40,6 +41,7 @@ class TestHDFManifestStore:
         )
         xr.testing.assert_allclose(basic_ds, rountripped_ds)
 
+    @requires_minio
     @requires_obstore
     def test_default_store_s3(self, minio_bucket, chunked_roundtrip_hdf5_s3_file):
         store = HDFVirtualBackend._create_manifest_store(

--- a/virtualizarr/tests/test_readers/test_hdf/test_hdf_manifest_store.py
+++ b/virtualizarr/tests/test_readers/test_hdf/test_hdf_manifest_store.py
@@ -41,12 +41,23 @@ class TestHDFManifestStore:
         )
         xr.testing.assert_allclose(basic_ds, rountripped_ds)
 
+    def test_rountrip_simple_virtualdataset_default_store(self, tmpdir, basic_ds):
+        "Roundtrip a dataset to/from NetCDF with the HDF reader and ManifestStore"
+
+        filepath = f"{tmpdir}/basic_ds_roundtrip.nc"
+        basic_ds.to_netcdf(filepath, engine="h5netcdf")
+        store = HDFVirtualBackend._create_manifest_store(filepath=filepath)
+        rountripped_ds = xr.open_dataset(
+            store, engine="zarr", consolidated=False, zarr_format=3
+        )
+        xr.testing.assert_allclose(basic_ds, rountripped_ds)
+
     @requires_minio
     @requires_obstore
     def test_default_store_s3(self, minio_bucket, chunked_roundtrip_hdf5_s3_file):
         store = HDFVirtualBackend._create_manifest_store(
             filepath=chunked_roundtrip_hdf5_s3_file,
-            config={"endpoint": minio_bucket["endpoint"]},
+            config={"endpoint": minio_bucket["endpoint"], "skip_signature": True},
         )
         vds = store.to_virtual_dataset()
         assert vds.dims == {"phony_dim_0": 5}

--- a/virtualizarr/tests/test_readers/test_hdf/test_hdf_manifest_store.py
+++ b/virtualizarr/tests/test_readers/test_hdf/test_hdf_manifest_store.py
@@ -27,14 +27,12 @@ def basic_ds():
 @requires_obstore
 class TestHDFManifestStore:
     def test_rountrip_simple_virtualdataset(self, tmpdir, basic_ds):
-        from obstore.store import LocalStore
-
         "Roundtrip a dataset to/from NetCDF with the HDF reader and ManifestStore"
 
         filepath = f"{tmpdir}/basic_ds_roundtrip.nc"
         basic_ds.to_netcdf(filepath, engine="h5netcdf")
         store = HDFVirtualBackend._create_manifest_store(
-            filepath=filepath, store=LocalStore(), prefix="file://"
+            filepath=filepath,
         )
         rountripped_ds = xr.open_dataset(
             store, engine="zarr", consolidated=False, zarr_format=3

--- a/virtualizarr/utils.py
+++ b/virtualizarr/utils.py
@@ -4,6 +4,7 @@ import importlib
 import io
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Iterable, Optional, Union
+from urllib.parse import urlparse
 
 from zarr.abc.codec import ArrayArrayCodec, BytesBytesCodec
 from zarr.core.metadata import ArrayV2Metadata, ArrayV3Metadata
@@ -28,7 +29,9 @@ class ObstoreReader:
     def __init__(self, store: ObjectStore, path: str) -> None:
         import obstore as obs
 
-        self._reader = obs.open_reader(store, path)
+        parsed = urlparse(path)
+
+        self._reader = obs.open_reader(store, parsed.path)
 
     def read(self, size: int, /) -> bytes:
         return self._reader.read(size).to_bytes()


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
This PR makes it possible to have an empty dict in `ManifestStores._stores` and automatically create an S3Store or LocalStore from a filepath.

Part of https://github.com/zarr-developers/VirtualiZarr/issues/498

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
