### PR TITLE
Separate understanding (data models) from learning (usage) in docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,6 +160,7 @@ cython_debug/
 #.idea/
 virtualizarr/_version.py
 docs/generated/
+docs/jupyter_execute/
 examples/
 
 # Created by https://www.toptal.com/developers/gitignore/api/visualstudiocode

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,3 +22,8 @@ repos:
     rev: ebf0b5e44d67f8beaa1cd13a0d0393ea04c6058d
     hooks:
       - id: validate-cff
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+        args: ["-L", "fo,ihs,kake,te", "-S", "fixture"]

--- a/docs/data_structures.md
+++ b/docs/data_structures.md
@@ -1,0 +1,141 @@
+
+# Data structures
+
+This page explains the data structures available as part of VirtualiZarr today, by introducing the key concepts one-by-one.
+
+## Chunk Manifests
+
+In the Zarr model N-dimensional arrays are stored as a series of compressed chunks, each labelled by a chunk key which indicates its position in the array. Whilst conventionally each of these Zarr chunks are a separate compressed binary file stored within a Zarr Store, there is no reason why these chunks could not actually already exist as part of another file (e.g. a netCDF file), and be loaded by reading a specific byte range from this pre-existing file.
+
+A "Chunk Manifest" is a list of chunk keys and their corresponding byte ranges in specific files, grouped together such that all the chunks form part of one Zarr-like array. For example, a chunk manifest for a 3-dimensional array made up of 4 chunks might look like this:
+
+```python
+{
+    "0.0.0": {"path": "s3://bucket/foo.nc", "offset": 100, "length": 100},
+    "0.0.1": {"path": "s3://bucket/foo.nc", "offset": 200, "length": 100},
+    "0.1.0": {"path": "s3://bucket/foo.nc", "offset": 300, "length": 100},
+    "0.1.1": {"path": "s3://bucket/foo.nc", "offset": 400, "length": 100},
+}
+```
+
+Notice that the `"path"` attribute points to a netCDF file `"foo.nc"` stored in a remote S3 bucket. There is no need for the files the chunk manifest refers to to be local.
+
+The virtual dataset we created in the [usage guide](usage.md) above contains multiple chunk manifests stored in-memory, which we can see by pulling one out as a python dictionary.
+
+```python
+marr = vds['air'].data
+manifest = marr.manifest
+manifest.dict()
+```
+
+```python
+{'0.0.0': {'path': 'file:///work/data/air.nc', 'offset': 15419, 'length': 7738000}}
+```
+
+In this case we can see that the `"air"` variable contains only one chunk, the bytes for which live in the `file:///work/data/air.nc` file, at the location given by the `'offset'` and `'length'` attributes.
+
+The {py:class}`ChunkManifest <virtualizarr.manifests.ChunkManifest>` class is virtualizarr's internal in-memory representation of this manifest.
+
+## `ManifestArray` class
+
+A Zarr array is defined not just by the location of its constituent chunk data, but by its array-level attributes such as `shape` and `dtype`. The {py:class}`ManifestArray <virtualizarr.manifests.ManifestArray>` class stores both the array-level attributes and the corresponding chunk manifest.
+
+```python
+marr
+```
+
+```
+ManifestArray<shape=(2920, 25, 53), dtype=int16, chunks=(2920, 25, 53)>
+```
+
+```python
+marr.manifest
+```
+
+```
+ChunkManifest<shape=(1, 1, 1)>
+```
+
+```python
+marr.metadata
+```
+
+```
+ArrayV3Metadata(shape=(2920, 25, 53),
+                data_type=<DataType.float64: 'float64'>,
+                chunk_grid=RegularChunkGrid(chunk_shape=(2920, 25, 53)),
+                chunk_key_encoding=DefaultChunkKeyEncoding(name='default',
+                                                           separator='/'),
+                fill_value=np.float64(-327.67),
+                codecs=(FixedScaleOffset(codec_name='numcodecs.fixedscaleoffset', codec_config={'scale': 100.0, 'offset': 0, 'dtype': '<f8', 'astype': '<i2'}),
+                        BytesCodec(endian=<Endian.little: 'little'>)),
+                attributes={'GRIB_id': 11,
+                            'GRIB_name': 'TMP',
+                            'actual_range': [185.16000366210938,
+                                             322.1000061035156],
+                            'dataset': 'NMC Reanalysis',
+                            'level_desc': 'Surface',
+                            'long_name': '4xDaily Air temperature at sigma '
+                                         'level 995',
+                            'parent_stat': 'Other',
+                            'precision': 2,
+                            'statistic': 'Individual Obs',
+                            'units': 'degK',
+                            'var_desc': 'Air temperature'},
+                dimension_names=None,
+                zarr_format=3,
+                node_type='array',
+                storage_transformers=())
+```
+
+A `ManifestArray` can therefore be thought of as a virtualized representation of a single Zarr array.
+
+As it defines various array-like methods, a `ManifestArray` can often be treated like a ["duck array"](https://docs.xarray.dev/en/stable/user-guide/duckarrays.html). In particular, concatenation of multiple `ManifestArray` objects can be done via merging their chunk manifests into one (and re-labelling the chunk keys).
+
+```python
+import numpy as np
+
+concatenated = np.concatenate([marr, marr], axis=0)
+concatenated
+```
+
+```
+ManifestArray<shape=(5840, 25, 53), dtype=int16, chunks=(2920, 25, 53)>
+```
+
+```python
+concatenated.manifest.dict()
+```
+
+```
+{'0.0.0': {'path': 'file:///work/data/air.nc', 'offset': 15419, 'length': 7738000},
+ '1.0.0': {'path': 'file:///work/data/air.nc', 'offset': 15419, 'length': 7738000}}
+```
+
+This concatenation property is what will allow us to combine the data from multiple netCDF files on disk into a single Zarr store containing arrays of many chunks.
+
+```{note}
+As a single Zarr array has only one array-level set of compression codecs by definition, concatenation of arrays from files saved to disk with differing codecs cannot be achieved through concatenation of `ManifestArray` objects. Implementing this feature will require a more abstract and general notion of concatenation, see [GH issue #5](https://github.com/zarr-developers/VirtualiZarr/issues/5).
+```
+
+Remember that you cannot load values from a `ManifestArray` directly.
+
+```python
+vds['air'].values
+```
+
+```python
+NotImplementedError: ManifestArrays can't be converted into numpy arrays or pandas Index objects
+```
+
+The whole point is to manipulate references to the data without actually loading any data.
+
+```{note}
+You also cannot currently index into a `ManifestArray`, as arbitrary indexing would require loading data values to create the new array. We could imagine supporting indexing without loading data when slicing only along chunk boundaries, but this has not yet been implemented (see [GH issue #51](https://github.com/zarr-developers/VirtualiZarr/issues/51)).
+```
+
+## Virtual Datasets as Zarr Groups
+
+The full Zarr model (for a single group) includes multiple arrays, array names, named dimensions, and arbitrary dictionary-like attrs on each array. Whilst the duck-typed `ManifestArray` cannot store all of this information, an `xarray.Dataset` wrapping multiple `ManifestArray`s maps neatly to the Zarr model. This is what the virtual dataset we opened represents - all the information in one entire Zarr group, but held as references to on-disk chunks instead of as in-memory arrays.
+
+The problem of combining many archival format files (e.g. netCDF files) into one virtual Zarr store therefore becomes just a matter of opening each file using `open_virtual_dataset` and using [xarray's various combining functions](https://docs.xarray.dev/en/stable/user-guide/combining.html) to combine them into one aggregate virtual dataset.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -15,7 +15,7 @@ The main restrictions of the zarr data model are:
 - **Recognized format** - Firstly, there must be a virtualizarr reader that understands how to parse the file format that your data is in. The VirtualiZarr package ships with readers for a number of common formats, if your data is not supported you may first have to write your own dedicated virtualizarr reader which understands your format.
 - **Rectilinear arrays** - The zarr data model is one of a set of rectilinear arrays, so your data must be decodable as a set of rectilinear arrays, each of which will map to single zarr array (via the `ManifestArray` class). If your data cannot be directly mapped to a rectilinear array, for example because it has inconsistent lengths along a common dimension (known as "ragged data"), then it cannot be virtualized.
 - **Homogeneous chunking** - The zarr data model assumes that every chunk of data in a single array has the same chunk shape. For multi-file datasets each chunk often corresponds to (part of) one file, so if all your files do not have consistent chunking your data cannot be virtualized. This is a big restriction, and there are plans to relax it in future, by adding support for variable-length chunks to the zarr data model.
-- **Homogenous codecs** - The zarr data model assumes that every chunk of data in a single array uses the same set of codecs for compression etc. or multi-file datasets each chunk often corresponds to (part of) one file, so if all your files do not have consistent compression or other codecs your data cannot be virtualized. This is another big restriction, and there are also plans to relax it in the future.
+- **Homogeneous codecs** - The zarr data model assumes that every chunk of data in a single array uses the same set of codecs for compression etc. or multi-file datasets each chunk often corresponds to (part of) one file, so if all your files do not have consistent compression or other codecs your data cannot be virtualized. This is another big restriction, and there are also plans to relax it in the future.
 - **Registered codecs** - The codecs needed to decompress and deserialize your data must be known to zarr. This might require defining and registering a new zarr codec.
 - **Registered data types** - The dtype of your data must be known to zarr. This might require registering a new zarr data type.
 
@@ -92,6 +92,17 @@ You can also use this approach to write a reader that starts from a kerchunk-for
 
 Currently if you want to call your new reader from `virtualizarr.open_virtual_dataset` you would need to open a PR to this repository, but we plan to generalize this system to allow 3rd party libraries to plug in via an entrypoint (see [issue #245](https://github.com/zarr-developers/VirtualiZarr/issues/245)).
 
+### Why would I want to load variables using `loadable_variables`?
+
+Loading variables can be useful in a few scenarios:
+
+1. You need to look at the actual values of a multi-dimensional variable in order to decide what to do next,
+2. You want in-memory indexes to use with `xr.combine_by_coords`,
+3. Storing a variable on-disk as a set of references would be inefficient, e.g. because it's a very small array (saving the values like this is similar to kerchunk's concept of "inlining" data),
+4. The variable has encoding, and the simplest way to decode it correctly is to let xarray's standard decoding machinery load it into memory and apply the decoding,
+5. Some of your variables have inconsistent-length chunks, and you want to be able to concatenate them together. For example you might have multiple virtual datasets with coordinates of inconsistent length (e.g., leap years within multi-year daily data). Loading them allows you to rechunk them however you like.
+
+
 ## How does this actually work?
 
 I'm glad you asked! We can think of the problem of providing virtualized zarr-like access to a set of archival files in some other format as a series of steps:
@@ -148,6 +159,7 @@ Users of Kerchunk may find the following comparison table useful, which shows wh
 | Kerchunk reference format as parquet                                     | `df.refs_to_dataframe(out_dict, "combined.parq")`, then read using an `fsspec` `ReferenceFileSystem` mapper | `ds.virtualize.to_kerchunk('combined.parq', format=parquet')` , then read using an `fsspec` `ReferenceFileSystem` mapper |
 | Zarr v3 store with `manifest.json` files                                 | ❌                                                                                                                                 | `ds.virtualize.to_zarr()`, then read via any Zarr v3 reader which implements the manifest storage transformer ZEP                                |
 | [Icechunk](https://icechunk.io/) store                          | ❌                                                                                                                                 | `ds.virtualize.to_icechunk()`, then read back via xarray (requires zarr-python v3).                                |
+
 
 ## Development
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -81,6 +81,7 @@ usage
 examples
 faq
 api
+data_structures
 releases
 contributing
 core_team_guide

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -26,7 +26,7 @@ The full list of optional dependencies can be seen in the `pyproject.toml` file:
 
 ```{literalinclude} ../pyproject.toml
 :start-at: "[project.optional-dependencies]"
-:end-before: "test ="
+:end-before: "# Dependency sets under dependencies-groups are NOT available via PyPI"
 ```
 
 The compound groups allow you to install multiple sets of dependencies at once, e.g. install every file reader via

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -269,7 +269,7 @@ Internal Changes
   (:pull:`87`) By `Sean Harkins <https://github.com/sharkinsspatial>`_.
 - Support downstream type checking by adding py.typed marker file.
   (:pull:`306`) By `Max Jones <https://github.com/maxrjones>`_.
-- File paths in chunk manifests are now always stored as abolute URIs.
+- File paths in chunk manifests are now always stored as absolute URIs.
   (:pull:`243`) By `Tom Nicholas <https://github.com/TomNicholas>`_.
 
 .. _v1.1.0:
@@ -294,7 +294,7 @@ New Features
   By `Gustavo Hidalgo <https://github.com/ghidalgo3>`_.
 - Support empty files (:pull:`260`)
   By `Justus Magin <https://github.com/keewis>`_.
-- Can write virtual datasets to Icechunk stores using `vitualize.to_icechunk` (:pull:`256`)
+- Can write virtual datasets to Icechunk stores using `virtualize.to_icechunk` (:pull:`256`)
   By `Matt Iannucci <https://github.com/mpiannucci>`_.
 
 Breaking changes

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -30,7 +30,7 @@ vds = open_virtual_dataset('air.nc')
 We did not have to explicitly indicate the file format because {py:func}`open_virtual_dataset <virtualizarr.open_virtual_dataset>` will attempt to automatically infer it.
 ```
 
-Printing this "virtual dataset" shows that although it is an instance of `xarray.Dataset`, unlike a typical xarray dataset, in addition to a few in-memory numpy arrays, it also wraps {py:class}`ManifestArray <virtualizarr.manifests.ManifestArray>` objects.
+Printing this "virtual dataset" shows that although it is an instance of `xarray.Dataset`, unlike a typical xarray dataset, in addition to a few in-memory numpy arrays, it also wraps {py:class}`ManifestArray <virtualizarr.manifests.ManifestArray>` objects. You can learn more about the `ManifestArray` class in the [Data Structures documentation](data_structures.md).
 
 ```python
 vds

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -93,7 +93,8 @@ vds = open_virtual_dataset("s3://some-bucket/file.nc", reader_options={'storage_
 
 ## Loading variables
 
-Once a virtual dataset is created, you won't be able to load the values of the virtual variables into memory. Instead, you could load specific variables during virtual dataset creation using the regular syntax of `xr.open_dataset`.
+Once a virtual dataset is created, you won't be able to load the values of the virtual variables into memory. Instead, you could load specific variables during virtual dataset creation using the regular syntax of `xr.open_dataset`. Loading
+the variables during virtual dataset creation has several benefits detailed in the [FAQ](faq.md#why-would-i-want-to-load-variables-using-loadable-variables).
 
 You can use the `loadable_variables` argument to specify variables to load as regular variables rather than virtual variables:
 

--- a/examples/coiled/terraclimate.ipynb
+++ b/examples/coiled/terraclimate.ipynb
@@ -32,7 +32,7 @@
    "source": [
     "## Installation and environment\n",
     "\n",
-    "You should install the Python requirements in a clean virtual environment of your choice. Each coiled serverless function will re-use this environment, so it's best to start with a clean slate.\n",
+    "You should install the Python requirements in a clean virtual environment of your choice. Each coiled serverless function will reuse this environment, so it's best to start with a clean slate.\n",
     "\n",
     "```bash\n",
     "pip install 'virtualizarr['icechunk','hdf']' coiled ipykernel bokeh\n",

--- a/examples/mursst-icechunk-with-lithops/README.md
+++ b/examples/mursst-icechunk-with-lithops/README.md
@@ -4,7 +4,7 @@ This package provides functionality for processing MUR SST (Multi-scale Ultra-hi
 
 ## Environment + Lithops Setup
 
-1. Set up a Python environment. The below example uses [`uv`](https://docs.astral.sh/uv/), but other environment mangers should work as well:
+1. Set up a Python environment. The below example uses [`uv`](https://docs.astral.sh/uv/), but other environment managers should work as well:
 
 ```sh
 uv venv virtualizarr-lithops --python 3.11
@@ -19,7 +19,7 @@ uv pip install -r requirements.txt
 4. Check and modify as necessary compute and storage backends for [lithops](https://lithops-cloud.github.io/docs/source/configuration.html) in `lithops.yaml`.
 
 
-5. Build the lithops lambda runtime if it does not exist in your target AWS environemnt.
+5. Build the lithops lambda runtime if it does not exist in your target AWS environment.
 ```bash
 export LITHOPS_CONFIG_FILE=$(pwd)/lithops.yaml
 lithops runtime build -b aws_lambda -f Dockerfile vz-runtime

--- a/examples/mursst-icechunk-with-lithops/ec2_for_lithops_runtime/README.md
+++ b/examples/mursst-icechunk-with-lithops/ec2_for_lithops_runtime/README.md
@@ -1,6 +1,6 @@
 # Launch and use an EC2 for building the Lithops lambda runtime
 
-The scripts in this directy will help to launch and set up an ec2 so that you can build and push a lithops lambda runtime.
+The scripts in this directly will help to launch and set up an ec2 so that you can build and push a lithops lambda runtime.
 
 You will need AWS console and CLI access.
 

--- a/virtualizarr/manifests/array_api.py
+++ b/virtualizarr/manifests/array_api.py
@@ -204,7 +204,7 @@ def broadcast_to(x: "ManifestArray", /, shape: tuple[int, ...]) -> "ManifestArra
             f"array of shape {x.shape} cannot be broadcast to shape {new_shape}"
         )
 
-    # new chunk_shape is old chunk_shape with singleton dimensions pre-pended
+    # new chunk_shape is old chunk_shape with singleton dimensions prepended
     # (chunk shape can never change by more than adding length-1 axes because each chunk represents a fixed number of array elements)
     old_chunk_shape = x.chunks
     new_chunk_shape = _prepend_singleton_dimensions(

--- a/virtualizarr/manifests/manifest.py
+++ b/virtualizarr/manifests/manifest.py
@@ -70,7 +70,7 @@ def validate_and_normalize_path_to_uri(path: str, fs_root: str | None = None) ->
         # (empty paths are allowed through as they represent missing chunks)
         return path
 
-    # TODO ideally we would just use cloudpathlib.AnyPath to handle all types of paths but that would require extra depedencies, see https://github.com/drivendataorg/cloudpathlib/issues/489#issuecomment-2504725280
+    # TODO ideally we would just use cloudpathlib.AnyPath to handle all types of paths but that would require extra dependencies, see https://github.com/drivendataorg/cloudpathlib/issues/489#issuecomment-2504725280
 
     if path.startswith("http://") or path.startswith("https://"):
         # hopefully would raise if given a malformed URL
@@ -373,7 +373,7 @@ class ChunkManifest:
         path = self._paths[indices]
         offset = self._offsets[indices]
         length = self._lengths[indices]
-        # TODO fix bug here - types of path, offset, length shoudl be coerced
+        # TODO fix bug here - types of path, offset, length should be coerced
         return ChunkEntry(path=path, offset=offset, length=length)
 
     def __iter__(self) -> Iterator[ChunkKey]:

--- a/virtualizarr/readers/dmrpp.py
+++ b/virtualizarr/readers/dmrpp.py
@@ -116,7 +116,7 @@ class DMRParser:
         Parameters
         ----------
         root: xml.ElementTree.Element
-            Root of the xml tree struture of a DMR++ file.
+            Root of the xml tree structure of a DMR++ file.
         data_filepath : str, optional
             The path to the actual data file that will be set in the chunk manifests.
             If None, the data file path is taken from the DMR++ file.
@@ -280,7 +280,7 @@ class DMRParser:
         for c in coord_tags:
             if c.text is not None:
                 coord_names.update(c.text.split(" "))
-        # Seperate and parse coords + data variables
+        # Separate and parse coords + data variables
         coord_vars: dict[str, Variable] = {}
         data_vars: dict[str, Variable] = {}
         for var_tag in self._find_var_tags(root):

--- a/virtualizarr/readers/kerchunk.py
+++ b/virtualizarr/readers/kerchunk.py
@@ -69,7 +69,7 @@ class KerchunkVirtualBackend(VirtualBackend):
             lrm = LazyReferenceMapper(filepath, fs.fs)
 
             # build reference dict from KV pairs in LazyReferenceMapper
-            # is there a better / more preformant way to extract this?
+            # is there a better / more performant way to extract this?
             array_refs = {k: lrm[k] for k in lrm.keys()}
 
             full_reference = {"refs": array_refs}

--- a/virtualizarr/tests/test_writers/test_icechunk.py
+++ b/virtualizarr/tests/test_writers/test_icechunk.py
@@ -292,7 +292,7 @@ def test_write_loadable_variable(
         data=np.random.rand(3, 4),
         attrs={"units": "km"},
     )
-    vds = xr.Dataset({"air": la_v}, {"pres": ma_v})
+    vds = xr.Dataset({"air": la_v}, {"pressure": ma_v})
 
     # Icechunk checksums currently store with second precision, so we need to make sure
     # the checksum_date is at least one second in the future
@@ -307,14 +307,14 @@ def test_write_loadable_variable(
     assert air_array.attrs["units"] == "km"
     npt.assert_equal(air_array[:], la_v[:])
 
-    pres_array = root_group["pres"]
-    assert isinstance(pres_array, zarr.Array)
-    assert pres_array.shape == (3, 4)
-    assert pres_array.dtype == np.dtype("int32")
+    pressure_array = root_group["pressure"]
+    assert isinstance(pressure_array, zarr.Array)
+    assert pressure_array.shape == (3, 4)
+    assert pressure_array.dtype == np.dtype("int32")
 
     with xr.open_dataset(simple_netcdf4) as expected_ds:
         expected_array = expected_ds["foo"].to_numpy()
-        npt.assert_equal(pres_array, expected_array)
+        npt.assert_equal(pressure_array, expected_array)
 
 
 def test_checksum(
@@ -346,7 +346,7 @@ def test_checksum(
 
     ma_v = xr.Variable(data=ma, dims=["x", "y"])
 
-    vds = xr.Dataset({"pres": ma_v})
+    vds = xr.Dataset({"pressure": ma_v})
 
     # Icechunk checksums currently store with second precision, so we need to make sure
     # the checksum_date is at least one second in the future
@@ -358,14 +358,14 @@ def test_checksum(
         vds.virtualize.to_icechunk(icechunk_filestore, last_updated_at="not a datetime")  # type: ignore
 
     root_group = zarr.group(store=icechunk_filestore)
-    pres_array = root_group["pres"]
-    assert isinstance(pres_array, zarr.Array)
-    assert pres_array.shape == (3, 4)
-    assert pres_array.dtype == np.dtype("int32")
+    pressure_array = root_group["pressure"]
+    assert isinstance(pressure_array, zarr.Array)
+    assert pressure_array.shape == (3, 4)
+    assert pressure_array.dtype == np.dtype("int32")
 
     with xr.open_dataset(netcdf_path) as expected_ds:
         expected_array = expected_ds["foo"].to_numpy()
-        npt.assert_equal(pres_array, expected_array)
+        npt.assert_equal(pressure_array, expected_array)
 
     # Now we can overwrite the simple_netcdf4 file with new data to make sure that
     # the checksum_date is being used to determine if the data is valid
@@ -378,9 +378,9 @@ def test_checksum(
     # Now if we try to read the data back in, it should fail because the checksum_date
     # is newer than the last_updated_at
     with pytest.raises(IcechunkError):
-        pres_array = root_group["pres"]
-        assert isinstance(pres_array, zarr.Array)
-        npt.assert_equal(pres_array, arr)
+        pressure_array = root_group["pressure"]
+        assert isinstance(pressure_array, zarr.Array)
+        npt.assert_equal(pressure_array, arr)
 
 
 def test_generate_chunk_key_no_offset():


### PR DESCRIPTION
This PR moves the understanding oriented documentation to a separate data structures page to keep the usage guide focused on practical activities, following the [Diátaxis framework](https://diataxis.fr/).
