### PR TITLE
Allows the zarr_reader to use the new Obstore functionallity released in `zarr-python 3.0.7` 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,7 +227,7 @@ module = [
     "minio",
     "numcodecs.*",
     "ujson",
-    "zarr",
+    "zarr>=3.0.7",
     "requests",
 ]
 ignore_missing_imports = true

--- a/virtualizarr/manifests/store.py
+++ b/virtualizarr/manifests/store.py
@@ -145,7 +145,8 @@ def default_object_store(filepath: str) -> ObjectStore:
     parsed = urlparse(filepath)
 
     if parsed.scheme in ["", "file"]:
-        return obs.store.LocalStore()
+        return obs.store.LocalStore(parsed.path)
+
     if parsed.scheme == "s3":
         bucket = parsed.netloc
         return obs.store.S3Store(


### PR DESCRIPTION
- [ ] Towards https://github.com/zarr-developers/VirtualiZarr/issues/565
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation

cc @maxrjones 

