### PR TITLE
Improve indexing errors

### DIFF
--- a/virtualizarr/manifests/array.py
+++ b/virtualizarr/manifests/array.py
@@ -225,9 +225,15 @@ class ManifestArray:
         """
         from xarray.core.indexing import BasicIndexer
 
+        # check type is valid
         if isinstance(key, BasicIndexer):
             indexer = key.tuple
         elif isinstance(key, (int, slice, EllipsisType, np.ndarray)) or key is None:
+            if isinstance(key, np.ndarray):
+                raise NotImplementedError(
+                    f"indexing with so-called 'fancy indexing' via numpy arrays is not supported. Got {key}"
+                )
+
             indexer = (key,)
         elif isinstance(key, tuple):
             for dim_indexer in key:
@@ -238,14 +244,20 @@ class ManifestArray:
                     raise TypeError(
                         f"indexer must be of type int, slice, ellipsis, None, or np.ndarray; or a tuple of such types. Got {key}"
                     )
+
+                if isinstance(key, np.ndarray):
+                    raise NotImplementedError(
+                        f"indexing with so-called 'fancy indexing' via numpy arrays is not supported. Got {key}"
+                    )
+
             indexer = key
         else:
             raise TypeError(
                 f"indexer must be of type int, slice, ellipsis, None, or np.ndarray; or a tuple of such types. Got {key}"
             )
 
+        # check value is valid
         indexer = _possibly_expand_trailing_ellipsis(indexer, self.ndim)
-
         if len(indexer) != self.ndim:
             raise ValueError(
                 f"Invalid indexer for array with ndim={self.ndim}: {indexer}"

--- a/virtualizarr/manifests/array.py
+++ b/virtualizarr/manifests/array.py
@@ -225,6 +225,7 @@ class ManifestArray:
         """
         from xarray.core.indexing import BasicIndexer
 
+        indexer: tuple[Union[int, slice, EllipsisType, None, np.ndarray], ...]
         # check type is valid
         if isinstance(key, BasicIndexer):
             indexer = key.tuple
@@ -356,7 +357,7 @@ def _possibly_expand_trailing_ellipsis(
             raise ValueError(f"Invalid indexer for array with ndim={ndim}: {indexer}")
 
         extra_slices_needed = ndim - (len(indexer) - 1)
-        *indexer, ellipsis = indexer
-        return tuple(tuple(indexer) + (slice(None),) * extra_slices_needed)
+        *indexer_as_list, ellipsis = indexer
+        return tuple(tuple(indexer_as_list) + (slice(None),) * extra_slices_needed)
     else:
         return indexer

--- a/virtualizarr/tests/test_manifests/test_array.py
+++ b/virtualizarr/tests/test_manifests/test_array.py
@@ -386,6 +386,15 @@ def test_refuse_combine(array_v3_metadata):
             func([marr1, marr2], axis=0)
 
 
+class TestIndexing:
+    @pytest.mark.parametrize("dodgy_indexer", ["string", [], (5, "string")])
+    def test_invalid_indexer_types(self, manifest_array, dodgy_indexer):
+        marr = manifest_array(shape=(4,), chunks=(2,))
+
+        with pytest.raises(TypeError, match="indexer must be of type"):
+            marr[dodgy_indexer]
+
+
 def test_to_xarray(array_v3_metadata):
     chunks = (5, 10)
     shape = (5, 20)

--- a/virtualizarr/tests/test_manifests/test_array.py
+++ b/virtualizarr/tests/test_manifests/test_array.py
@@ -394,6 +394,13 @@ class TestIndexing:
         with pytest.raises(TypeError, match="indexer must be of type"):
             marr[dodgy_indexer]
 
+    @pytest.mark.parametrize("dodgy_indexer", [(5, 4), (5, ...)])
+    def test_invalid_indexer_shape(self, manifest_array, dodgy_indexer):
+        marr = manifest_array(shape=(4,), chunks=(2,))
+
+        with pytest.raises(ValueError, match="Invalid indexer for array with ndim"):
+            marr[dodgy_indexer]
+
 
 def test_to_xarray(array_v3_metadata):
     chunks = (5, 10)

--- a/virtualizarr/tests/test_manifests/test_array.py
+++ b/virtualizarr/tests/test_manifests/test_array.py
@@ -401,6 +401,13 @@ class TestIndexing:
         with pytest.raises(ValueError, match="Invalid indexer for array with ndim"):
             marr[dodgy_indexer]
 
+    @pytest.mark.parametrize("dodgy_indexer", [np.ndarray(5)])
+    def test_index_with_numpy_array_notimplemented(self, manifest_array, dodgy_indexer):
+        marr = manifest_array(shape=(4,), chunks=(2,))
+
+        with pytest.raises(NotImplementedError):
+            marr[dodgy_indexer]
+
 
 def test_to_xarray(array_v3_metadata):
     chunks = (5, 10)


### PR DESCRIPTION
Improves error reporting in unsupported indexing cases, which can happen when trying to do complex xarray concatenations.

- [ ] Closes #xxxx
- [x] Tests added
- [x] Tests passing
- [x] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] ~~New functions/methods are listed in `api.rst`~~
- [ ] ~~New functionality has documentation~~
