### PR TITLE
Add requires_network decorator to tests that were missing it

### DIFF
--- a/virtualizarr/tests/test_manifests/test_store.py
+++ b/virtualizarr/tests/test_manifests/test_store.py
@@ -27,8 +27,8 @@ from virtualizarr.tests import (
     requires_hdf5plugin,
     requires_imagecodecs,
     requires_minio,
-    requires_obstore,
     requires_network,
+    requires_obstore,
 )
 
 if TYPE_CHECKING:

--- a/virtualizarr/tests/test_manifests/test_store.py
+++ b/virtualizarr/tests/test_manifests/test_store.py
@@ -28,6 +28,7 @@ from virtualizarr.tests import (
     requires_imagecodecs,
     requires_minio,
     requires_obstore,
+    requires_network,
 )
 
 if TYPE_CHECKING:
@@ -161,6 +162,7 @@ def test_default_object_store_local(tmpdir):
     assert isinstance(store, LocalStore)
 
 
+@requires_network
 @requires_obstore
 def test_default_region_raises():
     file = "s3://cworthy/oae-efficiency-atlas/data/experiments/000/01/alk-forcing.000-1999-01.pop.h.0347-01.nc"

--- a/virtualizarr/tests/test_readers/test_hdf/test_hdf_manifest_store.py
+++ b/virtualizarr/tests/test_readers/test_hdf/test_hdf_manifest_store.py
@@ -7,8 +7,8 @@ from virtualizarr.readers.hdf import HDFVirtualBackend
 from virtualizarr.tests import (
     requires_hdf5plugin,
     requires_minio,
-    requires_obstore,
     requires_network,
+    requires_obstore,
 )
 
 

--- a/virtualizarr/tests/test_readers/test_hdf/test_hdf_manifest_store.py
+++ b/virtualizarr/tests/test_readers/test_hdf/test_hdf_manifest_store.py
@@ -8,6 +8,7 @@ from virtualizarr.tests import (
     requires_hdf5plugin,
     requires_minio,
     requires_obstore,
+    requires_network,
 )
 
 
@@ -72,6 +73,7 @@ class TestHDFManifestStore:
         assert vds.dims == {"phony_dim_0": 5}
         assert isinstance(vds["data"].data, ManifestArray)
 
+    @requires_network
     @requires_obstore
     def test_default_store(self):
         store = HDFVirtualBackend._create_manifest_store(


### PR DESCRIPTION
The test suite was failing on a local machine without an internet connection - this fixes it.
