### PR TITLE
Fix upstream tests by removing fsspec pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,6 @@ upstream = [
     'zarr @ git+https://github.com/zarr-developers/zarr-python',
     # optional dependencies
     'astropy @ git+https://github.com/astropy/astropy',
-    'fsspec @ git+https://github.com/fsspec/filesystem_spec',
     's3fs @ git+https://github.com/fsspec/s3fs',
     'kerchunk @ git+https://github.com/fsspec/kerchunk',
     'icechunk @ git+https://github.com/earth-mover/icechunk#subdirectory=icechunk-python',


### PR DESCRIPTION
Fixing dependency resolution, See https://github.com/fsspec/s3fs/pull/966 for context