### PR TITLE
Suppress numcodecs not in spec warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -304,3 +304,6 @@ markers = [
     "network: marks test requiring internet (select with '--run-network-tests')",
     "minio: marks test requiring docker and minio (select with '--run-minio-tests')",
 ]
+filterwarnings = [
+    "ignore:Numcodecs codecs are not in the Zarr version 3 specification*:UserWarning:numcodecs"
+]

--- a/virtualizarr/tests/test_backend.py
+++ b/virtualizarr/tests/test_backend.py
@@ -162,7 +162,7 @@ def test_cftime_index(tmp_path: Path, hdf_backend: type[VirtualBackend]):
         # TODO use xr.testing.assert_identical(vds.indexes, ds.indexes) instead once class supported by assertion comparison, see https://github.com/pydata/xarray/issues/5812
         assert index_mappings_equal(vds.xindexes, ds.xindexes)
         assert list(ds.coords) == list(vds.coords)
-        assert vds.dims == ds.dims
+        assert vds.sizes == ds.sizes
         assert vds.attrs == ds.attrs
 
 
@@ -229,7 +229,7 @@ class TestReadFromS3:
             reader_options={"storage_options": {"anon": True}},
             backend=hdf_backend,
         ) as vds:
-            assert vds.dims == {"time": 2920, "lat": 25, "lon": 53}
+            assert vds.sizes == {"time": 2920, "lat": 25, "lon": 53}
 
             assert isinstance(vds["air"].data, ManifestArray)
             for name in ["time", "lat", "lon"]:

--- a/virtualizarr/tests/test_readers/test_hdf/test_hdf_manifest_store.py
+++ b/virtualizarr/tests/test_readers/test_hdf/test_hdf_manifest_store.py
@@ -86,7 +86,7 @@ class TestHDFManifestStore:
             store=s3store,
         )
         vds = store.to_virtual_dataset()
-        assert vds.dims == {"phony_dim_0": 5}
+        assert vds.sizes == {"phony_dim_0": 5}
         assert isinstance(vds["data"].data, ManifestArray)
 
     @requires_network
@@ -96,7 +96,7 @@ class TestHDFManifestStore:
             filepath="s3://carbonplan-share/virtualizarr/local.nc",
         )
         vds = store.to_virtual_dataset()
-        assert vds.dims == {"time": 2920, "lat": 25, "lon": 53}
+        assert vds.sizes == {"time": 2920, "lat": 25, "lon": 53}
         assert isinstance(vds["air"].data, ManifestArray)
         for name in ["time", "lat", "lon"]:
             assert isinstance(vds[name].data, np.ndarray)

--- a/virtualizarr/tests/test_readers/test_zarr.py
+++ b/virtualizarr/tests/test_readers/test_zarr.py
@@ -48,7 +48,7 @@ class TestOpenVirtualDatasetZarr:
 
         # check dims and coords are present
         assert set(vds.coords) == set(non_var_arrays)
-        assert set(vds.dims) == set(non_var_arrays)
+        assert set(vds.sizes) == set(non_var_arrays)
         # check vars match
         assert set(vds.keys()) == set(["air"])
 


### PR DESCRIPTION
Don't log the 100+ warnings about Numcodecs codecs not being included in the Zarr version 3 specification. Also use ds.sizes over ds.dims where appropriate.