### PR TITLE
Remove default_object_store and support PrefixStore

### DIFF
--- a/virtualizarr/parsers/hdf/hdf.py
+++ b/virtualizarr/parsers/hdf/hdf.py
@@ -19,7 +19,7 @@ from virtualizarr.manifests import (
     ManifestGroup,
     ManifestStore,
 )
-from virtualizarr.manifests.store import ObjectStoreRegistry
+from virtualizarr.manifests.store import ObjectStoreRegistry, get_store_prefix
 from virtualizarr.manifests.utils import create_v3_array_metadata
 from virtualizarr.parsers.hdf.filters import codecs_from_dataset
 from virtualizarr.parsers.utils import encode_cf_fill_value
@@ -163,7 +163,7 @@ class Parser:
             group=self.group,
             drop_variables=self.drop_variables,
         )
-        registry = ObjectStoreRegistry({file_url: object_store})
+        registry = ObjectStoreRegistry({get_store_prefix(file_url): object_store})
         # Convert to a manifest store
         return ManifestStore(store_registry=registry, group=manifest_group)
 

--- a/virtualizarr/tests/test_manifests/test_store.py
+++ b/virtualizarr/tests/test_manifests/test_store.py
@@ -21,13 +21,11 @@ from virtualizarr.manifests import (
     ManifestStore,
     ObjectStoreRegistry,
 )
-from virtualizarr.manifests.store import default_object_store
 from virtualizarr.manifests.utils import create_v3_array_metadata
 from virtualizarr.tests import (
     requires_hdf5plugin,
     requires_imagecodecs,
     requires_minio,
-    requires_network,
     requires_obstore,
 )
 
@@ -127,49 +125,6 @@ def s3_store(minio_bucket):
         prefix=prefix,
         filepath=filepath,
     )
-
-
-@requires_obstore
-@requires_minio
-def test_default_object_store_s3(minio_bucket):
-    from obstore.store import S3Store
-
-    filepath = f"s3://{minio_bucket['bucket']}/data/data.tmp"
-    store = default_object_store(
-        filepath,
-    )
-    assert isinstance(store, S3Store)
-
-
-@requires_obstore
-@requires_minio
-def test_default_object_store_http(minio_bucket):
-    from obstore.store import HTTPStore
-
-    filepath = minio_bucket["endpoint"]
-    store = default_object_store(
-        filepath,
-    )
-    assert isinstance(store, HTTPStore)
-
-
-@requires_obstore
-def test_default_object_store_local(tmpdir):
-    from obstore.store import LocalStore
-
-    filepath = f"{tmpdir}/data.tmp"
-    store = default_object_store(filepath)
-    assert isinstance(store, LocalStore)
-
-
-@requires_network
-@requires_obstore
-def test_default_region_raises():
-    file = "s3://cworthy/oae-efficiency-atlas/data/experiments/000/01/alk-forcing.000-1999-01.pop.h.0347-01.nc"
-    with pytest.raises(
-        ValueError, match="Unable to automatically determine region for bucket*"
-    ):
-        default_object_store(file)
 
 
 @requires_obstore

--- a/virtualizarr/tests/test_parsers/test_hdf/test_hdf_manifest_store.py
+++ b/virtualizarr/tests/test_parsers/test_hdf/test_hdf_manifest_store.py
@@ -107,3 +107,6 @@ class TestHDFManifestStore:
         vds = manifest_store.to_virtual_dataset()
         assert vds.dims == {"phony_dim_0": 5}
         assert isinstance(vds["data"].data, ManifestArray)
+        assert xr.open_dataset(
+            manifest_store, engine="zarr", consolidated=False, zarr_format=3
+        ).load()

--- a/virtualizarr/utils.py
+++ b/virtualizarr/utils.py
@@ -30,7 +30,14 @@ class ObstoreReader:
         import obstore as obs
 
         parsed = urlparse(path)
-        filepath = os.path.basename(parsed.path)
+        if (
+            isinstance(store, obs.store.HTTPStore)
+            or isinstance(store, obs.store.MemoryStore)
+            or store.prefix
+        ):
+            filepath = os.path.basename(parsed.path)
+        else:
+            filepath = parsed.path
 
         self._reader = obs.open_reader(store, filepath)
 


### PR DESCRIPTION
This is a PR to @sharkinsspatial's branch to better support prefix stores and remove default_object_store to better indentify issues with loadable variables