### PR TITLE
Support ManifestArray expansion via None in the indexer

### DIFF
--- a/virtualizarr/manifests/array.py
+++ b/virtualizarr/manifests/array.py
@@ -277,7 +277,7 @@ class ManifestArray:
                     output_arr = expand_dims(output_arr, axis=ind)
                 elif axis_indexer != slice(None):
                     raise NotImplementedError(f"Doesn't support slicing with {indexer}")
-                return output_arr
+            return output_arr
 
     def rename_paths(
         self,


### PR DESCRIPTION
This PR adds ManifestArray support this component of the array API:
> Each None in the selection tuple must expand the dimensions of the resulting selection by one dimension of size 1. The position of the added dimension must be the same as the position of None in the selection tuple.

Fixes #596 

