### PR TITLE
Zarr data types refactor compatibility

### DIFF
--- a/virtualizarr/tests/test_parsers/test_fits.py
+++ b/virtualizarr/tests/test_parsers/test_fits.py
@@ -11,9 +11,6 @@ pytest.importorskip("astropy")
 
 @requires_kerchunk
 @requires_network
-@pytest.mark.xfail(
-    reason="Big endian not yet supported by zarr-python 3.0"
-)  # https://github.com/zarr-developers/zarr-python/issues/2324
 def test_open_hubble_data():
     # data from https://registry.opendata.aws/hst/
     file_url = "s3://stpubdata/hst/public/f05i/f05i0201m/f05i0201m_a1f.fits"

--- a/virtualizarr/tests/test_parsers/test_hdf/test_hdf.py
+++ b/virtualizarr/tests/test_parsers/test_hdf/test_hdf.py
@@ -221,7 +221,6 @@ class TestOpenVirtualDataset:
         ) as vds:
             assert set(vds.coords) == {"lat", "lon"}
 
-    @pytest.mark.xfail(reason="Requires Zarr v3 big endian dtype support")
     def test_big_endian(
         self,
         big_endian_dtype_hdf5_file,

--- a/virtualizarr/tests/test_parsers/test_netcdf3.py
+++ b/virtualizarr/tests/test_parsers/test_netcdf3.py
@@ -10,9 +10,6 @@ from virtualizarr.tests.utils import obstore_http, obstore_local
 
 
 @requires_scipy
-@pytest.mark.xfail(
-    reason="Big endian not yet supported by zarr-python 3.0"
-)  # https://github.com/zarr-developers/zarr-python/issues/2324
 def test_read_netcdf3(netcdf3_file, array_v3_metadata):
     filepath = str(netcdf3_file)
     store = obstore_local(file_url=filepath)
@@ -37,9 +34,6 @@ def test_read_netcdf3(netcdf3_file, array_v3_metadata):
 
 
 @requires_network
-@pytest.mark.xfail(
-    reason="Big endian not yet supported by zarr-python 3.0"
-)  # https://github.com/zarr-developers/zarr-python/issues/2324
 def test_read_http_netcdf3(array_v3_metadata):
     file_url = "https://github.com/pydata/xarray-data/raw/master/air_temperature.nc"
     store = obstore_http(file_url=file_url)


### PR DESCRIPTION
Supercedes #545 now that https://github.com/zarr-developers/zarr-python/pull/2874 has been merged upstream.

The upstream changes are already being tested (and unsurprisingly causing some issues - see also #617) in our upstream dev CI tests. But here we will x-fail stuff, start trying to fix things, and bump required dependencies.

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation

FYI @d-v-b