### PR TITLE
Move Parser definition to new parser.typing module

### DIFF
--- a/virtualizarr/parsers/__init__.py
+++ b/virtualizarr/parsers/__init__.py
@@ -1,10 +1,3 @@
-from __future__ import annotations
-
-from typing import Protocol, runtime_checkable
-
-from obstore.store import ObjectStore
-
-from virtualizarr.manifests import ManifestStore
 from virtualizarr.parsers.dmrpp import DMRPPParser
 from virtualizarr.parsers.fits import FITSParser
 from virtualizarr.parsers.hdf.hdf import HDFParser
@@ -22,30 +15,3 @@ __all__ = [
     "KerchunkParquetParser",
     "ZarrParser",
 ]
-
-
-@runtime_checkable
-class Parser(Protocol):
-    def __call__(
-        self,
-        file_url: str,
-        object_store: ObjectStore,
-    ) -> ManifestStore: ...
-
-    """
-    Parse the contents of a given file to produce a ManifestStore.
-
-    Effectively maps the contents of the file (e.g. metadata, compression codecs, chunk byte offsets) to the Zarr data model.
-
-    Parameters
-    ----------
-    file_url
-        The URI or path to the input file (e.g., "s3://bucket/file.nc").
-    object_store
-        An obstore ObjectStore instance for accessing the file specified in the `file_url` parameter.
-
-    Returns
-    -------
-    ManifestStore
-        A ManifestStore which provides a Zarr representation of the parsed file.
-    """

--- a/virtualizarr/parsers/typing.py
+++ b/virtualizarr/parsers/typing.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from obstore.store import ObjectStore
+
+from virtualizarr.manifests import ManifestStore
+
+
+@runtime_checkable
+class Parser(Protocol):
+    def __call__(
+        self,
+        file_url: str,
+        object_store: ObjectStore,
+    ) -> ManifestStore: ...
+
+    """
+    Parse the contents of a given file to produce a ManifestStore.
+
+    Effectively maps the contents of the file (e.g. metadata, compression codecs, chunk byte offsets) to the Zarr data model.
+
+    Parameters
+    ----------
+    file_url
+        The URI or path to the input file (e.g., "s3://bucket/file.nc").
+    object_store
+        An obstore ObjectStore instance for accessing the file specified in the `file_url` parameter.
+
+    Returns
+    -------
+    ManifestStore
+        A ManifestStore which provides a Zarr representation of the parsed file.
+    """


### PR DESCRIPTION
The targeted PR that #619 should have been. All this does is move where `Parser` is defined to `virtualizarr.parsers.typing`. This PR doesn't touch any docs, so shouldn't conflict with #615. #619 should be merged after this one.

- [x] Closes #616
- [ ] ~~Tests added~~
- [ ] Tests passing
- [x] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
