### PR TITLE
Only expose manifest classes behind `.manifest` namespace

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -32,8 +32,8 @@ If you want to write a new reader to create virtual references pointing to a cus
 
 VirtualiZarr uses these classes to store virtual references internally.
 
-::: virtualizarr.ChunkManifest
-::: virtualizarr.ManifestArray
+::: virtualizarr.manifests.ChunkManifest
+::: virtualizarr.manifests.ManifestArray
 
 #### Array API
 

--- a/docs/data_structures.md
+++ b/docs/data_structures.md
@@ -43,7 +43,7 @@ The [virtualizarr.ChunkManifest][] class is virtualizarr's internal in-memory re
 ## `ManifestArray` class
 
 A Zarr array is defined not just by the location of its constituent chunk data, but by its array-level attributes such as `shape` and `dtype`.
-The [virtualizarr.ManifestArray][] class stores both the array-level attributes and the corresponding chunk manifest.
+The [virtualizarr.manifests.ManifestArray][] class stores both the array-level attributes and the corresponding chunk manifest.
 
 ```python
 marr

--- a/virtualizarr/__init__.py
+++ b/virtualizarr/__init__.py
@@ -4,7 +4,6 @@ from virtualizarr.accessor import (
     VirtualiZarrDatasetAccessor,
     VirtualiZarrDataTreeAccessor,
 )
-from virtualizarr.manifests import ChunkManifest, ManifestArray
 from virtualizarr.xarray import open_virtual_dataset, open_virtual_mfdataset
 
 try:
@@ -15,8 +14,6 @@ except Exception:
     __version__ = "9999"
 
 __all__ = [
-    "ChunkManifest",
-    "ManifestArray",
     "VirtualiZarrDatasetAccessor",
     "VirtualiZarrDataTreeAccessor",
     "open_virtual_dataset",

--- a/virtualizarr/manifests/__init__.py
+++ b/virtualizarr/manifests/__init__.py
@@ -5,3 +5,10 @@ from virtualizarr.manifests.array import ManifestArray  # type: ignore # noqa
 from virtualizarr.manifests.group import ManifestGroup  # type: ignore # noqa
 from virtualizarr.manifests.manifest import ChunkEntry, ChunkManifest  # type: ignore # noqa
 from virtualizarr.manifests.store import ManifestStore, ObjectStoreRegistry  # type: ignore # noqa
+
+__all__ = [
+    "ChunkManifest",
+    "ManifestArray",
+    "ManifestGroup",
+    "ManifestStore",
+]


### PR DESCRIPTION
- [x] Closes #620
- [ ] ~~Tests added~~
- [ ] ~~Tests passing~~
- [ ] ~~Full type hint coverage~~
- [ ] Changes are documented in `docs/releases.rst`
- [ ] ~~New functions/methods are listed in `api.rst`~~
- [ ] ~~New functionality has documentation~~
