### PR TITLE
Parse kerchunk dict using memorystore

### DIFF
--- a/virtualizarr/tests/test_parsers/test_kerchunk.py
+++ b/virtualizarr/tests/test_parsers/test_kerchunk.py
@@ -353,16 +353,12 @@ def test_parse_dict_via_memorystore(array_v3_metadata):
 
     # generate some example kerchunk references 
     refs: dict = gen_ds_refs()
-    print(refs)
 
     memory_store = obstore.store.MemoryStore()
     memory_store.put("refs.json", json.dumps(refs).encode())
 
     parser = KerchunkJSONParser()
-
     manifeststore = parser("refs.json", memory_store)
-
-    print(manifeststore)
 
     assert isinstance(manifeststore, ManifestStore)
     

--- a/virtualizarr/tests/test_parsers/test_kerchunk.py
+++ b/virtualizarr/tests/test_parsers/test_kerchunk.py
@@ -343,3 +343,23 @@ def test_load_manifest(tmp_path, netcdf4_file, netcdf4_virtual_dataset):
         ).load() as manifest_ds,
     ):
         xrt.assert_identical(ds, manifest_ds)
+
+
+def test_parse_dict_via_memorystore():
+    import obstore
+    import json
+    from virtualizarr.parsers import KerchunkJSONParser
+
+    # generate some example kerchunk references 
+    refs: dict = gen_ds_refs()
+
+    memory_store = obstore.store.MemoryStore()
+    memory_store.put("refs.json", json.dumps(refs).encode())
+
+    parser = KerchunkJSONParser()
+
+    manifeststore = parser("refs.json", memory_store)
+
+    print(manifeststore)
+
+    # TODO assert metadata loaded correctly

--- a/virtualizarr/tests/test_parsers/test_kerchunk.py
+++ b/virtualizarr/tests/test_parsers/test_kerchunk.py
@@ -352,6 +352,7 @@ def test_parse_dict_via_memorystore():
 
     # generate some example kerchunk references 
     refs: dict = gen_ds_refs()
+    print(refs)
 
     memory_store = obstore.store.MemoryStore()
     memory_store.put("refs.json", json.dumps(refs).encode())
@@ -363,3 +364,6 @@ def test_parse_dict_via_memorystore():
     print(manifeststore)
 
     # TODO assert metadata loaded correctly
+    assert isinstance(manifeststore, manifeststore)
+
+    # TODO assert that manifeststore.to_kerchunk_refs() roundtrips, once we have that method

--- a/virtualizarr/utils.py
+++ b/virtualizarr/utils.py
@@ -23,18 +23,24 @@ if TYPE_CHECKING:
     ]
 
 
+def remove_prefix(store: ObjectStore, path: str) -> str:
+    """Remove a store prefix like file:/// or memory:// if it exists in the path"""
+    parsed = urlparse(path)
+    if hasattr(store, "prefix") and store.prefix:
+        filepath = os.path.basename(parsed.path)
+    else:
+        filepath = parsed.path
+    
+    return filepath
+
+
 class ObstoreReader:
     _reader: ReadableFile
 
     def __init__(self, store: ObjectStore, path: str) -> None:
         import obstore as obs
 
-        parsed = urlparse(path)
-        if hasattr(store, "prefix") and store.prefix:
-            filepath = os.path.basename(parsed.path)
-        else:
-            filepath = parsed.path
-
+        filepath = remove_prefix(store, path)
         self._reader = obs.open_reader(store, filepath)
 
     def read(self, size: int, /) -> bytes:


### PR DESCRIPTION
Ensures that the new `KerchunkJSONParser` can be used on in-memory python dictionaries containing JSON, not just on-disk JSON files. This is a really nice demonstration of the power of delegating all IO code to obstore.

- [ ] Closes #xxxx
- [x] Tests added
- [x] Tests passing
- [x] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] ~~New functions/methods are listed in `api.rst`~~
- [ ] New functionality has documentation
