### PR TITLE
Fix mkdocs site_url and don't use directory urls

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+        exclude: mkdocs.yml
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,6 +10,5 @@ build:
   commands:
     - mamba install -c conda-forge -c nodefaults pixi
     - pixi install --environment docs
-    - pixi run prep-site-url
     - pixi run build-docs
     - pixi run readthedocs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ repo_name: zarr-developers/VirtualiZarr
 repo_url: https://github.com/zarr-developers/VirtualiZarr
 site_description: Cloud-Optimize your Scientific Data as Virtual Zarr stores, using Xarray syntax.
 site_author: VirtualiZarr developers
-site_url: https://virtualizarr.readthedocs.io/en/latest/
+site_url: !ENV [READTHEDOCS_CANONICAL_URL, 'https://virtualizarr.readthedocs.io/en/latest/']
 docs_dir: docs
 use_directory_urls: false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,7 +201,6 @@ docs = ["docs"]
 serve-docs = { cmd = "mkdocs serve" }
 build-docs = { cmd = "mkdocs build" }
 check-docs = { cmd = "mkdocs build --strict" }
-prep-site-url = { cmd = 'sed "s|^site_url: https://virtualizarr.readthedocs.io/en/latest/|site_url: $READTHEDOCS_CANONICAL_URL|" mkdocs.yml > mkdocs.yml.tmp && mv mkdocs.yml.tmp mkdocs.yml' }
 readthedocs = { cmd = "rm -rf $READTHEDOCS_OUTPUT/html && cp -r site $READTHEDOCS_OUTPUT/html" }
 # Define commands to run within the docs environment
 [tool.pixi.feature.minio.tasks]


### PR DESCRIPTION
I think the should make the old usage.html relative link still work and also customize the 404 page, but there may be more debugging required based on the RTD preview.

- [ ] Closes #643
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
