### PR TITLE
Fix icechunk tests with Zarr 3.0.9

### DIFF
--- a/virtualizarr/tests/test_integration.py
+++ b/virtualizarr/tests/test_integration.py
@@ -141,11 +141,14 @@ def roundtrip_as_in_memory_icechunk(
 
     # write those references to an icechunk store
     vdata.virtualize.to_icechunk(session.store, **(virtualize_kwargs or {}))
+    session.commit("Test")
+
+    read_only_session = repo.readonly_session("main")
 
     if isinstance(vdata, xr.DataTree):
         # read the dataset from icechunk
         return xr.open_datatree(
-            session.store,  # type: ignore
+            read_only_session.store,  # type: ignore
             engine="zarr",
             zarr_format=3,
             consolidated=False,
@@ -153,7 +156,9 @@ def roundtrip_as_in_memory_icechunk(
         )
 
     # read the dataset from icechunk
-    return xr.open_zarr(session.store, zarr_format=3, consolidated=False, **kwargs)
+    return xr.open_zarr(
+        read_only_session.store, zarr_format=3, consolidated=False, **kwargs
+    )
 
 
 @requires_zarr_python


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
Use read-only stores with `xr.open_zarr()`.

- [x] Closes #652 
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
