### PR TITLE
Proof of concept: lazily loading datasets with VirtualiZarr

### DIFF
--- a/virtualizarr/__init__.py
+++ b/virtualizarr/__init__.py
@@ -4,7 +4,11 @@ from virtualizarr.accessor import (
     VirtualiZarrDatasetAccessor,
     VirtualiZarrDataTreeAccessor,
 )
-from virtualizarr.xarray import open_virtual_dataset, open_virtual_mfdataset
+from virtualizarr.xarray import (
+    open_dataset,
+    open_virtual_dataset,
+    open_virtual_mfdataset,
+)
 
 try:
     __version__ = _version("virtualizarr")
@@ -18,4 +22,5 @@ __all__ = [
     "VirtualiZarrDataTreeAccessor",
     "open_virtual_dataset",
     "open_virtual_mfdataset",
+    "open_dataset",
 ]

--- a/virtualizarr/xarray.py
+++ b/virtualizarr/xarray.py
@@ -34,6 +34,31 @@ if TYPE_CHECKING:
     )
 
 
+def open_dataset(
+    file_url: str,
+    object_store: ObjectStore,
+    parser: Parser,
+    drop_variables: Iterable[str] | None = None,
+    decode_times: bool | None = None,
+    cftime_variables: Iterable[str] | None = None,
+) -> xr.Dataset:
+    filepath = validate_and_normalize_path_to_uri(file_url, fs_root=Path.cwd().as_uri())
+
+    manifest_store = parser(
+        file_url=filepath,
+        object_store=object_store,
+    )
+
+    ds = xr.open_dataset(
+        manifest_store,
+        decode_times=decode_times,
+        engine="zarr",
+        consolidated=False,
+        zarr_format=3,
+    )
+    return ds.drop_vars(list(drop_variables or ()))
+
+
 def open_virtual_dataset(
     file_url: str,
     object_store: ObjectStore,


### PR DESCRIPTION
Just showing how simple it would be to support the ask from https://github.com/zarr-developers/VirtualiZarr/issues/647. I think we should consider it. 

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
