### PR TITLE
Handle scalar array and vars named c in ManifestStore

### DIFF
--- a/virtualizarr/manifests/store.py
+++ b/virtualizarr/manifests/store.py
@@ -125,10 +125,16 @@ def parse_manifest_index(key: str, chunk_key_encoding: str = ".") -> tuple[int, 
 
     # Look for f"/c{chunk_key_encoding"}" followed by digits and more /digits
     match = re.search(
-        f"(?:^|/)c{chunk_key_encoding}(\d+(?:{chunk_key_encoding}\d+)*)", key
-    ).group()
-    match = match.removeprefix("/").removeprefix(f"c{chunk_key_encoding}")
-    return tuple(int(ind) for ind in match.split(chunk_key_encoding))
+        rf"(?:^|/)c{chunk_key_encoding}(\d+(?:{chunk_key_encoding}\d+)*)", key
+    )
+    if not match:
+        raise ValueError(
+            "Key {key} with chunk_key_encoding {chunk_key_encoding} did not match the expected pattern for nodes in the Zarr hierarchy."
+        )
+    chunk_component = (
+        match.group().removeprefix("/").removeprefix(f"c{chunk_key_encoding}")
+    )
+    return tuple(int(ind) for ind in chunk_component.split(chunk_key_encoding))
 
 
 class ObjectStoreRegistry:

--- a/virtualizarr/tests/test_integration.py
+++ b/virtualizarr/tests/test_integration.py
@@ -475,6 +475,9 @@ def test_open_scalar_variable(tmp_path: Path):
         parser=parser,
     ) as vds:
         assert vds["a"].shape == ()
+    ms = parser(file_url=nc_path, object_store=store)
+    roundtripped = xr.open_zarr(ms, consolidated=False, zarr_format=3)
+    xr.testing.assert_allclose(ds, roundtripped.load())
 
 
 class TestPathsToURIs:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
Improves the extraction of chunk indexes from the node name/key in the Zarr hierarchy to support scalar values and variables named `c`.


- [x] Closes #530 
- [x] Closes #671
- [x] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
