### PR TITLE
Migrate to Icechunk v1.0, exclude broken Xarray compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 requires-python = ">=3.11"
 dynamic = ["version"]
 dependencies = [
-    "xarray>=2025.3.0",
+    "xarray>=2025.3.0,!=2025.7.0,!=2025.7.1",
     "numpy>=2.0.0",
     "universal-pathlib",
     "numcodecs>=0.15.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ all_parsers = [
 
 # writers
 icechunk = [
-    "icechunk>=0.2.4",
+    "icechunk>=1.0.0",
 ]
 kerchunk = ["fastparquet"]
 

--- a/virtualizarr/tests/test_integration.py
+++ b/virtualizarr/tests/test_integration.py
@@ -138,15 +138,20 @@ def roundtrip_as_in_memory_icechunk(
     storage = icechunk.Storage.new_in_memory()
 
     config = icechunk.RepositoryConfig.default()
-    container = icechunk.VirtualChunkContainer(
-        url_prefix="file:///private/var/folders/70",
-        store=icechunk.local_filesystem_store("file:///private/var/folders/70"),
-    )
-    config.set_virtual_chunk_container(container)
+
+    url_prefixes = ["file:///private/var/folders/70", "file:///tmp/"]
+
+    for url_prefix in url_prefixes:
+        container = icechunk.VirtualChunkContainer(
+            url_prefix=url_prefix,
+            store=icechunk.local_filesystem_store(url_prefix),
+        )
+        config.set_virtual_chunk_container(container)
+
     repo = icechunk.Repository.create(
         storage=storage,
         config=config,
-        authorize_virtual_chunk_access={"file:///private/var/folders/70": None},
+        authorize_virtual_chunk_access={prefix: None for prefix in url_prefixes},
     )
     session = repo.writable_session("main")
 

--- a/virtualizarr/tests/test_writers/test_icechunk.py
+++ b/virtualizarr/tests/test_writers/test_icechunk.py
@@ -35,21 +35,22 @@ def icechunk_storage(tmp_path: Path) -> "Storage":
 
 @pytest.fixture(scope="function")
 def icechunk_repo(icechunk_storage: "Storage", tmp_path: Path) -> "Repository":
-    from icechunk import Repository
-
     config = icechunk.RepositoryConfig.default()
-    container = icechunk.VirtualChunkContainer(
-        url_prefix="file:///private/var/folders/70",
-        store=icechunk.local_filesystem_store("file:///private/var/folders/70"),
-    )
-    config.set_virtual_chunk_container(container)
-    repo = Repository.create(
+
+    url_prefixes = ["file:///private/var/folders/70", "file:///tmp/"]
+
+    for url_prefix in url_prefixes:
+        container = icechunk.VirtualChunkContainer(
+            url_prefix=url_prefix,
+            store=icechunk.local_filesystem_store(url_prefix),
+        )
+        config.set_virtual_chunk_container(container)
+
+    return icechunk.Repository.create(
         storage=icechunk_storage,
         config=config,
-        authorize_virtual_chunk_access={"file:///private/var/folders/70": None},
+        authorize_virtual_chunk_access={prefix: None for prefix in url_prefixes},
     )
-
-    return repo
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
Following https://icechunk.io/en/latest/migration/#virtual-datasets

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
