### PR TITLE
Add some units tests for `result_dtype`

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -358,11 +358,12 @@ def manifest_array(array_v3_metadata):
     def _manifest_array(
         shape: tuple = (5, 2),
         chunks: tuple = (5, 2),
+        data_type: np.dtype = np.dtype("int32"),
         codecs: list[dict] | None = [ARRAYBYTES_CODEC, ZLIB_CODEC],
         dimension_names: Iterable[str] | None = None,
     ):
         metadata = array_v3_metadata(
-            shape=shape, chunks=chunks, codecs=codecs, dimension_names=dimension_names
+            shape=shape, chunks=chunks, data_type=data_type, codecs=codecs, dimension_names=dimension_names
         )
         entries = _generate_chunk_entries(shape, chunks, _entry_from_chunk_key)
         chunkmanifest = ChunkManifest(entries=entries)

--- a/conftest.py
+++ b/conftest.py
@@ -363,7 +363,11 @@ def manifest_array(array_v3_metadata):
         dimension_names: Iterable[str] | None = None,
     ):
         metadata = array_v3_metadata(
-            shape=shape, chunks=chunks, data_type=data_type, codecs=codecs, dimension_names=dimension_names
+            shape=shape,
+            chunks=chunks,
+            data_type=data_type,
+            codecs=codecs,
+            dimension_names=dimension_names,
         )
         entries = _generate_chunk_entries(shape, chunks, _entry_from_chunk_key)
         chunkmanifest = ChunkManifest(entries=entries)

--- a/virtualizarr/manifests/array_api.py
+++ b/virtualizarr/manifests/array_api.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Callable, cast, Union
+from typing import TYPE_CHECKING, Any, Callable, Union, cast
 
 import numpy as np
 
@@ -38,12 +38,17 @@ def result_type(*arrays_and_dtypes: Union["ManifestArray", np.dtype]) -> np.dtyp
     """Called by xarray to ensure all arguments to concat have the same dtype."""
     from virtualizarr.manifests.array import ManifestArray
 
-    dtypes = (obj.dtype if isinstance(obj, ManifestArray) else np.dtype(obj) for obj in arrays_and_dtypes)
+    dtypes = (
+        obj.dtype if isinstance(obj, ManifestArray) else np.dtype(obj)
+        for obj in arrays_and_dtypes
+    )
     first_dtype, *other_dtypes = dtypes
     unique_dtypes = set(dtypes)
     for other_dtype in other_dtypes:
         if other_dtype != first_dtype:
-            raise ValueError(f"Cannot combine arrays with inconsistent dtypes, but got {len(unique_dtypes)} distinct dtypes: {unique_dtypes}")
+            raise ValueError(
+                f"Cannot combine arrays with inconsistent dtypes, but got {len(unique_dtypes)} distinct dtypes: {unique_dtypes}"
+            )
 
     return first_dtype
 

--- a/virtualizarr/tests/test_manifests/test_array.py
+++ b/virtualizarr/tests/test_manifests/test_array.py
@@ -9,7 +9,7 @@ from conftest import (
 from virtualizarr.manifests import ChunkManifest, ManifestArray
 
 
-class TestManifestArray:
+class TestInit:
     def test_manifest_array(self, array_v3_metadata):
         chunks_dict = {
             "0.0.0": {"path": "s3://bucket/foo.nc", "offset": 100, "length": 100},
@@ -48,6 +48,23 @@ class TestManifestArray:
         assert marr.shape == shape
         assert marr.size == 5 * 2 * 20
         assert marr.ndim == 3
+
+
+class TestResultType:
+    def test_idempotent(self, manifest_array):
+        marr1 = manifest_array(shape=(), chunks=(), data_type=np.dtype("int32"))
+        marr2 = manifest_array(shape=(), chunks=(), data_type=np.dtype("int32"))
+
+        assert np.result_type(marr1) == marr1.dtype
+        assert np.result_type(marr1, marr1.dtype) == marr1.dtype
+        assert np.result_type(marr1, marr2) == marr1.dtype
+    
+    def test_raises(self, manifest_array):
+        marr1 = manifest_array(shape=(), chunks=(), data_type=np.dtype("int32"))
+        marr2 = manifest_array(shape=(), chunks=(), data_type=np.dtype("int64"))
+
+        with pytest.raises(ValueError, match="inconsistent"):
+            np.result_type(marr1, marr2)
 
 
 class TestEquals:

--- a/virtualizarr/tests/test_manifests/test_array.py
+++ b/virtualizarr/tests/test_manifests/test_array.py
@@ -58,7 +58,7 @@ class TestResultType:
         assert np.result_type(marr1) == marr1.dtype
         assert np.result_type(marr1, marr1.dtype) == marr1.dtype
         assert np.result_type(marr1, marr2) == marr1.dtype
-    
+
     def test_raises(self, manifest_array):
         marr1 = manifest_array(shape=(), chunks=(), data_type=np.dtype("int32"))
         marr2 = manifest_array(shape=(), chunks=(), data_type=np.dtype("int64"))


### PR DESCRIPTION
This splits out part of #677, by adding some targeted unit tests for a part of the array_api that probably should have been added when I first wrote that module.

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
