### PR TITLE
Temporarily restrict Zarr versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "numcodecs>=0.15.1",
     "ujson",
     "packaging",
-    "zarr>=3.0.8",
+    "zarr>=3.0.8,!=3.1.0",
     "obstore>=0.5.1",
 ]
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
We can remove this if https://github.com/zarr-developers/VirtualiZarr/pull/677 lands before we're ready to release V2.0.

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
