### PR TITLE
Do not allow exceptions in ManifestStore

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -87,7 +87,8 @@ ZLIB_CODEC = {"name": "numcodecs.zlib", "configuration": {"level": 1}}
 def _generate_chunk_entries(
     shape: tuple[int, ...],
     chunks: tuple[int, ...],
-    entry_generator: Callable[[tuple[int, ...]], dict[str, Any]],
+    itemsize: int,
+    entry_generator: Callable[[tuple[int, ...], tuple[int, ...], int], dict[str, Any]],
 ) -> dict[str, dict[str, Any]]:
     """
     Generate chunk entries for a manifest based on shape and chunks.
@@ -112,30 +113,29 @@ def _generate_chunk_entries(
     )
 
     if chunk_grid_shape == ():
-        return {"0": entry_generator((0,))}
+        return {"0": entry_generator((0,), (0,), itemsize)}
 
     all_possible_combos = itertools.product(
         *[range(length) for length in chunk_grid_shape]
     )
-    return {join(ind): entry_generator(ind) for ind in all_possible_combos}
+    return {
+        join(ind): entry_generator(ind, chunks, itemsize) for ind in all_possible_combos
+    }
 
 
-def _offset_from_chunk_key(ind: tuple[int, ...]) -> int:
-    """Generate an offset value from chunk indices."""
-    return sum(ind) * 10
-
-
-def _length_from_chunk_key(ind: tuple[int, ...]) -> int:
+def _length_from_chunk_key(chunks: tuple[int, ...], itemsize: int) -> int:
     """Generate a length value from chunk indices."""
-    return sum(ind) + 5
+    return int(np.prod(chunks) * itemsize)
 
 
-def _entry_from_chunk_key(ind: tuple[int, ...]) -> dict[str, str | int]:
+def _entry_from_chunk_key(
+    ind: tuple[int, ...], chunks: tuple[int, ...], itemsize: int
+) -> dict[str, str | int]:
     """Generate a (somewhat) unique manifest entry from a given chunk key."""
     entry = {
         "path": f"/foo.{str(join(ind))}.nc",
-        "offset": _offset_from_chunk_key(ind),
-        "length": _length_from_chunk_key(ind),
+        "offset": 0,
+        "length": _length_from_chunk_key(chunks, itemsize),
     }
     return entry  # type: ignore[return-value]
 
@@ -150,7 +150,9 @@ def _generate_chunk_manifest(
     """Generate a chunk manifest with sequential offsets for each chunk."""
     current_offset = [offset]  # Use list to allow mutation in closure
 
-    def sequential_entry_generator(ind: tuple[int, ...]) -> dict[str, Any]:
+    def sequential_entry_generator(
+        ind: tuple[int, ...], chunks: tuple[int, ...], itemsize: int
+    ) -> dict[str, Any]:
         entry = {
             "path": netcdf4_file,
             "offset": current_offset[0],
@@ -159,7 +161,7 @@ def _generate_chunk_manifest(
         current_offset[0] += length
         return entry
 
-    entries = _generate_chunk_entries(shape, chunks, sequential_entry_generator)
+    entries = _generate_chunk_entries(shape, chunks, 32, sequential_entry_generator)
     return ChunkManifest(entries)
 
 
@@ -369,7 +371,9 @@ def manifest_array(array_v3_metadata):
             codecs=codecs,
             dimension_names=dimension_names,
         )
-        entries = _generate_chunk_entries(shape, chunks, _entry_from_chunk_key)
+        entries = _generate_chunk_entries(
+            shape, chunks, data_type.itemsize, _entry_from_chunk_key
+        )
         chunkmanifest = ChunkManifest(entries=entries)
         return ManifestArray(chunkmanifest=chunkmanifest, metadata=metadata)
 

--- a/virtualizarr/manifests/store.py
+++ b/virtualizarr/manifests/store.py
@@ -32,9 +32,6 @@ if TYPE_CHECKING:
 __all__ = ["ManifestStore"]
 
 
-_ALLOWED_EXCEPTIONS: tuple[type[Exception], ...] = ()
-
-
 @dataclass
 class StoreRequest:
     """Dataclass for matching a key to the store instance"""
@@ -267,15 +264,12 @@ class ManifestStore(Store):
         )
 
         # Actually get the bytes
-        try:
-            bytes = await store.get_range_async(
-                path_in_store,
-                start=byte_range.start,
-                end=byte_range.end,
-            )
-            return prototype.buffer.from_bytes(bytes)  # type: ignore[arg-type]
-        except _ALLOWED_EXCEPTIONS:
-            return None
+        bytes = await store.get_range_async(
+            path_in_store,
+            start=byte_range.start,
+            end=byte_range.end,
+        )
+        return prototype.buffer.from_bytes(bytes)  # type: ignore[arg-type]
 
     async def get_partial_values(
         self,

--- a/virtualizarr/manifests/store.py
+++ b/virtualizarr/manifests/store.py
@@ -256,7 +256,9 @@ class ManifestStore(Store):
         if hasattr(store, "prefix") and store.prefix:
             prefix = str(store.prefix).lstrip("/")
             path_in_store = path_in_store.lstrip("/").removeprefix(prefix).lstrip("/")
-
+        elif hasattr(store, "url"):
+            prefix = urlparse(store.url).path.lstrip("/")
+            path_in_store = path_in_store.lstrip("/").removeprefix(prefix).lstrip("/")
         # Transform the input byte range to account for the chunk location in the file
         chunk_end_exclusive = offset + length
         byte_range = _transform_byte_range(

--- a/virtualizarr/tests/test_manifests/test_array.py
+++ b/virtualizarr/tests/test_manifests/test_array.py
@@ -138,9 +138,9 @@ class TestBroadcast:
         assert expanded.shape == (3, 2)
         assert expanded.chunks == (1, 2)
         assert expanded.manifest.dict() == {
-            "0.0": {"path": "file:///foo.0.0.nc", "offset": 0, "length": 5},
-            "1.0": {"path": "file:///foo.0.0.nc", "offset": 0, "length": 5},
-            "2.0": {"path": "file:///foo.0.0.nc", "offset": 0, "length": 5},
+            "0.0": {"path": "file:///foo.0.0.nc", "offset": 0, "length": 8},
+            "1.0": {"path": "file:///foo.0.0.nc", "offset": 0, "length": 8},
+            "2.0": {"path": "file:///foo.0.0.nc", "offset": 0, "length": 8},
         }
 
     def test_broadcast_new_axis(self, manifest_array):
@@ -149,9 +149,9 @@ class TestBroadcast:
         assert expanded.shape == (1, 3)
         assert expanded.chunks == (1, 1)
         assert expanded.manifest.dict() == {
-            "0.0": {"path": "file:///foo.0.nc", "offset": 0, "length": 5},
-            "0.1": {"path": "file:///foo.1.nc", "offset": 10, "length": 6},
-            "0.2": {"path": "file:///foo.2.nc", "offset": 20, "length": 7},
+            "0.0": {"path": "file:///foo.0.nc", "offset": 0, "length": 4},
+            "0.1": {"path": "file:///foo.1.nc", "offset": 0, "length": 4},
+            "0.2": {"path": "file:///foo.2.nc", "offset": 0, "length": 4},
         }
 
     def test_broadcast_scalar(self, manifest_array):
@@ -160,14 +160,14 @@ class TestBroadcast:
         assert marr.shape == ()
         assert marr.chunks == ()
         assert marr.manifest.dict() == {
-            "0": {"path": "file:///foo.0.nc", "offset": 0, "length": 5},
+            "0": {"path": "file:///foo.0.nc", "offset": 0, "length": 0},
         }
 
         expanded = np.broadcast_to(marr, shape=(1,))
         assert expanded.shape == (1,)
         assert expanded.chunks == (1,)
         assert expanded.manifest.dict() == {
-            "0": {"path": "file:///foo.0.nc", "offset": 0, "length": 5},
+            "0": {"path": "file:///foo.0.nc", "offset": 0, "length": 0},
         }
 
     @pytest.mark.parametrize(

--- a/virtualizarr/tests/test_manifests/test_store.py
+++ b/virtualizarr/tests/test_manifests/test_store.py
@@ -5,6 +5,7 @@ import pickle
 from typing import TYPE_CHECKING
 
 import numpy as np
+import obstore as obs
 import pytest
 from obstore.store import MemoryStore
 from zarr.abc.store import (
@@ -341,20 +342,28 @@ class TestToVirtualXarray:
         expected_loadable_variables,
     ):
         marr1 = manifest_array(
-            shape=(3, 2, 5), chunks=(1, 2, 1), dimension_names=["x", "y", "t"]
+            shape=(3, 2, 5),
+            chunks=(1, 2, 1),
+            dimension_names=["x", "y", "t"],
+            codecs=None,
         )
-        marr2 = manifest_array(shape=(3, 2), chunks=(1, 2), dimension_names=["x", "y"])
-        marr3 = manifest_array(shape=(5,), chunks=(5,), dimension_names=["t"])
+        marr2 = manifest_array(
+            shape=(3, 2), chunks=(1, 2), dimension_names=["x", "y"], codecs=None
+        )
+        marr3 = manifest_array(
+            shape=(5,), chunks=(5,), dimension_names=["t"], codecs=None
+        )
 
-        paths1 = list({v["path"] for v in marr1.manifest.values()})
-        paths2 = list({v["path"] for v in marr2.manifest.values()})
-        paths3 = list({v["path"] for v in marr2.manifest.values()})
-        unique_paths = list(set(paths1 + paths2 + paths3))
-        stores = {}
-        for path in unique_paths:
-            store = MemoryStore()
-            stores[get_store_prefix(path)] = store
-        store_registry = ObjectStoreRegistry(stores=stores)
+        store = MemoryStore()
+        for marr in [marr1, marr2, marr3]:
+            unique_paths = list({v["path"] for v in marr.manifest.values()})
+            for path in unique_paths:
+                obs.put(
+                    store,
+                    path.split("/")[-1],
+                    np.ones(marr.chunks, dtype=marr.dtype).tobytes(),
+                )
+        store_registry = ObjectStoreRegistry({"file://": store})
 
         manifest_group = ManifestGroup(
             arrays={

--- a/virtualizarr/tests/test_parsers/test_dmrpp.py
+++ b/virtualizarr/tests/test_parsers/test_dmrpp.py
@@ -1,16 +1,16 @@
 import textwrap
+from contextlib import nullcontext
 from pathlib import Path
 from xml.etree import ElementTree as ET
 
-import numpy as np
 import pytest
 import xarray as xr
+import xarray.testing as xrt
 
-from virtualizarr.manifests.manifest import ChunkManifest
 from virtualizarr.parsers import DMRPPParser, HDFParser
 from virtualizarr.parsers.dmrpp import DMRParser
 from virtualizarr.tests import requires_network
-from virtualizarr.tests.utils import obstore_s3
+from virtualizarr.tests.utils import obstore_local, obstore_s3
 from virtualizarr.xarray import open_virtual_dataset
 
 urls = [
@@ -21,160 +21,328 @@ urls = [
     # TODO: later add MUR, SWOT, TEMPO and others by using kerchunk JSON to read refs (rather than reading the whole netcdf file)
 ]
 
-
+# This DMRPP was created following the instructions from https://opendap.github.io/DMRpp-wiki/DMRpp.html#sec-build-them on the files produced by conftest.py with the key matching the fixture name.
 DMRPP_XML_STRINGS = {
-    "basic": textwrap.dedent(
+    "netcdf4_file": textwrap.dedent(
         """\
         <?xml version="1.0" encoding="ISO-8859-1"?>
-        <Dataset xmlns="http://xml.opendap.org/ns/DAP/4.0#" xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#" dapVersion="4.0" dmrVersion="1.0" name="test.dmrpp">
-            <Dimension name="x" size="720"/>
-            <Dimension name="y" size="1440"/>
-            <Dimension name="z" size="3"/>
-            <Int32 name="x">
-                <Dim name="/x"/>
-                <Attribute name="long_name" type="String">
-                    <Value>grid x-axis</Value>
+        <Dataset xmlns="http://xml.opendap.org/ns/DAP/4.0#" xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#" dapVersion="4.0" dmrVersion="1.0" name="air.nc" dmrpp:href="OPeNDAP_DMRpp_DATA_ACCESS_URL" dmrpp:version="3.21.1-451">
+            <Dimension name="lat" size="25"/>
+            <Dimension name="lon" size="53"/>
+            <Dimension name="time" size="2920"/>
+            <Float32 name="lat">
+                <Dim name="/lat"/>
+                <Attribute name="_FillValue" type="Float32">
+                    <Value>NaN</Value>
                 </Attribute>
-                <dmrpp:chunks fillValue="-2147483647" byteOrder="LE">
-                    <dmrpp:chunk offset="41268" nBytes="4"/>
+                <Attribute name="standard_name" type="String">
+                    <Value>latitude</Value>
+                </Attribute>
+                <Attribute name="long_name" type="String">
+                    <Value>Latitude</Value>
+                </Attribute>
+                <Attribute name="units" type="String">
+                    <Value>degrees_north</Value>
+                </Attribute>
+                <Attribute name="axis" type="String">
+                    <Value>Y</Value>
+                </Attribute>
+                <dmrpp:chunks fillValue="nan" byteOrder="LE">
+                    <dmrpp:chunk offset="5179" nBytes="100"/>
                 </dmrpp:chunks>
-            </Int32>
-            <Int32 name="y">
-                <Dim name="/y"/>
-                <Attribute name="long_name" type="String">
-                    <Value>grid y-axis</Value>
+            </Float32>
+            <Float32 name="lon">
+                <Dim name="/lon"/>
+                <Attribute name="_FillValue" type="Float32">
+                    <Value>NaN</Value>
                 </Attribute>
-                <dmrpp:chunks fillValue="-2147483647" byteOrder="LE">
-                    <dmrpp:chunk offset="41272" nBytes="4"/>
+                <Attribute name="standard_name" type="String">
+                    <Value>longitude</Value>
+                </Attribute>
+                <Attribute name="long_name" type="String">
+                    <Value>Longitude</Value>
+                </Attribute>
+                <Attribute name="units" type="String">
+                    <Value>degrees_east</Value>
+                </Attribute>
+                <Attribute name="axis" type="String">
+                    <Value>X</Value>
+                </Attribute>
+                <dmrpp:chunks fillValue="nan" byteOrder="LE">
+                    <dmrpp:chunk offset="5279" nBytes="212"/>
                 </dmrpp:chunks>
-            </Int32>
-            <Int32 name="z">
-                <Dim name="/z"/>
-                <Attribute name="long_name" type="String">
-                    <Value>grid z-axis</Value>
+            </Float32>
+            <Float32 name="time">
+                <Dim name="/time"/>
+                <Attribute name="_FillValue" type="Float32">
+                    <Value>NaN</Value>
                 </Attribute>
-                <dmrpp:chunks fillValue="-2147483647" byteOrder="LE">
-                    <dmrpp:chunk offset="41276" nBytes="4"/>
+                <Attribute name="standard_name" type="String">
+                    <Value>time</Value>
+                </Attribute>
+                <Attribute name="long_name" type="String">
+                    <Value>Time</Value>
+                </Attribute>
+                <Attribute name="units" type="String">
+                    <Value>hours since 1800-01-01</Value>
+                </Attribute>
+                <Attribute name="calendar" type="String">
+                    <Value>standard</Value>
+                </Attribute>
+                <dmrpp:chunks fillValue="nan" byteOrder="LE">
+                    <dmrpp:chunk offset="7757515" nBytes="11680"/>
                 </dmrpp:chunks>
-            </Int32>
-            <Float32 name="data">
-                <Dim name="/x"/>
-                <Dim name="/y"/>
+            </Float32>
+            <Int16 name="air">
+                <Dim name="/time"/>
+                <Dim name="/lat"/>
+                <Dim name="/lon"/>
                 <Attribute name="long_name" type="String">
-                    <Value>analysed sea surface temperature</Value>
+                    <Value>4xDaily Air temperature at sigma level 995</Value>
                 </Attribute>
-                <Attribute name="items" type="Int16">
-                    <Value>1</Value>
+                <Attribute name="units" type="String">
+                    <Value>degK</Value>
+                </Attribute>
+                <Attribute name="precision" type="Int16">
                     <Value>2</Value>
-                    <Value>3</Value>
                 </Attribute>
-                <Attribute name="_FillValue" type="Int16">
-                    <Value>-32768</Value>
+                <Attribute name="GRIB_id" type="Int16">
+                    <Value>11</Value>
                 </Attribute>
-                <Attribute name="add_offset" type="Float64">
-                    <Value>298.14999999999998</Value>
+                <Attribute name="GRIB_name" type="String">
+                    <Value>TMP</Value>
+                </Attribute>
+                <Attribute name="var_desc" type="String">
+                    <Value>Air temperature</Value>
+                </Attribute>
+                <Attribute name="dataset" type="String">
+                    <Value>NMC Reanalysis</Value>
+                </Attribute>
+                <Attribute name="level_desc" type="String">
+                    <Value>Surface</Value>
+                </Attribute>
+                <Attribute name="statistic" type="String">
+                    <Value>Individual Obs</Value>
+                </Attribute>
+                <Attribute name="parent_stat" type="String">
+                    <Value>Other</Value>
+                </Attribute>
+                <Attribute name="actual_range" type="Float32">
+                    <Value>185.1600037</Value>
+                    <Value>322.1000061</Value>
                 </Attribute>
                 <Attribute name="scale_factor" type="Float64">
-                    <Value>0.001</Value>
+                    <Value>0.01</Value>
                 </Attribute>
-                <Attribute name="coordinates" type="String">
-                    <Value>x y z</Value>
-                </Attribute>
-                <dmrpp:chunks compressionType="shuffle deflate" deflateLevel="5" fillValue="-32768" byteOrder="LE">
-                    <dmrpp:chunkDimensionSizes>360 720</dmrpp:chunkDimensionSizes>
-                    <dmrpp:chunk offset="40762" nBytes="4083" chunkPositionInArray="[0,0]"/>
-                    <dmrpp:chunk offset="44845" nBytes="4083" chunkPositionInArray="[0,720]"/>
-                    <dmrpp:chunk offset="48928" nBytes="4083" chunkPositionInArray="[0,1440]"/>
-                    <dmrpp:chunk offset="53011" nBytes="4083" chunkPositionInArray="[360, 0]"/>
-                    <dmrpp:chunk offset="57094" nBytes="4083" chunkPositionInArray="[360, 720]"/>
-                    <dmrpp:chunk offset="61177" nBytes="4083" chunkPositionInArray="[360, 1440]"/>
-                    <dmrpp:chunk offset="65260" nBytes="4083" chunkPositionInArray="[720, 0]"/>
-                    <dmrpp:chunk offset="69343" nBytes="4083" chunkPositionInArray="[720, 720]"/>
-                    <dmrpp:chunk offset="73426" nBytes="4083" chunkPositionInArray="[720, 1440]"/>
+                <Map name="/time"/>
+                <Map name="/lat"/>
+                <Map name="/lon"/>
+                <dmrpp:chunks fillValue="-32767" byteOrder="LE">
+                    <dmrpp:chunk offset="15419" nBytes="7738000"/>
                 </dmrpp:chunks>
-            </Float32>
-            <Float32 name="mask">
-                <Dim name="/x"/>
-                <Dim name="/y"/>
-                <Dim name="/z"/>
-                <Attribute name="long_name" type="String">
-                    <Value>mask</Value>
-                </Attribute>
-                <dmrpp:chunks compressionType="shuffle" fillValue="-2147483647" byteOrder="LE">
-                    <dmrpp:chunk offset="41276" nBytes="4"/>
-                </dmrpp:chunks>
-            </Float32>
+            </Int16>
             <Attribute name="Conventions" type="String">
-                <Value>CF-1.6</Value>
+                <Value>COARDS</Value>
             </Attribute>
             <Attribute name="title" type="String">
-                <Value>Sample Dataset</Value>
+                <Value>4x daily NMC reanalysis (1948)</Value>
+            </Attribute>
+            <Attribute name="description" type="String">
+                <Value>Data is from NMC initialized reanalysis
+        (4x/day).  These are the 0.9950 sigma level values.</Value>
+            </Attribute>
+            <Attribute name="platform" type="String">
+                <Value>Model</Value>
+            </Attribute>
+            <Attribute name="references" type="String">
+                <Value>http://www.esrl.noaa.gov/psd/data/gridded/data.ncep.reanalysis.html</Value>
+            </Attribute>
+            <Attribute name="build_dmrpp_metadata" type="Container">
+                <Attribute name="created" type="String">
+                    <Value>2025-07-16T18:48:42Z</Value>
+                </Attribute>
+                <Attribute name="build_dmrpp" type="String">
+                    <Value>3.21.1-451</Value>
+                </Attribute>
+                <Attribute name="bes" type="String">
+                    <Value>3.21.1-451</Value>
+                </Attribute>
+                <Attribute name="libdap" type="String">
+                    <Value>libdap-3.21.1-178</Value>
+                </Attribute>
+                <Attribute name="invocation" type="String">
+                    <Value>build_dmrpp -f /usr/share/hyrax/air.nc -r air.nc.dmr -u OPeNDAP_DMRpp_DATA_ACCESS_URL -M</Value>
+                </Attribute>
             </Attribute>
         </Dataset>
         """
     ),
-    "nested_groups": textwrap.dedent(
+    "hdf5_groups_file": textwrap.dedent(
         """\
-            <?xml version="1.0" encoding="ISO-8859-1"?>
-            <Dataset xmlns="http://xml.opendap.org/ns/DAP/4.0#" xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#" dapVersion="4.0" dmrVersion="1.0" name="test.dmrpp">
-                <Dimension name="a" size="10"/>
-                <Dimension name="b" size="10"/>
-                <Int32 name="a">
-                    <Dim name="/a"/>
-                    <dmrpp:chunks fillValue="-2147483647" byteOrder="LE">
-                        <dmrpp:chunk offset="41268" nBytes="4"/>
-                    </dmrpp:chunks>
-                </Int32>
-                <Int32 name="b">
-                    <Dim name="/b"/>
-                    <dmrpp:chunks fillValue="-2147483647" byteOrder="LE">
-                        <dmrpp:chunk offset="41268" nBytes="4"/>
-                    </dmrpp:chunks>
-                </Int32>
-                <Group name="group1">
-                    <Dimension name="x" size="720"/>
-                    <Dimension name="y" size="1440"/>
-                    <Int32 name="x">
-                        <Dim name="/group1/x"/>
-                        <Attribute name="test" type="String">
-                            <Value>test</Value>
+        <?xml version="1.0" encoding="ISO-8859-1"?>
+        <Dataset xmlns="http://xml.opendap.org/ns/DAP/4.0#" xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#" dapVersion="4.0" dmrVersion="1.0" name="hdf5_groups_file.nc" dmrpp:href="OPeNDAP_DMRpp_DATA_ACCESS_URL" dmrpp:version="3.21.1-451">
+            <Attribute name="build_dmrpp_metadata" type="Container">
+                <Attribute name="created" type="String">
+                    <Value>2025-07-16T21:57:57Z</Value>
+                </Attribute>
+                <Attribute name="build_dmrpp" type="String">
+                    <Value>3.21.1-451</Value>
+                </Attribute>
+                <Attribute name="bes" type="String">
+                    <Value>3.21.1-451</Value>
+                </Attribute>
+                <Attribute name="libdap" type="String">
+                    <Value>libdap-3.21.1-178</Value>
+                </Attribute>
+                <Attribute name="invocation" type="String">
+                    <Value>build_dmrpp -f /usr/share/hyrax/hdf5_groups_file.nc -r hdf5_groups_file.nc.dmr -u OPeNDAP_DMRpp_DATA_ACCESS_URL -M</Value>
+                </Attribute>
+            </Attribute>
+            <Group name="test">
+                <Group name="group">
+                    <Dimension name="lat" size="25"/>
+                    <Dimension name="lon" size="53"/>
+                    <Dimension name="time" size="2920"/>
+                    <Float32 name="lat">
+                        <Dim name="/test/group/lat"/>
+                        <Attribute name="_FillValue" type="Float32">
+                            <Value>NaN</Value>
                         </Attribute>
-                        <dmrpp:chunks fillValue="-2147483647" byteOrder="LE">
-                            <dmrpp:chunk offset="41268" nBytes="4"/>
-                        </dmrpp:chunks>
-                    </Int32>
-                    <Int32 name="y">
-                        <Dim name="/group1/y"/>
-                        <Attribute name="test" type="String">
-                            <Value>test</Value>
+                        <Attribute name="standard_name" type="String">
+                            <Value>latitude</Value>
                         </Attribute>
-                        <dmrpp:chunks fillValue="-2147483647" byteOrder="LE">
-                            <dmrpp:chunk offset="41268" nBytes="4"/>
+                        <Attribute name="long_name" type="String">
+                            <Value>Latitude</Value>
+                        </Attribute>
+                        <Attribute name="units" type="String">
+                            <Value>degrees_north</Value>
+                        </Attribute>
+                        <Attribute name="axis" type="String">
+                            <Value>Y</Value>
+                        </Attribute>
+                        <dmrpp:chunks fillValue="nan" byteOrder="LE">
+                            <dmrpp:chunk offset="5533" nBytes="100"/>
                         </dmrpp:chunks>
-                    </Int32>
-                    <Group name="group2">
-                        <Int32 name="area">
-                            <Dim name="/group1/x"/>
-                            <Dim name="/group1/y"/>
-                            <dmrpp:chunks fillValue="-2147483647" byteOrder="LE">
-                                <dmrpp:chunk offset="41268" nBytes="4"/>
-                            </dmrpp:chunks>
-                        </Int32>
-                    </Group>
+                    </Float32>
+                    <Float32 name="lon">
+                        <Dim name="/test/group/lon"/>
+                        <Attribute name="_FillValue" type="Float32">
+                            <Value>NaN</Value>
+                        </Attribute>
+                        <Attribute name="standard_name" type="String">
+                            <Value>longitude</Value>
+                        </Attribute>
+                        <Attribute name="long_name" type="String">
+                            <Value>Longitude</Value>
+                        </Attribute>
+                        <Attribute name="units" type="String">
+                            <Value>degrees_east</Value>
+                        </Attribute>
+                        <Attribute name="axis" type="String">
+                            <Value>X</Value>
+                        </Attribute>
+                        <dmrpp:chunks fillValue="nan" byteOrder="LE">
+                            <dmrpp:chunk offset="5633" nBytes="212"/>
+                        </dmrpp:chunks>
+                    </Float32>
+                    <Float32 name="time">
+                        <Dim name="/test/group/time"/>
+                        <Attribute name="_FillValue" type="Float32">
+                            <Value>NaN</Value>
+                        </Attribute>
+                        <Attribute name="standard_name" type="String">
+                            <Value>time</Value>
+                        </Attribute>
+                        <Attribute name="long_name" type="String">
+                            <Value>Time</Value>
+                        </Attribute>
+                        <Attribute name="units" type="String">
+                            <Value>hours since 1800-01-01</Value>
+                        </Attribute>
+                        <Attribute name="calendar" type="String">
+                            <Value>standard</Value>
+                        </Attribute>
+                        <dmrpp:chunks fillValue="nan" byteOrder="LE">
+                            <dmrpp:chunk offset="7757869" nBytes="11680"/>
+                        </dmrpp:chunks>
+                    </Float32>
+                    <Int16 name="air">
+                        <Dim name="/test/group/time"/>
+                        <Dim name="/test/group/lat"/>
+                        <Dim name="/test/group/lon"/>
+                        <Attribute name="long_name" type="String">
+                            <Value>4xDaily Air temperature at sigma level 995</Value>
+                        </Attribute>
+                        <Attribute name="units" type="String">
+                            <Value>degK</Value>
+                        </Attribute>
+                        <Attribute name="precision" type="Int16">
+                            <Value>2</Value>
+                        </Attribute>
+                        <Attribute name="GRIB_id" type="Int16">
+                            <Value>11</Value>
+                        </Attribute>
+                        <Attribute name="GRIB_name" type="String">
+                            <Value>TMP</Value>
+                        </Attribute>
+                        <Attribute name="var_desc" type="String">
+                            <Value>Air temperature</Value>
+                        </Attribute>
+                        <Attribute name="dataset" type="String">
+                            <Value>NMC Reanalysis</Value>
+                        </Attribute>
+                        <Attribute name="level_desc" type="String">
+                            <Value>Surface</Value>
+                        </Attribute>
+                        <Attribute name="statistic" type="String">
+                            <Value>Individual Obs</Value>
+                        </Attribute>
+                        <Attribute name="parent_stat" type="String">
+                            <Value>Other</Value>
+                        </Attribute>
+                        <Attribute name="actual_range" type="Float32">
+                            <Value>185.1600037</Value>
+                            <Value>322.1000061</Value>
+                        </Attribute>
+                        <Attribute name="scale_factor" type="Float64">
+                            <Value>0.01</Value>
+                        </Attribute>
+                        <Map name="/test/group/time"/>
+                        <Map name="/test/group/lat"/>
+                        <Map name="/test/group/lon"/>
+                        <dmrpp:chunks fillValue="-32767" byteOrder="LE">
+                            <dmrpp:chunk offset="15773" nBytes="7738000"/>
+                        </dmrpp:chunks>
+                    </Int16>
+                    <Attribute name="Conventions" type="String">
+                        <Value>COARDS</Value>
+                    </Attribute>
+                    <Attribute name="title" type="String">
+                        <Value>4x daily NMC reanalysis (1948)</Value>
+                    </Attribute>
+                    <Attribute name="description" type="String">
+                        <Value>Data is from NMC initialized reanalysis
+        (4x/day).  These are the 0.9950 sigma level values.</Value>
+                    </Attribute>
+                    <Attribute name="platform" type="String">
+                        <Value>Model</Value>
+                    </Attribute>
+                    <Attribute name="references" type="String">
+                        <Value>http://www.esrl.noaa.gov/psd/data/gridded/data.ncep.reanalysis.html</Value>
+                    </Attribute>
                 </Group>
-            </Dataset>
+            </Group>
+        </Dataset>
             """
     ),
 }
 
 
-def dmrparser(dmrpp_xml_str: str, tmp_path: Path, filename="test.nc") -> DMRParser:
+def dmrparser(dmrpp_xml_str: str, filepath: str) -> DMRParser:
     # TODO we should actually create a dmrpp file in a temporary directory
     # this would avoid the need to pass tmp_path separately
 
-    return DMRParser(
-        root=ET.fromstring(dmrpp_xml_str), data_filepath=str(tmp_path / filename)
-    )
+    return DMRParser(root=ET.fromstring(dmrpp_xml_str), data_filepath=filepath)
 
 
 @requires_network
@@ -220,36 +388,44 @@ def test_NASA_dmrpp_load(data_url, dmrpp_url):
 
 
 @pytest.mark.parametrize(
-    "dmrpp_xml_str_key, fqn_path, expected_xpath",
+    "fqn_path, expected_xpath",
     [
-        ("basic", "/", "."),
-        ("basic", "/data", "./*[@name='data']"),
-        ("basic", "/data/items", "./*[@name='data']/*[@name='items']"),
-        (
-            "nested_groups",
-            "/group1/group2/area",
-            "./*[@name='group1']/*[@name='group2']/*[@name='area']",
-        ),
+        ("/", "."),
+        ("/air", "./*[@name='air']"),
     ],
 )
-def test_find_node_fqn(tmp_path, dmrpp_xml_str_key, fqn_path, expected_xpath):
-    parser_instance = dmrparser(DMRPP_XML_STRINGS[dmrpp_xml_str_key], tmp_path=tmp_path)
+def test_find_node_fqn_simple(netcdf4_file, fqn_path, expected_xpath):
+    parser_instance = dmrparser(
+        DMRPP_XML_STRINGS["netcdf4_file"], filepath=netcdf4_file
+    )
     result = parser_instance.find_node_fqn(fqn_path)
     expected = parser_instance.root.find(expected_xpath, parser_instance._NS)
     assert result == expected
 
 
+def test_find_node_fqn_grouped(hdf5_groups_file):
+    parser_instance = dmrparser(
+        DMRPP_XML_STRINGS["hdf5_groups_file"], filepath=hdf5_groups_file
+    )
+    result = parser_instance.find_node_fqn("/test/group/air")
+    expected = parser_instance.root.find(
+        "./*[@name='test']/*[@name='group']/*[@name='air']", parser_instance._NS
+    )
+    assert result == expected
+
+
 @pytest.mark.parametrize(
-    "dmrpp_xml_str_key, group_path",
+    "group_path",
     [
-        ("basic", "/"),
-        ("nested_groups", "/"),
-        ("nested_groups", "/group1"),
-        ("nested_groups", "/group1/group2"),
+        ("/"),
+        ("/test"),
+        ("/test/group"),
     ],
 )
-def test_split_groups(tmp_path, dmrpp_xml_str_key, group_path):
-    dmrpp_instance = dmrparser(DMRPP_XML_STRINGS[dmrpp_xml_str_key], tmp_path=tmp_path)
+def test_split_groups(hdf5_groups_file, group_path):
+    dmrpp_instance = dmrparser(
+        DMRPP_XML_STRINGS["hdf5_groups_file"], filepath=hdf5_groups_file
+    )
 
     # get all tags in a dataset (so all tags excluding nested groups)
     dataset_tags = lambda x: [
@@ -264,155 +440,91 @@ def test_split_groups(tmp_path, dmrpp_xml_str_key, group_path):
 
 
 @pytest.mark.parametrize(
-    "dim_path, expected",
+    "group,warns",
     [
-        ("/a", {"a": 10}),
-        ("/group1/x", {"x": 720}),
+        pytest.param(None, False, id="None"),
+        pytest.param("/", False, id="/"),
+        pytest.param("/no-such-group", True, id="/no-such-group"),
     ],
 )
-def test_parse_dim(tmp_path, dim_path, expected):
+def test_parse_dataset(group: str | None, warns: bool, netcdf4_file):
+    drmpp = dmrparser(DMRPP_XML_STRINGS["netcdf4_file"], filepath=netcdf4_file)
+    store = obstore_local(file_url=drmpp.data_filepath)
+
+    with nullcontext() if warns else pytest.raises(BaseException, match="DID NOT WARN"):
+        with pytest.warns(UserWarning, match=f"ignoring group parameter {group!r}"):
+            ms = drmpp.parse_dataset(object_store=store, group=group)
+
+    vds = ms.to_virtual_dataset(loadable_variables=None, indexes=None)
+
+    assert vds.sizes == {"lat": 25, "lon": 53, "time": 2920}
+    assert vds.data_vars.keys() == {"air"}
+    assert vds.data_vars["air"].dims == ("time", "lat", "lon")
+    assert vds.attrs == {
+        "Conventions": "COARDS",
+        "title": "4x daily NMC reanalysis (1948)",
+        "description": "Data is from NMC initialized reanalysis\n(4x/day).  These are the 0.9950 sigma level values.",
+        "platform": "Model",
+        "references": "http://www.esrl.noaa.gov/psd/data/gridded/data.ncep.reanalysis.html",
+    }
+    assert vds.coords.keys() == {"lat", "lon", "time"}
+
+
+def test_parse_dataset_nested(hdf5_groups_file):
     nested_groups_dmrpp = dmrparser(
-        DMRPP_XML_STRINGS["nested_groups"], tmp_path=tmp_path
+        DMRPP_XML_STRINGS["hdf5_groups_file"], filepath=hdf5_groups_file
     )
+    store = obstore_local(file_url=nested_groups_dmrpp.data_filepath)
 
-    result = nested_groups_dmrpp._parse_dim(nested_groups_dmrpp.find_node_fqn(dim_path))
-    assert result == expected
+    vds_root_implicit = nested_groups_dmrpp.parse_dataset(
+        object_store=store
+    ).to_virtual_dataset(loadable_variables=[])
+    vds_root = nested_groups_dmrpp.parse_dataset(
+        group="/", object_store=store
+    ).to_virtual_dataset(loadable_variables=[])
+
+    xrt.assert_identical(vds_root_implicit, vds_root)
+    assert vds_root.sizes == {}
+
+    vds_g1 = nested_groups_dmrpp.parse_dataset(
+        group="/test", object_store=store
+    ).to_virtual_dataset(loadable_variables=[])
+    assert vds_g1.sizes == {}
+
+    vds_g2 = nested_groups_dmrpp.parse_dataset(
+        group="/test/group", object_store=store
+    ).to_virtual_dataset(loadable_variables=[])
+
+    assert vds_g2.sizes == {"time": 2920, "lat": 25, "lon": 53}
+    assert vds_g2.data_vars.keys() == {"air"}
+    assert vds_g2.data_vars["air"].dims == ("time", "lat", "lon")
 
 
-@pytest.mark.parametrize("dim_path", ["/", "/mask"])
-def test_find_dimension_tags(tmp_path, dim_path):
-    basic_dmrpp = dmrparser(DMRPP_XML_STRINGS["basic"], tmp_path=tmp_path)
+def test_parse_variable(netcdf4_file):
+    parser = dmrparser(DMRPP_XML_STRINGS["netcdf4_file"], filepath=netcdf4_file)
 
-    # Check that Dimension tags match Dimension tags from the root
-    # Check that Dim tags reference the same Dimension tags from the root
-    assert basic_dmrpp._find_dimension_tags(
-        basic_dmrpp.find_node_fqn(dim_path)
-    ) == basic_dmrpp.root.findall("dap:Dimension", basic_dmrpp._NS)
-
-
-def test_parse_variable(tmp_path):
-    basic_dmrpp = dmrparser(DMRPP_XML_STRINGS["basic"], tmp_path=tmp_path)
-
-    var = basic_dmrpp._parse_variable(basic_dmrpp.find_node_fqn("/data"))
-    assert var.metadata.dtype == "float32"
-    assert var.metadata.dimension_names == ("x", "y")
-    assert var.shape == (720, 1440)
-    assert var.chunks == (360, 720)
+    var = parser._parse_variable(parser.find_node_fqn("/air"))
+    assert var.metadata.dtype == "int16"
+    assert var.metadata.dimension_names == ("time", "lat", "lon")
+    assert var.shape == (2920, 25, 53)
+    assert var.chunks == (2920, 25, 53)
     # _FillValue is encoded for array dtype
-    assert var.metadata.attributes["_FillValue"] == "AAAAAAAA4MA="
-    assert var.metadata.attributes["add_offset"] == 298.15
-    assert var.metadata.attributes["scale_factor"] == 0.001
-    assert var.metadata.attributes["long_name"] == "analysed sea surface temperature"
-    assert var.metadata.attributes["items"] == [1, 2, 3]
-    assert var.metadata.attributes["coordinates"] == "x y z"
+    assert var.metadata.attributes["scale_factor"] == 0.01
+    assert (
+        var.metadata.attributes["long_name"]
+        == "4xDaily Air temperature at sigma level 995"
+    )
 
 
 @pytest.mark.parametrize(
     "attr_path, expected",
     [
-        ("data/long_name", {"long_name": "analysed sea surface temperature"}),
-        ("data/items", {"items": [1, 2, 3]}),
-        ("data/_FillValue", {"_FillValue": -32768}),
+        ("air/long_name", {"long_name": "4xDaily Air temperature at sigma level 995"}),
+        ("air/scale_factor", {"scale_factor": 0.01}),
     ],
 )
-def test_parse_attribute(tmp_path, attr_path, expected):
-    basic_dmrpp = dmrparser(DMRPP_XML_STRINGS["basic"], tmp_path=tmp_path)
+def test_parse_attribute(netcdf4_file, attr_path, expected):
+    parser = dmrparser(DMRPP_XML_STRINGS["netcdf4_file"], filepath=netcdf4_file)
 
-    result = basic_dmrpp._parse_attribute(basic_dmrpp.find_node_fqn(attr_path))
+    result = parser._parse_attribute(parser.find_node_fqn(attr_path))
     assert result == expected
-
-
-@pytest.mark.parametrize(
-    "var_path, dtype, expected_filters",
-    [
-        (
-            "/data",
-            np.dtype("float32"),
-            [
-                {
-                    "configuration": {"elementsize": np.dtype("float32").itemsize},
-                    "name": "numcodecs.shuffle",
-                },
-                {"name": "numcodecs.zlib", "configuration": {"level": 5}},
-            ],
-        ),
-        (
-            "/mask",
-            np.dtype("float32"),
-            [
-                {
-                    "configuration": {"elementsize": np.dtype("float32").itemsize},
-                    "name": "numcodecs.shuffle",
-                }
-            ],
-        ),
-    ],
-)
-def test_parse_filters(tmp_path, var_path, dtype, expected_filters):
-    basic_dmrpp = dmrparser(DMRPP_XML_STRINGS["basic"], tmp_path=tmp_path)
-
-    chunks_tag = basic_dmrpp.find_node_fqn(var_path).find(
-        "dmrpp:chunks", basic_dmrpp._NS
-    )
-    result = basic_dmrpp._parse_filters(chunks_tag, dtype)
-    assert result == expected_filters
-
-
-@pytest.mark.parametrize(
-    "var_path, chunk_shape, chunk_grid_shape, expected_lengths, expected_offsets",
-    [
-        (
-            "/data",
-            (360, 720),
-            (3, 3),
-            np.full((3, 3), 4083, dtype=np.uint64),
-            (np.arange(9, dtype=np.uint64) * 4083 + 40762).reshape(3, 3),
-        ),
-        (
-            "/mask",
-            (720, 1440),
-            (1,),
-            np.array([4], dtype=np.uint64),
-            np.array([41276], dtype=np.uint64),
-        ),
-    ],
-)
-def test_parse_chunks(
-    tmp_path,
-    var_path,
-    chunk_shape,
-    chunk_grid_shape,
-    expected_lengths,
-    expected_offsets,
-):
-    basic_dmrpp = dmrparser(DMRPP_XML_STRINGS["basic"], tmp_path=tmp_path)
-
-    chunks_tag = basic_dmrpp.find_node_fqn(var_path).find(
-        "dmrpp:chunks", basic_dmrpp._NS
-    )
-    result = basic_dmrpp._parse_chunks(chunks_tag, chunk_shape)
-
-    expected_paths = np.full(
-        shape=chunk_grid_shape,
-        fill_value=str(tmp_path / "test.nc"),
-        dtype=np.dtypes.StringDType,
-    )
-    expected = ChunkManifest.from_arrays(
-        lengths=expected_lengths, offsets=expected_offsets, paths=expected_paths
-    )
-    assert result == expected
-
-
-@pytest.fixture
-def basic_dmrpp_temp_filepath(tmp_path: Path) -> Path:
-    # TODO generalize key here? Would require the factory pattern
-    # (https://docs.pytest.org/en/stable/how-to/fixtures.html#factories-as-fixtures)
-    drmpp_xml_str = DMRPP_XML_STRINGS["basic"]
-
-    # TODO generalize filename here?
-    filepath = tmp_path / "test.nc.dmrpp"
-
-    with open(filepath, "w") as f:
-        f.write(drmpp_xml_str)
-
-    return filepath

--- a/virtualizarr/tests/utils.py
+++ b/virtualizarr/tests/utils.py
@@ -8,8 +8,8 @@ from obstore.store import LocalStore, ObjectStore, from_url
 
 
 def obstore_local(file_url: str) -> ObjectStore:
-    path = Path(file_url)
-    store = LocalStore(prefix=path.parent)
+    path = Path(file_url).resolve()
+    store = LocalStore(prefix=str(path.parent))
     return store
 
 


### PR DESCRIPTION
Zarr python allows some exceptions to pass because nodes in the hierarchy that contain only fill values can be represented by missing files. We have a different way of representing missing files after https://github.com/zarr-developers/VirtualiZarr/pull/668, so we should never be expecting to have a failed get request due to a FileNotFoundError. I don't think we should expect the other errors used in regular Zarr store implementations.

TODO: 
- [x] Fix failing DMR++ tests, which likely relate to the test data not actually existing.
- [x] Fix `TestToVirtualXarray` tests
- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
