### PR TITLE
Ensure virtual chunk container points to pytest temporary directory

### DIFF
--- a/virtualizarr/tests/test_writers/test_icechunk.py
+++ b/virtualizarr/tests/test_writers/test_icechunk.py
@@ -28,8 +28,8 @@ if TYPE_CHECKING:
     )
 
 
-# Set pytest temporary data into a known location in what should be a cross-platform way. See https://docs.pytest.org/en/stable/how-to/tmp_path.html#temporary-directory-location-and-retention
-# The realpath call is there to resolve with symbolic links, such as from /var/ to /private/var/ on MacOS, as Icechunk also needs to know the entire URI prefix.
+# Find location of pytest temporary data in what should be a cross-platform way. This should be the same as what pytest actually does - see https://docs.pytest.org/en/stable/how-to/tmp_path.html#temporary-directory-location-and-retention
+# The realpath call is there to resolve any symbolic links, such as from /var/ to /private/var/ on MacOS, as Icechunk needs the entire URI prefix without symlinks.
 PYTEST_TMP_DIRECTORY_URI_PREFIX = f"file://{os.path.realpath(tempfile.gettempdir())}"
 
 


### PR DESCRIPTION
I find that since v1.0.0, Icechunk tests fail locally for me (on MacOS), as they are unable to find quite the right path to use for the virtual chunk container. Instead of guessing, I looked up [how pytest actually chooses the temporary directory](https://docs.pytest.org/en/stable/how-to/tmp_path.html#temporary-directory-location-and-retention), and just made a single virtual chunk container pointing at that directory.

This is really a follow-up to #673, to try and ensure it works on all machines.
