### PR TITLE
Support HDF over HTTPS

### DIFF
--- a/virtualizarr/parsers/dmrpp.py
+++ b/virtualizarr/parsers/dmrpp.py
@@ -61,8 +61,8 @@ class DMRPPParser:
         ManifestStore
             A ManifestStore that provides a Zarr representation of the parsed file.
         """
-        store, _ = registry.resolve(file_url)
-        reader = ObstoreReader(store=store, path=file_url)
+        store, path_in_store = registry.resolve(file_url)
+        reader = ObstoreReader(store=store, path=path_in_store)
         file_bytes = reader.readall()
         stream = io.BytesIO(file_bytes)
 

--- a/virtualizarr/parsers/hdf/hdf.py
+++ b/virtualizarr/parsers/hdf/hdf.py
@@ -5,7 +5,6 @@ from typing import (
     TYPE_CHECKING,
     Iterable,
 )
-from urllib.parse import urlparse
 
 import numpy as np
 
@@ -140,8 +139,8 @@ class HDFParser:
         file_url: str,
         registry: ObjectStoreRegistry,
     ) -> ManifestStore:
-        store, _ = registry.resolve(file_url)
-        reader = ObstoreReader(store=store, path=urlparse(file_url).path)
+        store, path_in_store = registry.resolve(file_url)
+        reader = ObstoreReader(store=store, path=path_in_store)
         manifest_group = _construct_manifest_group(
             filepath=file_url,
             reader=reader,

--- a/virtualizarr/tests/test_parsers/test_hdf/test_hdf.py
+++ b/virtualizarr/tests/test_parsers/test_hdf/test_hdf.py
@@ -2,9 +2,11 @@ import h5py  # type: ignore
 import numpy as np
 import pytest
 import xarray as xr
+from obstore.store import from_url
 
 from virtualizarr import open_virtual_dataset
 from virtualizarr.parsers import HDFParser
+from virtualizarr.registry import ObjectStoreRegistry
 from virtualizarr.tests import (
     requires_hdf5plugin,
     requires_imagecodecs,
@@ -195,3 +197,13 @@ def test_subgroup_variable_names(
         parser=parser,
     ) as vds:
         assert list(vds.dims) == ["dim_0"]
+
+
+def test_netcdf_over_https():
+    url = "https://oceania.generic-mapping-tools.org/cache/Iceland.nc"
+    store = from_url(url)
+    registry = ObjectStoreRegistry({url: store})
+    parser = HDFParser()
+    with parser(file_url=url, registry=registry) as ms:
+        ds = xr.open_zarr(ms, zarr_format=3, consolidated=False).load()
+        np.testing.assert_allclose(ds["z"].min().to_numpy(), -1857)

--- a/virtualizarr/tests/test_parsers/test_hdf/test_hdf.py
+++ b/virtualizarr/tests/test_parsers/test_hdf/test_hdf.py
@@ -10,6 +10,7 @@ from virtualizarr.registry import ObjectStoreRegistry
 from virtualizarr.tests import (
     requires_hdf5plugin,
     requires_imagecodecs,
+    requires_network,
 )
 from virtualizarr.tests.utils import manifest_store_from_hdf_url
 
@@ -199,6 +200,7 @@ def test_subgroup_variable_names(
         assert list(vds.dims) == ["dim_0"]
 
 
+@requires_network
 def test_netcdf_over_https():
     url = "https://oceania.generic-mapping-tools.org/cache/Iceland.nc"
     store = from_url(url)

--- a/virtualizarr/utils.py
+++ b/virtualizarr/utils.py
@@ -4,10 +4,9 @@ import copy
 import importlib
 import io
 import json
-import os
 from typing import TYPE_CHECKING, Any, Iterable, Mapping, Optional, Sequence, Union
-from urllib.parse import urlparse
 
+import obstore as obs
 from zarr.abc.codec import ArrayArrayCodec, BytesBytesCodec
 from zarr.core.metadata import ArrayV2Metadata, ArrayV3Metadata
 
@@ -30,25 +29,22 @@ if TYPE_CHECKING:
     ]
 
 
-def remove_prefix(store: ObjectStore, path: str) -> str:
-    """Remove a store prefix like file:/// or memory:// if it exists in the path"""
-    parsed = urlparse(path)
-    if hasattr(store, "prefix") and store.prefix:
-        filepath = os.path.basename(parsed.path)
-    else:
-        filepath = parsed.path
-
-    return filepath
-
-
 class ObstoreReader:
     _reader: ReadableFile
 
     def __init__(self, store: ObjectStore, path: str) -> None:
-        import obstore as obs
+        """
+        Create an obstore file reader that implements the read, readall, seek, and tell methods, which
+        can be used in libraries that file-like objects.
 
-        filepath = remove_prefix(store, path)
-        self._reader = obs.open_reader(store, filepath)
+        Parameters
+        ----------
+        store
+            [ObjectStore][obstore.store.ObjectStore] for reading the file.
+        path
+            The path to the file within the store. This should not include the prefix.
+        """
+        self._reader = obs.open_reader(store, path)
 
     def read(self, size: int, /) -> bytes:
         return self._reader.read(size).to_bytes()


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
The HDF and DMRPP files previously didn't work when using an `HTTPStore` that was mounted using a prefix, which is almost always the case when using `obstore.from_url`. This PR fixes that by using the more robust prefix parsing code inside `ObjectStoreRegistry` rather than a separate lighter weight version in `ObstoreReader`. It also documents the inputs for `ObstoreReader` so users know to not include the prefix.

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
