### PR TITLE
Standardize open_virtual_*dataset/parser signature to use "url"

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -268,12 +268,12 @@ def netcdf4_virtual_dataset(netcdf4_file):
     from virtualizarr.parsers import HDFParser
     from virtualizarr.tests.utils import obstore_local
 
-    store = obstore_local(file_url=netcdf4_file)
+    store = obstore_local(url=netcdf4_file)
     registry = ObjectStoreRegistry()
     registry.register("file://", store)
     parser = HDFParser()
     with open_virtual_dataset(
-        file_url=netcdf4_file,
+        url=netcdf4_file,
         registry=registry,
         parser=parser,
         loadable_variables=[],
@@ -394,7 +394,7 @@ def virtual_variable(array_v3_metadata: Callable) -> Callable:
     """Generate a virtual variable with configurable parameters."""
 
     def _virtual_variable(
-        file_uri: str,
+        url: str,
         shape: tuple[int, ...] = (3, 4),
         chunk_shape: tuple[int, ...] = (3, 4),
         dtype: np.dtype = np.dtype("int32"),
@@ -407,7 +407,7 @@ def virtual_variable(array_v3_metadata: Callable) -> Callable:
         attrs: dict[str, Any] = {},
     ) -> xr.Variable:
         manifest = _generate_chunk_manifest(
-            file_uri,
+            url,
             shape=shape,
             chunks=chunk_shape,
             offset=offset,
@@ -436,7 +436,7 @@ def virtual_dataset(virtual_variable: Callable) -> Callable:
     """Generate a virtual dataset with configurable parameters."""
 
     def _virtual_dataset(
-        file_uri: str,
+        url: str,
         shape: tuple[int, ...] = (3, 4),
         chunk_shape: tuple[int, ...] = (3, 4),
         dtype: np.dtype = np.dtype("int32"),
@@ -449,9 +449,9 @@ def virtual_dataset(virtual_variable: Callable) -> Callable:
         dims: Optional[list[str]] = None,
         coords: Optional[xr.Coordinates] = None,
     ) -> xr.Dataset:
-        with xr.open_dataset(file_uri) as ds:
+        with xr.open_dataset(url) as ds:
             var = virtual_variable(
-                file_uri=file_uri,
+                url=url,
                 shape=shape,
                 chunk_shape=chunk_shape,
                 dtype=dtype,

--- a/virtualizarr/parsers/dmrpp.py
+++ b/virtualizarr/parsers/dmrpp.py
@@ -42,33 +42,33 @@ class DMRPPParser:
 
     def __call__(
         self,
-        file_url: str,
+        url: str,
         registry: ObjectStoreRegistry,
     ) -> ManifestStore:
         """
-        Parse the metadata and byte offsets from a given file to product a
+        Parse the metadata and byte offsets from a given DMR++ file to product a
         VirtualiZarr ManifestStore.
 
         Parameters
         ----------
-        file_url
-            The URI or path to the input file (e.g., "s3://bucket/file.dmrpp").
+        url
+            The URL of the input DMR++ file (e.g., "s3://bucket/file.dmrpp").
         registry
             An [ObjectStoreRegistry][virtualizarr.registry.ObjectStoreRegistry] for resolving urls and reading data.
 
         Returns
         -------
         ManifestStore
-            A ManifestStore that provides a Zarr representation of the parsed file.
+            A ManifestStore that provides a Zarr representation of the data source referenced by the DMR++ file.
         """
-        store, path_in_store = registry.resolve(file_url)
+        store, path_in_store = registry.resolve(url)
         reader = ObstoreReader(store=store, path=path_in_store)
         file_bytes = reader.readall()
         stream = io.BytesIO(file_bytes)
 
         parser = DMRParser(
             root=ET.parse(stream).getroot(),
-            data_filepath=file_url.removesuffix(".dmrpp"),
+            data_filepath=url.removesuffix(".dmrpp"),
             skip_variables=self.skip_variables,
         )
         manifest_store = parser.parse_dataset(object_store=store, group=self.group)

--- a/virtualizarr/parsers/fits.py
+++ b/virtualizarr/parsers/fits.py
@@ -34,7 +34,7 @@ class FITSParser:
 
     def __call__(
         self,
-        file_url: str,
+        url: str,
         registry: ObjectStoreRegistry,
     ) -> ManifestStore:
         """
@@ -42,23 +42,21 @@ class FITSParser:
 
         Parameters
         ----------
-        file_url
-            The URI or path to the input file (e.g., "s3://bucket/file.fits").
+        url
+            The URL of the input FITS file (e.g., "s3://bucket/file.fits").
         registry
             An [ObjectStoreRegistry][virtualizarr.registry.ObjectStoreRegistry] for resolving urls and reading data.
 
         Returns
         -------
         ManifestStore
-            A ManifestStore which provides a Zarr representation of the parsed file.
+            A ManifestStore which provides a Zarr representation of the parsed FITS file.
         """
 
         from kerchunk.fits import process_file
 
         # handle inconsistency in kerchunk, see GH issue https://github.com/zarr-developers/VirtualiZarr/issues/160
-        refs = KerchunkStoreRefs(
-            {"refs": process_file(file_url, **self.reader_options)}
-        )
+        refs = KerchunkStoreRefs({"refs": process_file(url, **self.reader_options)})
 
         manifestgroup = manifestgroup_from_kerchunk_refs(
             refs,

--- a/virtualizarr/parsers/hdf/hdf.py
+++ b/virtualizarr/parsers/hdf/hdf.py
@@ -132,7 +132,7 @@ class HDFParser:
         drop_variables: Iterable[str] | None = None,
     ):
         """
-        Instantiate a parser with parser-specific parameters that can be used in the
+        Instantiate a parser that can be used to virtualize HDF5/NetCDF4 files using the
         `__call__` method.
 
         Parameters
@@ -148,7 +148,7 @@ class HDFParser:
 
     def __call__(
         self,
-        file_url: str,
+        url: str,
         registry: ObjectStoreRegistry,
     ) -> ManifestStore:
         """
@@ -157,8 +157,8 @@ class HDFParser:
 
         Parameters
         ----------
-        file_url
-            The URI or path to the input HDF5/NetCDF4 file (e.g., `"s3://bucket/store.zarr"`).
+        url
+            The URL of the input HDF5/NetCDF4 file (e.g., `"s3://bucket/store.zarr"`).
         registry
             An [ObjectStoreRegistry][virtualizarr.registry.ObjectStoreRegistry] for resolving urls and reading data.
 
@@ -167,10 +167,10 @@ class HDFParser:
         ManifestStore
             A [ManifestStore][virtualizarr.manifests.ManifestStore] which provides a Zarr representation of the parsed file.
         """
-        store, path_in_store = registry.resolve(file_url)
+        store, path_in_store = registry.resolve(url)
         reader = ObstoreReader(store=store, path=path_in_store)
         manifest_group = _construct_manifest_group(
-            filepath=file_url,
+            filepath=url,
             reader=reader,
             group=self.group,
             drop_variables=self.drop_variables,

--- a/virtualizarr/parsers/kerchunk/json.py
+++ b/virtualizarr/parsers/kerchunk/json.py
@@ -22,11 +22,11 @@ class KerchunkJSONParser:
         Parameters
         ----------
         group
-            The group within the file to be used as the Zarr root group for the ManifestStore.
+            The group within the Kerchunk JSON to be used as the Zarr root group for the ManifestStore.
         fs_root
-            The qualifier to be used for kerchunk references containing relative paths.
+            The qualifier to be used for Kerchunk chunk references containing relative paths.
         skip_variables
-            Variables in the file that will be ignored when creating the ManifestStore.
+            Variables in the Kerchunk JSON that will be ignored when creating the ManifestStore.
         """
 
         self.group = group
@@ -35,26 +35,26 @@ class KerchunkJSONParser:
 
     def __call__(
         self,
-        file_url: str,
+        url: str,
         registry: ObjectStoreRegistry,
     ) -> ManifestStore:
         """
-        Parse the metadata and byte offsets from a given file to produce a
+        Parse the metadata and byte offsets from a given Kerchunk JSON to produce a
         VirtualiZarr ManifestStore.
 
         Parameters
         ----------
-        file_url
-            The URI or path to the input file (e.g., "s3://bucket/kerchunk.json").
+        url
+            The URL of the input Kerchunk JSON (e.g., "s3://bucket/kerchunk.json").
         registry
             An [ObjectStoreRegistry][virtualizarr.registry.ObjectStoreRegistry] for resolving urls and reading data.
 
         Returns
         -------
         ManifestStore
-            A ManifestStore that provides a Zarr representation of the parsed file.
+            A ManifestStore that provides a Zarr representation of the parsed Kerchunk JSON.
         """
-        store, path_after_prefix = registry.resolve(file_url)
+        store, path_after_prefix = registry.resolve(url)
 
         # we need the whole thing so just get the entire contents in one request
         resp = store.get(path_after_prefix)

--- a/virtualizarr/parsers/kerchunk/parquet.py
+++ b/virtualizarr/parsers/kerchunk/parquet.py
@@ -34,17 +34,17 @@ class KerchunkParquetParser:
         reader_options: dict | None = None,
     ):
         """
-        Instantiate a parser with parser-specific parameters that can be used in the
-        `__call__` method.
+        Instantiate a parser for virtualizing Kerchunk's Parquet references into a Virtual Zarr store
+        using the `__call__` method.
 
         Parameters
         ----------
         group
-            The group within the file to be used as the Zarr root group for the ManifestStore.
+            The group within the input Kerchunk Parquet references to be used as the Zarr root group for the ManifestStore.
         fs_root
-            The qualifier to be used for kerchunk references containing relative paths.
+            The qualifier to be used for chunk references containing relative paths.
         skip_variables
-            Variables in the file that will be ignored when creating the ManifestStore.
+            Variables in the Kerchunk Parquet references that will be ignored when creating the ManifestStore.
         reader_options
             Configuration options used internally for the fsspec backend.
         """
@@ -56,32 +56,32 @@ class KerchunkParquetParser:
 
     def __call__(
         self,
-        file_url: str,
+        url: str,
         registry: ObjectStoreRegistry,
     ) -> ManifestStore:
         """
-        Parse the metadata and byte offsets from a given file to product a
+        Parse the metadata and byte offsets from a given Kerchunk Parquet directory to product a
         VirtualiZarr ManifestStore.
 
         Parameters
         ----------
-        file_url
-            The URI or path to the input parquet directory (e.g., "s3://bucket/file.parq").
+        url
+            The URL of the input parquet directory (e.g., "s3://bucket/my-kerchunk-references.parq").
         registry
             An [ObjectStoreRegistry][virtualizarr.registry.ObjectStoreRegistry] for resolving urls and reading data.
 
         Returns
         -------
         ManifestStore
-            A ManifestStore which provides a Zarr representation of the parsed file.
+            A ManifestStore which provides a Zarr representation based on the parsed Kerchunk Parquet directory.
         """
 
         # The kerchunk .parquet storage format isn't actually a parquet, but a
         # directory that contains named parquets for each group/variable.
-        fs = _FsspecFSFromFilepath(file_url, self.reader_options)
+        fs = _FsspecFSFromFilepath(url, self.reader_options)
         from fsspec.implementations.reference import LazyReferenceMapper
 
-        lrm = LazyReferenceMapper(file_url, fs.fs)
+        lrm = LazyReferenceMapper(url, fs.fs)
 
         # build reference dict from KV pairs in LazyReferenceMapper
         # is there a better / more performant way to extract this?

--- a/virtualizarr/parsers/netcdf3.py
+++ b/virtualizarr/parsers/netcdf3.py
@@ -33,31 +33,29 @@ class NetCDF3Parser:
 
     def __call__(
         self,
-        file_url: str,
+        url: str,
         registry: ObjectStoreRegistry,
     ) -> ManifestStore:
         """
-        Parse the metadata and byte offsets from a given file to product a VirtualiZarr ManifestStore.
+        Parse the metadata and byte offsets from a given NetCDF3 file to product a VirtualiZarr ManifestStore.
 
         Parameters
         ----------
-        file_url
-            The URI or path to the input file (e.g., "s3://bucket/file.nc").
+        url
+            The URL of the input NetCDF3 file (e.g., "s3://bucket/file.nc").
         registry
             An [ObjectStoreRegistry][virtualizarr.registry.ObjectStoreRegistry] for resolving urls and reading data.
 
         Returns
         -------
         ManifestStore
-            A ManifestStore that provides a Zarr representation of the parsed file.
+            A ManifestStore that provides a Zarr representation of the parsed NetCDF3 file.
         """
 
         from kerchunk.netCDF3 import NetCDF3ToZarr
 
         # handle inconsistency in kerchunk, see GH issue https://github.com/zarr-developers/VirtualiZarr/issues/160
-        refs = NetCDF3ToZarr(
-            file_url, inline_threshold=0, **self.reader_options
-        ).translate()
+        refs = NetCDF3ToZarr(url, inline_threshold=0, **self.reader_options).translate()
 
         manifestgroup = manifestgroup_from_kerchunk_refs(
             refs,

--- a/virtualizarr/parsers/tiff.py
+++ b/virtualizarr/parsers/tiff.py
@@ -34,7 +34,7 @@ class Parser:
 
     def __call__(
         self,
-        file_url: str,
+        url: str,
         registry: ObjectStoreRegistry,
     ) -> ManifestStore:
         """
@@ -42,23 +42,21 @@ class Parser:
 
         Parameters
         ----------
-        file_url
-            The URI or path to the input file (e.g., "s3://bucket/file.tiff").
+        url
+            The URL of the input TIFF file (e.g., "s3://bucket/file.tiff").
         registry
             An [ObjectStoreRegistry][virtualizarr.registry.ObjectStoreRegistry] for resolving urls and reading data.
 
         Returns
         -------
         ManifestStore
-            A ManifestStore which provides a Zarr representation of the parsed file.
+            A ManifestStore which provides a Zarr representation of the parsed TIFF file.
         """
 
         from kerchunk.tiff import tiff_to_zarr
 
         # handle inconsistency in kerchunk, see GH issue https://github.com/zarr-developers/VirtualiZarr/issues/160
-        refs = KerchunkStoreRefs(
-            {"refs": tiff_to_zarr(file_url, **self.remote_options)}
-        )
+        refs = KerchunkStoreRefs({"refs": tiff_to_zarr(url, **self.remote_options)})
 
         manifestgroup = manifestgroup_from_kerchunk_refs(
             refs,

--- a/virtualizarr/parsers/typing.py
+++ b/virtualizarr/parsers/typing.py
@@ -10,24 +10,25 @@ from virtualizarr.registry import ObjectStoreRegistry
 class Parser(Protocol):
     def __call__(
         self,
-        file_url: str,
+        url: str,
         registry: ObjectStoreRegistry,
     ) -> ManifestStore: ...
 
     """
-    Parse the contents of a given file to produce a ManifestStore.
+    Parse the contents of a given data source to produce a ManifestStore.
 
-    Effectively maps the contents of the file (e.g. metadata, compression codecs, chunk byte offsets) to the Zarr data model.
+    Effectively maps the contents of the data source (including the metadata, compression codecs, chunk byte offsets)
+    to the Zarr data model.
 
     Parameters
     ----------
-    file_url
-        The URL of the input file (e.g., "s3://bucket/file.nc").
+    url
+        The URL of the input data source (e.g., "s3://bucket/file.nc").
     registry
         An [ObjectStoreRegistry][virtualizarr.registry.ObjectStoreRegistry] for resolving urls and reading data.
 
     Returns
     -------
     ManifestStore
-        A ManifestStore which provides a Zarr representation of the parsed file.
+        A ManifestStore which provides a Zarr representation of the parsed data source.
     """

--- a/virtualizarr/tests/test_integration.py
+++ b/virtualizarr/tests/test_integration.py
@@ -91,7 +91,7 @@ def test_numpy_arrays_to_inlined_kerchunk_refs(
     # loading the variables should produce same result as inlining them using kerchunk
     parser = HDFParser()
     with open_virtual_dataset(
-        file_url=netcdf4_file,
+        url=netcdf4_file,
         registry=local_registry,
         parser=parser,
         loadable_variables=vars_to_inline,
@@ -207,7 +207,7 @@ class TestRoundtrip:
             registry = ObjectStoreRegistry({air_zarr_url: store})
             parser = ZarrParser()
             with open_virtual_dataset(
-                file_url=air_zarr_url,
+                url=air_zarr_url,
                 registry=registry,
                 parser=parser,
             ) as vds:
@@ -232,7 +232,7 @@ class TestRoundtrip:
             parser = HDFParser()
             # use open_dataset_via_kerchunk to read it as references
             with open_virtual_dataset(
-                file_url=air_nc_path, registry=local_registry, parser=parser
+                url=air_nc_path, registry=local_registry, parser=parser
             ) as vds:
                 roundtrip = roundtrip_func(vds, tmp_path, decode_times=False)
                 # assert all_close to original dataset
@@ -272,13 +272,13 @@ class TestRoundtrip:
             parser = HDFParser()
             with (
                 open_virtual_dataset(
-                    file_url=air1_nc_path,
+                    url=air1_nc_path,
                     registry=local_registry,
                     parser=parser,
                     loadable_variables=time_vars,
                 ) as vds1,
                 open_virtual_dataset(
-                    file_url=air2_nc_path,
+                    url=air2_nc_path,
                     registry=local_registry,
                     parser=parser,
                     loadable_variables=time_vars,
@@ -327,7 +327,7 @@ class TestRoundtrip:
 
         parser = HDFParser()
         with open_virtual_dataset(
-            file_url=nc_path, registry=local_registry, parser=parser
+            url=nc_path, registry=local_registry, parser=parser
         ) as vds:
             assert "lat" in vds.coords
             assert "coordinates" not in vds.attrs
@@ -405,14 +405,14 @@ def test_datatree_roundtrip(
         # use open_dataset_via_kerchunk to read it as references
         with (
             open_virtual_dataset(
-                file_url=air1_nc_path,
+                url=air1_nc_path,
                 registry=local_registry,
                 parser=parser,
                 loadable_variables=time_vars,
                 decode_times=decode_times,
             ) as vds1,
             open_virtual_dataset(
-                file_url=air2_nc_path,
+                url=air2_nc_path,
                 registry=local_registry,
                 parser=parser,
                 loadable_variables=time_vars,
@@ -482,21 +482,21 @@ def test_open_scalar_variable(tmp_path: Path, local_registry):
 
     parser = HDFParser()
     with open_virtual_dataset(
-        file_url=nc_path,
+        url=nc_path,
         registry=local_registry,
         parser=parser,
     ) as vds:
         assert vds["a"].shape == ()
-    ms = parser(file_url=f"file://{nc_path}", registry=local_registry)
+    ms = parser(url=f"file://{nc_path}", registry=local_registry)
     roundtripped = xr.open_zarr(ms, consolidated=False, zarr_format=3)
     xr.testing.assert_allclose(ds, roundtripped.load())
 
 
-class TestPathsToURIs:
-    def test_convert_absolute_paths_to_uris(self, netcdf4_file, local_registry):
+class TestPathsToURLs:
+    def test_convert_absolute_paths_to_urls(self, netcdf4_file, local_registry):
         parser = HDFParser()
         with open_virtual_dataset(
-            file_url=netcdf4_file,
+            url=netcdf4_file,
             registry=local_registry,
             parser=parser,
         ) as vds:
@@ -506,11 +506,11 @@ class TestPathsToURIs:
 
             assert path == expected_path
 
-    def test_convert_relative_paths_to_uris(self, netcdf4_file, local_registry):
+    def test_convert_relative_paths_to_urls(self, netcdf4_file, local_registry):
         relative_path = relpath(netcdf4_file)
         parser = HDFParser()
         with open_virtual_dataset(
-            file_url=relative_path,
+            url=relative_path,
             registry=local_registry,
             parser=parser,
         ) as vds:

--- a/virtualizarr/tests/test_parsers/test_dmrpp.py
+++ b/virtualizarr/tests/test_parsers/test_dmrpp.py
@@ -350,20 +350,20 @@ def dmrparser(dmrpp_xml_str: str, filepath: str) -> DMRParser:
 @pytest.mark.parametrize("data_url, dmrpp_url", urls)
 def test_NASA_dmrpp(data_url, dmrpp_url):
     store = obstore_s3(
-        file_url=dmrpp_url,
+        url=dmrpp_url,
         region="us-west-2",
     )
     registry = ObjectStoreRegistry()
     registry.register("s3://its-live-data/test-space", store)
     with (
         open_virtual_dataset(
-            file_url=dmrpp_url,
+            url=dmrpp_url,
             registry=registry,
             parser=DMRPPParser(),
             loadable_variables=[],
         ) as actual,
         open_virtual_dataset(
-            file_url=data_url,
+            url=data_url,
             registry=registry,
             parser=HDFParser(),
             loadable_variables=[],
@@ -376,13 +376,13 @@ def test_NASA_dmrpp(data_url, dmrpp_url):
 @pytest.mark.parametrize("data_url, dmrpp_url", urls)
 def test_NASA_dmrpp_load(data_url, dmrpp_url):
     store = obstore_s3(
-        file_url=dmrpp_url,
+        url=dmrpp_url,
         region="us-west-2",
     )
     registry = ObjectStoreRegistry()
     registry.register(dmrpp_url, store)
     parser = DMRPPParser()
-    manifest_store = parser(file_url=dmrpp_url, registry=registry)
+    manifest_store = parser(url=dmrpp_url, registry=registry)
 
     with xr.open_dataset(
         manifest_store, engine="zarr", consolidated=False, zarr_format=3
@@ -454,7 +454,7 @@ def test_parse_dataset(group: str | None, warns: bool, netcdf4_file):
     drmpp = dmrparser(
         DMRPP_XML_STRINGS["netcdf4_file"], filepath=f"file://{netcdf4_file}"
     )
-    store = obstore_local(file_url=drmpp.data_filepath)
+    store = obstore_local(url=drmpp.data_filepath)
 
     with nullcontext() if warns else pytest.raises(BaseException, match="DID NOT WARN"):
         with pytest.warns(UserWarning, match=f"ignoring group parameter {group!r}"):
@@ -479,7 +479,7 @@ def test_parse_dataset_nested(hdf5_groups_file):
     nested_groups_dmrpp = dmrparser(
         DMRPP_XML_STRINGS["hdf5_groups_file"], filepath=f"file://{hdf5_groups_file}"
     )
-    store = obstore_local(file_url=f"file://{nested_groups_dmrpp.data_filepath}")
+    store = obstore_local(url=f"file://{nested_groups_dmrpp.data_filepath}")
 
     vds_root_implicit = nested_groups_dmrpp.parse_dataset(
         object_store=store

--- a/virtualizarr/tests/test_parsers/test_fits.py
+++ b/virtualizarr/tests/test_parsers/test_fits.py
@@ -14,13 +14,13 @@ pytest.importorskip("astropy")
 @requires_network
 def test_open_hubble_data():
     # data from https://registry.opendata.aws/hst/
-    file_url = "s3://stpubdata/hst/public/f05i/f05i0201m/f05i0201m_a1f.fits"
-    store = obstore_s3(file_url=file_url, region="us-west-2")
+    url = "s3://stpubdata/hst/public/f05i/f05i0201m/f05i0201m_a1f.fits"
+    store = obstore_s3(url=url, region="us-west-2")
     parser = FITSParser(reader_options={"storage_options": {"anon": True}})
     registry = ObjectStoreRegistry()
-    registry.register(file_url, store)
+    registry.register(url, store)
     with open_virtual_dataset(
-        file_url=file_url,
+        url=url,
         registry=registry,
         parser=parser,
     ) as vds:

--- a/virtualizarr/tests/test_parsers/test_hdf/test_hdf.py
+++ b/virtualizarr/tests/test_parsers/test_hdf/test_hdf.py
@@ -137,9 +137,7 @@ class TestManifestGroupFromHDF:
 
     def test_drop_variables(self, multiple_datasets_hdf5_url, local_registry):
         parser = HDFParser(drop_variables=["data2"])
-        manifest_store = parser(
-            file_url=multiple_datasets_hdf5_url, registry=local_registry
-        )
+        manifest_store = parser(url=multiple_datasets_hdf5_url, registry=local_registry)
         assert "data2" not in manifest_store._group.arrays.keys()
 
     def test_dataset_in_group(self, group_hdf5_url):
@@ -158,7 +156,7 @@ class TestOpenVirtualDataset:
         root_coordinates_hdf5_url = f"file://{root_coordinates_hdf5_file}"
         parser = HDFParser()
         with open_virtual_dataset(
-            file_url=root_coordinates_hdf5_url,
+            url=root_coordinates_hdf5_url,
             registry=local_registry,
             parser=parser,
         ) as vds:
@@ -169,7 +167,7 @@ class TestOpenVirtualDataset:
         parser = HDFParser()
         with (
             parser(
-                file_url=big_endian_dtype_hdf5_url, registry=local_registry
+                url=big_endian_dtype_hdf5_url, registry=local_registry
             ) as manifest_store,
             xr.open_dataset(big_endian_dtype_hdf5_file) as expected,
         ):
@@ -192,7 +190,7 @@ def test_subgroup_variable_names(
     )
     parser = HDFParser(group=group)
     with open_virtual_dataset(
-        file_url=netcdf4_url_with_data_in_multiple_groups,
+        url=netcdf4_url_with_data_in_multiple_groups,
         registry=local_registry,
         parser=parser,
     ) as vds:
@@ -206,7 +204,7 @@ def test_netcdf_over_https():
     registry = ObjectStoreRegistry({url: store})
     parser = HDFParser()
     with (
-        parser(file_url=url, registry=registry) as ms,
+        parser(url=url, registry=registry) as ms,
         xr.open_zarr(ms, zarr_format=3, consolidated=False).load() as ds,
     ):
         np.testing.assert_allclose(ds["z"].min().to_numpy(), -6)

--- a/virtualizarr/tests/test_parsers/test_hdf/test_hdf_integration.py
+++ b/virtualizarr/tests/test_parsers/test_hdf/test_hdf_integration.py
@@ -27,7 +27,7 @@ class TestIntegration:
                 filter_encoded_roundtrip_hdf5_file, decode_times=True
             ) as ds,
             open_virtual_dataset(
-                file_url=url,
+                url=url,
                 registry=local_registry,
                 parser=parser,
                 loadable_variables=["time"],
@@ -49,7 +49,7 @@ class TestIntegration:
         with (
             xr.open_dataset(filepath) as ds,
             open_virtual_dataset(
-                file_url=filepath,
+                url=filepath,
                 parser=parser,
                 registry=local_registry,
             ) as vds,
@@ -67,7 +67,7 @@ class TestIntegration:
         with (
             xr.open_dataset(filter_and_cf_roundtrip_hdf5_file) as ds,
             open_virtual_dataset(
-                file_url=url,
+                url=url,
                 registry=local_registry,
                 parser=parser,
             ) as vds,
@@ -86,7 +86,7 @@ class TestIntegration:
         with (
             xr.open_dataset(non_coord_dim) as ds,
             open_virtual_dataset(
-                file_url=non_coord_dim,
+                url=non_coord_dim,
                 registry=local_registry,
                 parser=parser,
             ) as vds,
@@ -109,7 +109,7 @@ class TestIntegration:
                     " encoding in xarray zarr parser."
                 )
             with open_virtual_dataset(
-                file_url=cf_fill_value_hdf5_url,
+                url=cf_fill_value_hdf5_url,
                 registry=local_registry,
                 parser=parser,
             ) as vds:

--- a/virtualizarr/tests/test_parsers/test_hdf/test_hdf_manifest_store.py
+++ b/virtualizarr/tests/test_parsers/test_hdf/test_hdf_manifest_store.py
@@ -34,9 +34,9 @@ class TestHDFManifestStore:
         "Roundtrip a dataset to/from NetCDF with the HDF reader and ManifestStore"
 
         filepath = f"{tmpdir}/basic_ds_roundtrip.nc"
-        file_url = f"file://{filepath}"
+        url = f"file://{filepath}"
         basic_ds.to_netcdf(filepath, engine="h5netcdf")
-        manifest_store = manifest_store_from_hdf_url(file_url)
+        manifest_store = manifest_store_from_hdf_url(url)
         with xr.open_dataset(
             manifest_store, engine="zarr", consolidated=False, zarr_format=3
         ) as rountripped_ds:
@@ -46,12 +46,12 @@ class TestHDFManifestStore:
         "Roundtrip a dataset to/from NetCDF with the HDF reader and ManifestStore with a single partial chunk"
 
         filepath = f"{tmpdir}/basic_ds_roundtrip.nc"
-        file_url = f"file://{filepath}"
+        url = f"file://{filepath}"
         encoding = {
             "temperature": {"chunksizes": (90, 90), "original_shape": (100, 100)}
         }
         basic_ds.to_netcdf(filepath, engine="h5netcdf", encoding=encoding)
-        manifest_store = manifest_store_from_hdf_url(file_url)
+        manifest_store = manifest_store_from_hdf_url(url)
         with xr.open_dataset(
             manifest_store, engine="zarr", consolidated=False, zarr_format=3
         ) as rountripped_ds:
@@ -61,9 +61,9 @@ class TestHDFManifestStore:
         "Roundtrip a dataset to/from NetCDF with the HDF reader and ManifestStore"
 
         filepath = f"{tmpdir}/basic_ds_roundtrip.nc"
-        file_url = f"file://{filepath}"
+        url = f"file://{filepath}"
         basic_ds.to_netcdf(filepath, engine="h5netcdf")
-        manifest_store = manifest_store_from_hdf_url(file_url)
+        manifest_store = manifest_store_from_hdf_url(url)
         with xr.open_dataset(
             manifest_store, engine="zarr", consolidated=False, zarr_format=3
         ) as rountripped_ds:
@@ -91,9 +91,7 @@ class TestHDFManifestStore:
         registry = ObjectStoreRegistry()
         registry.register(url_without_file, s3store)
         parser = HDFParser()
-        manifest_store = parser(
-            file_url=chunked_roundtrip_hdf5_s3_file, registry=registry
-        )
+        manifest_store = parser(url=chunked_roundtrip_hdf5_s3_file, registry=registry)
 
         with manifest_store.to_virtual_dataset() as vds:
             assert vds.dims == {"phony_dim_0": 5}

--- a/virtualizarr/tests/test_parsers/test_kerchunk.py
+++ b/virtualizarr/tests/test_parsers/test_kerchunk.py
@@ -59,12 +59,12 @@ def refs_file_factory(
 
     def _refs_file(zgroup=None, zarray=None, zattrs=None, chunks=None) -> str:
         refs = gen_ds_refs(zgroup=zgroup, zarray=zarray, zattrs=zattrs, chunks=chunks)
-        file_url = tmp_path / "refs.json"
+        url = tmp_path / "refs.json"
 
-        with open(file_url, "w") as json_file:
+        with open(url, "w") as json_file:
             ujson.dump(refs, json_file)
 
-        return str(file_url)
+        return str(url)
 
     yield _refs_file
 
@@ -74,7 +74,7 @@ def test_dataset_from_df_refs(refs_file_factory, local_registry):
     refs_url = f"file://{refs_file}"
     parser = KerchunkJSONParser()
     with open_virtual_dataset(
-        file_url=refs_url, registry=local_registry, parser=parser
+        url=refs_url, registry=local_registry, parser=parser
     ) as vds:
         assert "a" in vds
         vda = vds["a"]
@@ -111,7 +111,7 @@ def test_dataset_from_df_refs_with_filters(refs_file_factory, local_registry):
     refs_file = refs_file_factory(zarray=ujson.dumps(zarray))
     parser = KerchunkJSONParser(fs_root="file://")
     with open_virtual_dataset(
-        file_url=refs_file, registry=local_registry, parser=parser
+        url=refs_file, registry=local_registry, parser=parser
     ) as vds:
         vda = vds["a"]
         assert vda.data.metadata.codecs[1].to_dict() == {
@@ -134,7 +134,7 @@ def test_empty_chunk_manifest(refs_file_factory, local_registry):
     refs_file = refs_file_factory(zarray=ujson.dumps(zarray), chunks={})
     parser = KerchunkJSONParser()
     with open_virtual_dataset(
-        file_url=refs_file, registry=local_registry, parser=parser
+        url=refs_file, registry=local_registry, parser=parser
     ) as vds:
         assert "a" in vds.variables
         assert isinstance(vds["a"].data, ManifestArray)
@@ -148,7 +148,7 @@ def test_handle_relative_paths(refs_file_factory, local_registry):
     parser = KerchunkJSONParser()
     with pytest.raises(ValueError, match="must be absolute posix paths"):
         with open_virtual_dataset(
-            file_url=refs_file,
+            url=refs_file,
             registry=local_registry,
             parser=parser,
         ) as _:
@@ -158,7 +158,7 @@ def test_handle_relative_paths(refs_file_factory, local_registry):
     parser = KerchunkJSONParser()
     with pytest.raises(ValueError, match="must be absolute posix paths"):
         with open_virtual_dataset(
-            file_url=refs_file,
+            url=refs_file,
             registry=local_registry,
             parser=parser,
         ) as _:
@@ -169,7 +169,7 @@ def test_handle_relative_paths(refs_file_factory, local_registry):
         ValueError, match="fs_root must be an absolute path to a filesystem directory"
     ):
         with open_virtual_dataset(
-            file_url=refs_file,
+            url=refs_file,
             registry=local_registry,
             parser=parser,
         ) as _:
@@ -180,14 +180,14 @@ def test_handle_relative_paths(refs_file_factory, local_registry):
         ValueError, match="fs_root must be an absolute path to a filesystem directory"
     ):
         with open_virtual_dataset(
-            file_url=refs_file,
+            url=refs_file,
             registry=local_registry,
             parser=parser,
         ) as _:
             pass
     parser = KerchunkJSONParser(fs_root="/some_directory/")
     with open_virtual_dataset(
-        file_url=refs_file,
+        url=refs_file,
         registry=local_registry,
         parser=parser,
     ) as vds:
@@ -202,7 +202,7 @@ def test_handle_relative_paths(refs_file_factory, local_registry):
 
     parser = KerchunkJSONParser(fs_root="file:///some_directory/")
     with open_virtual_dataset(
-        file_url=refs_file,
+        url=refs_file,
         registry=local_registry,
         parser=parser,
     ) as vds:
@@ -234,7 +234,7 @@ def test_open_virtual_dataset_existing_kerchunk_refs(
         parser = KerchunkJSONParser(fs_root="file://")
         with pytest.raises(ValueError):
             with open_virtual_dataset(
-                file_url=ref_filepath.as_posix(),
+                url=ref_filepath.as_posix(),
                 registry=local_registry,
                 parser=parser,
             ) as _:
@@ -257,7 +257,7 @@ def test_open_virtual_dataset_existing_kerchunk_refs(
             parser = KerchunkParquetParser(fs_root="file://")
         expected_refs = netcdf4_virtual_dataset.vz.to_kerchunk(format="dict")
         with open_virtual_dataset(
-            file_url=ref_filepath.as_posix(),
+            url=ref_filepath.as_posix(),
             registry=local_registry,
             parser=parser,
             loadable_variables=[],
@@ -294,7 +294,7 @@ def test_notimplemented_read_inline_refs(tmp_path, netcdf4_inlined_ref, local_re
         match="Reading inlined reference data is currently not supported",
     ):
         with open_virtual_dataset(
-            file_url=ref_filepath.as_posix(),
+            url=ref_filepath.as_posix(),
             registry=local_registry,
             parser=parser,
         ) as _:
@@ -306,7 +306,7 @@ def test_skip_variables(refs_file_factory, skip_variables, local_registry):
     refs_file = refs_file_factory()
     parser = KerchunkJSONParser(skip_variables=skip_variables, fs_root="file://")
     with open_virtual_dataset(
-        file_url=refs_file,
+        url=refs_file,
         registry=local_registry,
         parser=parser,
     ) as vds:
@@ -322,7 +322,7 @@ def test_load_manifest(tmp_path, netcdf4_file, netcdf4_virtual_dataset, local_re
 
     parser = KerchunkJSONParser()
     manifest_store = parser(
-        file_url=f"file://{ref_filepath.as_posix()}", registry=local_registry
+        url=f"file://{ref_filepath.as_posix()}", registry=local_registry
     )
     with (
         xr.open_dataset(

--- a/virtualizarr/tests/test_parsers/test_netcdf3.py
+++ b/virtualizarr/tests/test_parsers/test_netcdf3.py
@@ -11,10 +11,10 @@ from virtualizarr.tests.utils import obstore_http
 @requires_scipy
 def test_read_netcdf3(netcdf3_file, array_v3_metadata, local_registry):
     filepath = str(netcdf3_file)
-    file_url = f"file://{filepath}"
+    url = f"file://{filepath}"
     parser = NetCDF3Parser()
     with (
-        parser(file_url=file_url, registry=local_registry) as manifest_store,
+        parser(url=url, registry=local_registry) as manifest_store,
         xr.open_dataset(filepath) as expected,
     ):
         observed = xr.open_dataset(
@@ -28,12 +28,12 @@ def test_read_netcdf3(netcdf3_file, array_v3_metadata, local_registry):
 @requires_kerchunk
 @requires_network
 def test_read_http_netcdf3(array_v3_metadata):
-    file_url = "https://github.com/pydata/xarray-data/raw/master/air_temperature.nc"
-    store = obstore_http(file_url=file_url)
-    registry = ObjectStoreRegistry({file_url: store})
+    url = "https://github.com/pydata/xarray-data/raw/master/air_temperature.nc"
+    store = obstore_http(url=url)
+    registry = ObjectStoreRegistry({url: store})
     parser = NetCDF3Parser()
     with open_virtual_dataset(
-        file_url=file_url,
+        url=url,
         parser=parser,
         registry=registry,
     ) as vds:

--- a/virtualizarr/tests/test_parsers/test_zarr.py
+++ b/virtualizarr/tests/test_parsers/test_zarr.py
@@ -28,7 +28,7 @@ class TestOpenVirtualDatasetZarr:
         registry = ObjectStoreRegistry({f"file://{zarr_store}": store})
         parser = ZarrParser()
         with open_virtual_dataset(
-            file_url=zarr_store,
+            url=zarr_store,
             registry=registry,
             parser=parser,
             loadable_variables=loadable_variables,
@@ -43,7 +43,7 @@ class TestOpenVirtualDatasetZarr:
         parser = ZarrParser(skip_variables=skip_variables)
         # check variable is skipped
         with open_virtual_dataset(
-            file_url=zarr_store,
+            url=zarr_store,
             registry=registry,
             parser=parser,
         ) as vds:
@@ -54,7 +54,7 @@ class TestOpenVirtualDatasetZarr:
         registry = ObjectStoreRegistry({f"file://{zarr_store}": store})
         parser = ZarrParser()
         with open_virtual_dataset(
-            file_url=zarr_store,
+            url=zarr_store,
             registry=registry,
             parser=parser,
         ) as vds:
@@ -68,7 +68,7 @@ class TestOpenVirtualDatasetZarr:
         registry = ObjectStoreRegistry({f"file://{zarr_store}": store})
         parser = ZarrParser()
         with open_virtual_dataset(
-            file_url=zarr_store,
+            url=zarr_store,
             registry=registry,
             parser=parser,
             loadable_variables=[],
@@ -113,7 +113,7 @@ def test_scalar_get_chunk_mapping_prefix(zarr_store_scalar):
 
     chunk_map = asyncio.run(
         get_chunk_mapping_prefix(
-            zarr_array=zarr_store_scalar, filepath=str(zarr_store_scalar.store_path)
+            zarr_array=zarr_store_scalar, path=str(zarr_store_scalar.store_path)
         )
     )
     assert chunk_map["c"]["offset"] == 0

--- a/virtualizarr/tests/test_xarray.py
+++ b/virtualizarr/tests/test_xarray.py
@@ -198,13 +198,13 @@ class TestCombine:
         parser = HDFParser()
         with (
             open_virtual_dataset(
-                file_url=filepath1,
+                url=filepath1,
                 registry=local_registry,
                 parser=parser,
                 loadable_variables=["time", "lat", "lon"],
             ) as vds1,
             open_virtual_dataset(
-                file_url=filepath2,
+                url=filepath2,
                 registry=local_registry,
                 parser=parser,
                 loadable_variables=["time", "lat", "lon"],
@@ -227,25 +227,25 @@ class TestCombine:
         parser = HDFParser()
         with (
             open_virtual_dataset(
-                file_url=filepath1,
+                url=filepath1,
                 registry=local_registry,
                 parser=parser,
                 loadable_variables=["time", "lat", "lon"],
             ) as vds1,
             open_virtual_dataset(
-                file_url=filepath2,
+                url=filepath2,
                 registry=local_registry,
                 parser=parser,
                 loadable_variables=["time", "lat", "lon"],
             ) as vds2,
             open_virtual_dataset(
-                file_url=filepath3,
+                url=filepath3,
                 registry=local_registry,
                 parser=parser,
                 loadable_variables=["time", "lat", "lon"],
             ) as vds3,
             open_virtual_dataset(
-                file_url=filepath4,
+                url=filepath4,
                 registry=local_registry,
                 parser=parser,
                 loadable_variables=["time", "lat", "lon"],
@@ -274,25 +274,25 @@ class TestCombine:
         parser = HDFParser()
         with (
             open_virtual_dataset(
-                file_url=filepath1,
+                url=filepath1,
                 registry=local_registry,
                 parser=parser,
                 loadable_variables=["time", "lat", "lon"],
             ) as vds1,
             open_virtual_dataset(
-                file_url=filepath2,
+                url=filepath2,
                 registry=local_registry,
                 parser=parser,
                 loadable_variables=["time", "lat", "lon"],
             ) as vds2,
             open_virtual_dataset(
-                file_url=filepath3,
+                url=filepath3,
                 registry=local_registry,
                 parser=parser,
                 loadable_variables=["time", "lat", "lon"],
             ) as vds3,
             open_virtual_dataset(
-                file_url=filepath4,
+                url=filepath4,
                 registry=local_registry,
                 parser=parser,
                 loadable_variables=["time", "lat", "lon"],
@@ -324,10 +324,10 @@ class TestCombine:
         parser = HDFParser()
         with (
             open_virtual_dataset(
-                file_url=filepath1, registry=local_registry, parser=parser
+                url=filepath1, registry=local_registry, parser=parser
             ) as vds1,
             open_virtual_dataset(
-                file_url=filepath2, registry=local_registry, parser=parser
+                url=filepath2, registry=local_registry, parser=parser
             ) as vds2,
         ):
             combined_vds = xr.combine_by_coords([vds2, vds1])
@@ -341,7 +341,7 @@ class TestRenamePaths:
     def test_old_accessor(self, netcdf4_file, local_registry):
         parser = HDFParser()
         with open_virtual_dataset(
-            file_url=netcdf4_file,
+            url=netcdf4_file,
             registry=local_registry,
             parser=parser,
         ) as vds:
@@ -355,7 +355,7 @@ class TestRenamePaths:
     def test_rename_to_str(self, netcdf4_file, local_registry):
         parser = HDFParser()
         with open_virtual_dataset(
-            file_url=netcdf4_file,
+            url=netcdf4_file,
             registry=local_registry,
             parser=parser,
         ) as vds:
@@ -375,7 +375,7 @@ class TestRenamePaths:
 
         parser = HDFParser()
         with open_virtual_dataset(
-            file_url=netcdf4_file,
+            url=netcdf4_file,
             registry=local_registry,
             parser=parser,
         ) as vds:
@@ -388,7 +388,7 @@ class TestRenamePaths:
     def test_invalid_type(self, netcdf4_file, local_registry):
         parser = HDFParser()
         with open_virtual_dataset(
-            file_url=netcdf4_file, registry=local_registry, parser=parser
+            url=netcdf4_file, registry=local_registry, parser=parser
         ) as vds:
             with pytest.raises(TypeError):
                 vds.vz.rename_paths(["file1.nc", "file2.nc"])
@@ -400,7 +400,7 @@ class TestRenamePaths:
     ):
         parser = HDFParser()
         with open_virtual_dataset(
-            file_url=netcdf4_file,
+            url=netcdf4_file,
             registry=local_registry,
             parser=parser,
             loadable_variables=["lat", "lon"],
@@ -418,7 +418,7 @@ class TestRenamePaths:
 def test_nbytes(simple_netcdf4, local_registry):
     parser = HDFParser()
     with open_virtual_dataset(
-        file_url=simple_netcdf4,
+        url=simple_netcdf4,
         registry=local_registry,
         parser=parser,
     ) as vds:
@@ -426,7 +426,7 @@ def test_nbytes(simple_netcdf4, local_registry):
         assert vds.nbytes == 48
 
     with open_virtual_dataset(
-        file_url=simple_netcdf4,
+        url=simple_netcdf4,
         registry=local_registry,
         parser=parser,
         loadable_variables=["foo"],
@@ -442,7 +442,7 @@ class TestOpenVirtualDatasetIndexes:
     def test_specify_no_indexes(self, netcdf4_file, local_registry):
         parser = HDFParser()
         with open_virtual_dataset(
-            file_url=netcdf4_file, registry=local_registry, parser=parser, indexes={}
+            url=netcdf4_file, registry=local_registry, parser=parser, indexes={}
         ) as vds:
             assert vds.indexes == {}
 
@@ -456,7 +456,7 @@ class TestOpenVirtualDatasetIndexes:
         parser = HDFParser()
         with (
             open_virtual_dataset(
-                file_url=netcdf4_file,
+                url=netcdf4_file,
                 registry=local_registry,
                 parser=parser,
                 indexes=None,
@@ -505,7 +505,7 @@ def test_cftime_index(tmp_path: Path, local_registry):
 
     parser = HDFParser()
     with open_virtual_dataset(
-        file_url=filepath,
+        url=filepath,
         registry=local_registry,
         parser=parser,
         loadable_variables=["time", "lat", "lon"],
@@ -522,7 +522,7 @@ class TestOpenVirtualDatasetAttrs:
         parser = HDFParser()
         # regression test for GH issue #150
         vds = open_virtual_dataset(
-            file_url=netcdf4_file,
+            url=netcdf4_file,
             registry=local_registry,
             parser=parser,
         )
@@ -532,7 +532,7 @@ class TestOpenVirtualDatasetAttrs:
         # regression test for GH issue #155
         parser = HDFParser()
         with open_virtual_dataset(
-            file_url=netcdf4_file,
+            url=netcdf4_file,
             registry=local_registry,
             parser=parser,
         ) as vds:
@@ -548,7 +548,7 @@ class TestDetermineCoords:
     def test_infer_one_dimensional_coords(self, netcdf4_file, local_registry):
         parser = HDFParser()
         with open_virtual_dataset(
-            file_url=netcdf4_file,
+            url=netcdf4_file,
             registry=local_registry,
             parser=parser,
         ) as vds:
@@ -557,7 +557,7 @@ class TestDetermineCoords:
     def test_var_attr_coords(self, netcdf4_file_with_2d_coords, local_registry):
         parser = HDFParser()
         with open_virtual_dataset(
-            file_url=netcdf4_file_with_2d_coords,
+            url=netcdf4_file_with_2d_coords,
             registry=local_registry,
             parser=parser,
         ) as vds:
@@ -588,12 +588,12 @@ class TestReadRemote:
         """Parameterized tests for empty vs supplied indexes and filetypes."""
         # TODO: Switch away from this s3 url after minIO is implemented.
         filepath = "s3://carbonplan-share/virtualizarr/local.nc"
-        object_store = obstore_s3(file_url=filepath, region="us-west-2")
+        object_store = obstore_s3(url=filepath, region="us-west-2")
         registry = ObjectStoreRegistry()
         registry.register(filepath, object_store)
         parser = HDFParser()
         with open_virtual_dataset(
-            file_url=filepath,
+            url=filepath,
             registry=registry,
             indexes=indexes,
             parser=parser,
@@ -609,7 +609,7 @@ class TestReadRemote:
         # Open group directly from locally cached file with xarray
         url = "https://nisar.asf.earthdatacloud.nasa.gov/NISAR-SAMPLE-DATA/GCOV/ALOS1_Rosamond_20081012/NISAR_L2_PR_GCOV_001_005_A_219_4020_SHNA_A_20081012T060910_20081012T060926_P01101_F_N_J_001.h5"
         hdf_group = "science/LSAR/GCOV/grids/frequencyA"
-        store = obstore_http(file_url=url)
+        store = obstore_http(url=url)
         registry = ObjectStoreRegistry()
         registry.register(url, registry)
         drop_variables = ["listOfCovarianceTerms", "listOfPolarizations"]
@@ -624,7 +624,7 @@ class TestReadRemote:
             ) as dsXR,
             # save group reference file via virtualizarr, then open with engine="kerchunk"
             open_virtual_dataset(
-                file_url=url,
+                url=url,
                 object_store=store,
                 parser=parser,
             ) as vds,
@@ -641,7 +641,7 @@ class TestOpenVirtualDatasetHDFGroup:
     def test_open_empty_group(self, empty_netcdf4_file, local_registry):
         parser = HDFParser()
         with open_virtual_dataset(
-            file_url=empty_netcdf4_file,
+            url=empty_netcdf4_file,
             registry=local_registry,
             parser=parser,
         ) as vds:
@@ -654,7 +654,7 @@ class TestOpenVirtualDatasetHDFGroup:
     ):
         parser = HDFParser(group="subgroup")
         with open_virtual_dataset(
-            file_url=netcdf4_file_with_data_in_multiple_groups,
+            url=netcdf4_file_with_data_in_multiple_groups,
             registry=local_registry,
             parser=parser,
         ) as vds:
@@ -668,7 +668,7 @@ class TestOpenVirtualDatasetHDFGroup:
     ):
         parser = HDFParser(group=group)
         with open_virtual_dataset(
-            file_url=netcdf4_file_with_data_in_multiple_groups,
+            url=netcdf4_file_with_data_in_multiple_groups,
             registry=local_registry,
             parser=parser,
         ) as vds:
@@ -699,7 +699,7 @@ class TestLoadVirtualDataset:
         parser = HDFParser()
         with (
             open_virtual_dataset(
-                file_url=netcdf4_file,
+                url=netcdf4_file,
                 registry=local_registry,
                 loadable_variables=loadable_variables,
                 parser=parser,
@@ -733,7 +733,7 @@ class TestLoadVirtualDataset:
         parser = HDFParser(group="doesnt_exist")
         with pytest.raises(ValueError, match="not an HDF Group"):
             with open_virtual_dataset(
-                file_url=hdf5_groups_file,
+                url=hdf5_groups_file,
                 registry=local_registry,
                 parser=parser,
             ):
@@ -744,7 +744,7 @@ class TestLoadVirtualDataset:
         vars_to_load = ["air", "time"]
         with (
             open_virtual_dataset(
-                file_url=hdf5_groups_file,
+                url=hdf5_groups_file,
                 registry=local_registry,
                 loadable_variables=vars_to_load,
                 parser=parser,
@@ -758,7 +758,7 @@ class TestLoadVirtualDataset:
     def test_open_dataset_with_empty(self, hdf5_empty, local_registry):
         parser = HDFParser()
         with open_virtual_dataset(
-            file_url=hdf5_empty, registry=local_registry, parser=parser
+            url=hdf5_empty, registry=local_registry, parser=parser
         ) as vds:
             assert vds.empty.dims == ()
             assert vds.empty.attrs == {"empty": "true"}
@@ -766,12 +766,12 @@ class TestLoadVirtualDataset:
     def test_open_dataset_with_scalar(self, hdf5_scalar, local_registry):
         parser = HDFParser()
         with open_virtual_dataset(
-            file_url=f"file://{hdf5_scalar}", registry=local_registry, parser=parser
+            url=f"file://{hdf5_scalar}", registry=local_registry, parser=parser
         ) as vds:
             assert vds.scalar.dims == ()
             assert vds.scalar.attrs == {"scalar": "true"}
             assert isinstance(vds.scalar.data, ManifestArray)
-        ms = parser(registry=local_registry, file_url=f"file://{hdf5_scalar}")
+        ms = parser(registry=local_registry, url=f"file://{hdf5_scalar}")
         with (
             xr.open_dataset(hdf5_scalar, engine="h5netcdf") as expected,
             xr.open_zarr(ms, consolidated=False, zarr_format=3) as observed,
@@ -831,10 +831,10 @@ class TestOpenVirtualMFDataset:
         parser = HDFParser()
         with (
             open_virtual_dataset(
-                file_url=filepath1, registry=local_registry, parser=parser
+                url=filepath1, registry=local_registry, parser=parser
             ) as vds1,
             open_virtual_dataset(
-                file_url=filepath2,
+                url=filepath2,
                 registry=local_registry,
                 parser=parser,
             ) as vds2,
@@ -882,7 +882,7 @@ class TestOpenVirtualMFDataset:
 def test_drop_variables(netcdf4_file, local_registry):
     parser = HDFParser()
     with open_virtual_dataset(
-        file_url=netcdf4_file,
+        url=netcdf4_file,
         registry=local_registry,
         parser=parser,
         drop_variables=["air"],

--- a/virtualizarr/tests/utils.py
+++ b/virtualizarr/tests/utils.py
@@ -10,15 +10,15 @@ from virtualizarr.parsers import HDFParser
 from virtualizarr.registry import ObjectStoreRegistry
 
 
-def obstore_local(file_url: str) -> ObjectStore:
-    parsed = urlparse(file_url)
+def obstore_local(url: str) -> ObjectStore:
+    parsed = urlparse(url)
     path = Path(parsed.path)
     store = LocalStore(prefix=path.parent)
     return store
 
 
-def obstore_s3(file_url: str, region: str) -> ObjectStore:
-    parsed = urlparse(file_url)
+def obstore_s3(url: str, region: str) -> ObjectStore:
+    parsed = urlparse(url)
     bucket = parsed.netloc
     key_prefix = os.path.dirname(parsed.path.lstrip("/"))
     base_path = f"s3://{bucket}/{key_prefix}"
@@ -26,8 +26,8 @@ def obstore_s3(file_url: str, region: str) -> ObjectStore:
     return store
 
 
-def obstore_http(file_url: str) -> ObjectStore:
-    parsed = urlparse(file_url)
+def obstore_http(url: str) -> ObjectStore:
+    parsed = urlparse(url)
     key_prefix = os.path.dirname(parsed.path.lstrip("/"))
     base_path = f"{parsed.scheme}://{parsed.netloc}/{key_prefix}"
     store = from_url(url=base_path)
@@ -36,6 +36,6 @@ def obstore_http(file_url: str) -> ObjectStore:
 
 def manifest_store_from_hdf_url(url, group: str | None = None):
     registry = ObjectStoreRegistry()
-    registry.register(url, obstore_local(file_url=url))
+    registry.register(url, obstore_local(url=url))
     parser = HDFParser(group=group)
-    return parser(file_url=url, registry=registry)
+    return parser(url=url, registry=registry)

--- a/virtualizarr/xarray.py
+++ b/virtualizarr/xarray.py
@@ -60,7 +60,7 @@ def open_virtual_dataset(
 
 
 def open_virtual_mfdataset(
-    paths: (
+    file_urls: (
         str
         | os.PathLike
         | Sequence[str | os.PathLike]
@@ -91,45 +91,45 @@ def open_virtual_mfdataset(
     """
     Open multiple files as a single virtual dataset.
 
-    This function is explicitly modelled after `xarray.open_mfdataset`, and works in the same way.
+    This function is explicitly modelled after [xarray.open_mfdataset][], and works in the same way.
 
-    If combine='by_coords' then the function ``combine_by_coords`` is used to combine
+    If `combine='by_coords'` then the function `combine_by_coords` is used to combine
     the datasets into one before returning the result, and if combine='nested' then
-    ``combine_nested`` is used. The filepaths must be structured according to which
+    `combine_nested` is used. The filepaths must be structured according to which
     combining function is used, the details of which are given in the documentation for
-    ``combine_by_coords`` and ``combine_nested``. By default ``combine='by_coords'``
-    will be used. Global attributes from the ``attrs_file`` are used
+    `combine_by_coords` and `combine_nested`. By default `combine='by_coords'`
+    will be used. Global attributes from the `attrs_file` are used
     for the combined dataset.
 
     Parameters
     ----------
-    paths
-        Same as in xarray.open_mfdataset
+    file_urls
+        Same as in [virtualizarr.open_virtual_dataset][]
     registry
         An [ObjectStoreRegistry][virtualizarr.registry.ObjectStoreRegistry] for resolving urls and reading data.
     concat_dim
-        Same as in xarray.open_mfdataset
+        Same as in [xarray.open_mfdataset][]
     compat
-        Same as in xarray.open_mfdataset
+        Same as in [xarray.open_mfdataset][]
     preprocess
-        Same as in xarray.open_mfdataset
+        Same as in [xarray.open_mfdataset][]
     data_vars
-        Same as in xarray.open_mfdataset
+        Same as in [xarray.open_mfdataset][]
     coords
-        Same as in xarray.open_mfdataset
+        Same as in [xarray.open_mfdataset][]
     combine
-        Same as in xarray.open_mfdataset
-    parallel : "dask", "lithops", False, or type of subclass of ``concurrent.futures.Executor``
+        Same as in [xarray.open_mfdataset][]
+    parallel : "dask", "lithops", False, or type of subclass of [concurrent.futures.Executor][]
         Specify whether the open and preprocess steps of this function will be
-        performed in parallel using lithops, dask.delayed, or any executor compatible
-        with the ``concurrent.futures`` interface, or in serial.
+        performed in parallel using [lithops][], [dask.delayed][], or any executor compatible
+        with the [concurrent.futures][] interface, or in serial.
         Default is False, which will execute these steps in serial.
     join
-        Same as in xarray.open_mfdataset
+        Same as in [xarray.open_mfdataset][]
     attrs_file
-        Same as in xarray.open_mfdataset
+        Same as in [xarray.open_mfdataset][]
     combine_attrs
-        Same as in xarray.open_mfdataset
+        Same as in [xarray.open_mfdataset][]
     **kwargs : optional
         Additional arguments passed on to [virtualizarr.open_virtual_dataset][]. For an
         overview of some of the possible options, see the documentation of
@@ -137,18 +137,20 @@ def open_virtual_mfdataset(
 
     Returns
     -------
-    xarray.Dataset
+    vds
+        An [xarray.Dataset][] containing virtual chunk references for all variables not included
+        in `loadable_variables` and normal lazily indexed arrays for each variable in `loadable_variables`.
 
     Notes
     -----
-    The results of opening each virtual dataset in parallel are sent back to the client process, so must not be too large. See the docs page on Scaling.
+    The results of opening each virtual dataset in parallel are sent back to the client process, so must not be too large. See the docs page on [Scaling][].
     """
 
     # TODO this is practically all just copied from xarray.open_mfdataset - an argument for writing a virtualizarr engine for xarray?
 
     # TODO list kwargs passed to open_virtual_dataset explicitly in docstring?
 
-    paths = cast(NestedSequence[str], _find_absolute_paths(paths))
+    paths = cast(NestedSequence[str], _find_absolute_paths(file_urls))
 
     if not paths:
         raise OSError("no files to open")
@@ -236,7 +238,7 @@ def open_virtual_mfdataset(
             )
         else:
             raise ValueError(
-                f"{combine} is an invalid option for the keyword argument ``combine``"
+                f"{combine} is an invalid option for the keyword argument `combine`"
             )
     except ValueError:
         for vds in virtual_datasets:

--- a/virtualizarr/xarray.py
+++ b/virtualizarr/xarray.py
@@ -121,7 +121,7 @@ def open_virtual_mfdataset(
         Same as in [xarray.open_mfdataset][]
     parallel : "dask", "lithops", False, or type of subclass of [concurrent.futures.Executor][]
         Specify whether the open and preprocess steps of this function will be
-        performed in parallel using [lithops][], [dask.delayed][], or any executor compatible
+        performed in parallel using [lithops][], `dask.delayed`, or any executor compatible
         with the [concurrent.futures][] interface, or in serial.
         Default is False, which will execute these steps in serial.
     join


### PR DESCRIPTION
This is a breaking change to have consistent parameter names across the library for V2.

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
