### PR TITLE
Add docstrings to the HDFParser

### DIFF
--- a/virtualizarr/parsers/hdf/hdf.py
+++ b/virtualizarr/parsers/hdf/hdf.py
@@ -132,6 +132,18 @@ class HDFParser:
         group: str | None = None,
         drop_variables: Iterable[str] | None = None,
     ):
+        """
+        Instantiate a parser with parser-specific parameters that can be used in the
+        `__call__` method.
+
+        Parameters
+        ----------
+        group
+            Name of the group within the HDF5 file to virtualize.
+        drop_variables
+            Variables in the file that will be ignored when creating the ManifestStore
+            (default: `None`, do not ignore any variables).
+        """
         self.group = group
         self.drop_variables = drop_variables
 
@@ -140,6 +152,22 @@ class HDFParser:
         file_url: str,
         registry: ObjectStoreRegistry,
     ) -> ManifestStore:
+        """
+        Parse the metadata and byte offsets from a given HDF5/NetCDF4 file to produce a VirtualiZarr
+        [ManifestStore][virtualizarr.manifests.ManifestStore].
+
+        Parameters
+        ----------
+        file_url
+            The URI or path to the input HDF5/NetCDF4 file (e.g., `"s3://bucket/store.zarr"`).
+        registry
+            An [ObjectStoreRegistry][virtualizarr.registry.ObjectStoreRegistry] for resolving urls and reading data.
+
+        Returns
+        -------
+        ManifestStore
+            A [ManifestStore][virtualizarr.manifests.ManifestStore] which provides a Zarr representation of the parsed file.
+        """
         store, _ = registry.resolve(file_url)
         reader = ObstoreReader(store=store, path=urlparse(file_url).path)
         manifest_group = _construct_manifest_group(

--- a/virtualizarr/parsers/zarr.py
+++ b/virtualizarr/parsers/zarr.py
@@ -184,7 +184,8 @@ class ZarrParser:
 
         Returns
         -------
-        ManifestStore: A ManifestStore which provides a Zarr representation of the parsed file.
+        ManifestStore
+            A ManifestStore which provides a Zarr representation of the parsed file.
         """
 
         filepath = validate_and_normalize_path_to_uri(


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
This parser was missing docstrings, which are now added.


- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
