### PR TITLE
Pin xarray to 2025.06.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 requires-python = ">=3.11"
 dynamic = ["version"]
 dependencies = [
-    "xarray>=2025.3.0,!=2025.7.0,!=2025.7.1",
+    "xarray==2025.06.0",
     "numpy>=2.0.0",
     "universal-pathlib",
     "numcodecs>=0.15.1",
@@ -87,7 +87,7 @@ all_writers = [
 # Dependency sets under dependencies-groups are NOT available via PyPI
 [dependency-groups]
 upstream = [
-    'xarray @ git+https://github.com/pydata/xarray',
+    # 'xarray @ git+https://github.com/pydata/xarray',
     'universal_pathlib @ git+https://github.com/fsspec/universal_pathlib',
     'numcodecs @ git+https://github.com/zarr-developers/numcodecs',
     'ujson @ git+https://github.com/ultrajson/ultrajson',
@@ -166,7 +166,7 @@ h5netcdf = ">=1.5.0,<2"
 rust = "*"
 
 [tool.pixi.feature.minimum-versions.dependencies]
-xarray = "==2025.3.0"
+xarray = "==2025.6.0"
 numpy = "==2.0.0"
 numcodecs = "==0.15.1"
 zarr = "==3.1.0"


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
We currently only support one version of xarray, see https://github.com/zarr-developers/VirtualiZarr/actions/runs/16381686949/job/46294326109?pr=703 for incompatibility with earlier versions and https://github.com/zarr-developers/VirtualiZarr/issues/688 for compatibility with future versions 
- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
