### PR TITLE
Consistently use 'registry' rather than a mix with 'store_registry'

### DIFF
--- a/docs/custom_parsers.md
+++ b/docs/custom_parsers.md
@@ -27,7 +27,7 @@ def custom_parser(file_url: str, object_store: ObjectStore) -> ManifestStore:
     registry = ObjectStoreRegistry({store_prefix: object_store})
 
     # construct the Manifeststore from the parsed metadata and the object store registry
-    return ManifestStore(group=manifestgroup, store_registry=registry)
+    return ManifestStore(group=manifestgroup, registry=registry)
 
 
 vds = vz.open_virtual_dataset(
@@ -190,7 +190,7 @@ memory_store = obstore.store.MemoryStore()
 memory_store.put("refs.json", ujson.dumps(refs).encode())
 
 registry = ObjectStoreRegistry({"memory://": memory_store})
-parser = KerchunkJSONParser(store_registry=registry)
+parser = KerchunkJSONParser(registry=registry)
 manifeststore = parser("refs.json", memory_store)
 ```
 

--- a/virtualizarr/manifests/store.py
+++ b/virtualizarr/manifests/store.py
@@ -145,13 +145,11 @@ class ManifestStore(Store):
             raise TypeError
 
         super().__init__(read_only=True)
-        if registry is None:
-            registry = ObjectStoreRegistry()
-        self._registry = registry
+        self._registry = ObjectStoreRegistry() if registry is None else registry
         self._group = group
 
     def __str__(self) -> str:
-        return f"ManifestStore(group={self._group}, stores={self._registry})"
+        return f"ManifestStore(group={self._group}, registry={self._registry})"
 
     async def get(
         self,

--- a/virtualizarr/manifests/store.py
+++ b/virtualizarr/manifests/store.py
@@ -109,7 +109,7 @@ class ManifestStore(Store):
     group
         Root group of the store.
         Contains group metadata, [ManifestArrays][virtualizarr.manifests.ManifestArray], and any subgroups.
-    store_registry : ObjectStoreRegistry
+    registry : ObjectStoreRegistry
         [ObjectStoreRegistry][virtualizarr.registry.ObjectStoreRegistry] that maps the URL scheme and netloc to  [ObjectStore][obstore.store.ObjectStore] instances,
         allowing ManifestStores to read from different ObjectStore instances.
 
@@ -122,13 +122,13 @@ class ManifestStore(Store):
     #  Modified from https://github.com/zarr-developers/zarr-python/pull/1661
 
     _group: ManifestGroup
-    _store_registry: ObjectStoreRegistry
+    _registry: ObjectStoreRegistry
 
     def __eq__(self, value: object):
         NotImplementedError
 
     def __init__(
-        self, group: ManifestGroup, *, store_registry: ObjectStoreRegistry | None = None
+        self, group: ManifestGroup, *, registry: ObjectStoreRegistry | None = None
     ) -> None:
         """Instantiate a new ManifestStore.
 
@@ -136,7 +136,7 @@ class ManifestStore(Store):
         ----------
         group
             [ManifestGroup][virtualizarr.manifests.ManifestGroup] containing Group metadata and mapping variable names to ManifestArrays
-        store_registry
+        registry
             A registry mapping the URL scheme and netloc to  [ObjectStore][obstore.store.ObjectStore] instances,
             allowing [ManifestStores][virtualizarr.manifests.ManifestStore] to read from different  [ObjectStore][obstore.store.ObjectStore] instances.
         """
@@ -145,13 +145,13 @@ class ManifestStore(Store):
             raise TypeError
 
         super().__init__(read_only=True)
-        if store_registry is None:
-            store_registry = ObjectStoreRegistry()
-        self._store_registry = store_registry
+        if registry is None:
+            registry = ObjectStoreRegistry()
+        self._registry = registry
         self._group = group
 
     def __str__(self) -> str:
-        return f"ManifestStore(group={self._group}, stores={self._store_registry})"
+        return f"ManifestStore(group={self._group}, stores={self._registry})"
 
     async def get(
         self,
@@ -188,7 +188,7 @@ class ManifestStore(Store):
         length = manifest._lengths[chunk_indexes]
 
         # Get the configured object store instance that matches the path
-        store, path_after_prefix = self._store_registry.resolve(path)
+        store, path_after_prefix = self._registry.resolve(path)
         if not store:
             raise ValueError(
                 f"Could not find a store to use for {path} in the store registry"
@@ -305,7 +305,7 @@ class ManifestStore(Store):
 
         from virtualizarr.xarray import construct_virtual_dataset
 
-        if loadable_variables and self._store_registry.map is None:
+        if loadable_variables and self._registry.map is None:
             raise ValueError(
                 f"ManifestStore contains an empty store registry, but {loadable_variables} were provided as loadable variables. Must provide an ObjectStore instance in order to load variables."
             )

--- a/virtualizarr/parsers/dmrpp.py
+++ b/virtualizarr/parsers/dmrpp.py
@@ -182,7 +182,7 @@ class DMRParser:
         registry = ObjectStoreRegistry()
         registry.register(self.data_filepath, object_store)
 
-        return ManifestStore(store_registry=registry, group=manifest_group)
+        return ManifestStore(registry=registry, group=manifest_group)
 
     def find_node_fqn(self, fqn: str) -> ET.Element:
         """

--- a/virtualizarr/parsers/fits.py
+++ b/virtualizarr/parsers/fits.py
@@ -65,4 +65,4 @@ class FITSParser:
             fs_root=Path.cwd().as_uri(),
         )
 
-        return ManifestStore(group=manifestgroup, store_registry=registry)
+        return ManifestStore(group=manifestgroup, registry=registry)

--- a/virtualizarr/parsers/hdf/hdf.py
+++ b/virtualizarr/parsers/hdf/hdf.py
@@ -176,7 +176,7 @@ class HDFParser:
             drop_variables=self.drop_variables,
         )
         # Convert to a manifest store
-        return ManifestStore(store_registry=registry, group=manifest_group)
+        return ManifestStore(registry=registry, group=manifest_group)
 
 
 def _dataset_chunk_manifest(

--- a/virtualizarr/parsers/kerchunk/json.py
+++ b/virtualizarr/parsers/kerchunk/json.py
@@ -13,7 +13,7 @@ class KerchunkJSONParser:
         group: str | None = None,
         fs_root: str | None = None,
         skip_variables: Iterable[str] | None = None,
-        store_registry: ObjectStoreRegistry | None = None,
+        registry: ObjectStoreRegistry | None = None,
     ):
         """
         Instantiate a parser with parser-specific parameters that can be used in the
@@ -67,4 +67,4 @@ class KerchunkJSONParser:
             fs_root=self.fs_root,
             skip_variables=self.skip_variables,
         )
-        return ManifestStore(group=manifestgroup, store_registry=registry)
+        return ManifestStore(group=manifestgroup, registry=registry)

--- a/virtualizarr/parsers/kerchunk/parquet.py
+++ b/virtualizarr/parsers/kerchunk/parquet.py
@@ -96,7 +96,7 @@ class KerchunkParquetParser:
             skip_variables=self.skip_variables,
         )
 
-        return ManifestStore(group=manifestgroup, store_registry=registry)
+        return ManifestStore(group=manifestgroup, registry=registry)
 
 
 @dataclass

--- a/virtualizarr/parsers/netcdf3.py
+++ b/virtualizarr/parsers/netcdf3.py
@@ -63,4 +63,4 @@ class NetCDF3Parser:
             skip_variables=self.skip_variables,
             fs_root=Path.cwd().as_uri(),
         )
-        return ManifestStore(group=manifestgroup, store_registry=registry)
+        return ManifestStore(group=manifestgroup, registry=registry)

--- a/virtualizarr/parsers/tiff.py
+++ b/virtualizarr/parsers/tiff.py
@@ -65,4 +65,4 @@ class Parser:
             fs_root=Path.cwd().as_uri(),
         )
 
-        return ManifestStore(group=manifestgroup, store_registry=registry)
+        return ManifestStore(group=manifestgroup, registry=registry)

--- a/virtualizarr/parsers/zarr.py
+++ b/virtualizarr/parsers/zarr.py
@@ -199,4 +199,4 @@ class ZarrParser:
                 skip_variables=self.skip_variables,
             )
         )
-        return ManifestStore(store_registry=registry, group=manifest_group)
+        return ManifestStore(registry=registry, group=manifest_group)

--- a/virtualizarr/tests/test_manifests/test_store.py
+++ b/virtualizarr/tests/test_manifests/test_store.py
@@ -148,7 +148,7 @@ def _generate_manifest_store(
         attributes={"Zarr": "Hooray!"},
     )
     registry = ObjectStoreRegistry({prefix: store})
-    return ManifestStore(store_registry=registry, group=manifest_group)
+    return ManifestStore(registry=registry, group=manifest_group)
 
 
 @pytest.fixture()
@@ -207,7 +207,7 @@ def empty_memory_store():
     manifest_array = ManifestArray(metadata=array_metadata, chunkmanifest=manifest)
     manifest_group = ManifestGroup(arrays={"foo": manifest_array})
     registry = ObjectStoreRegistry({"memory://": store})
-    return ManifestStore(store_registry=registry, group=manifest_group)
+    return ManifestStore(registry=registry, group=manifest_group)
 
 
 @requires_obstore
@@ -362,7 +362,7 @@ class TestToVirtualXarray:
                     path.split("/")[-1],
                     np.ones(marr.chunks, dtype=marr.dtype).tobytes(),
                 )
-        store_registry = ObjectStoreRegistry({"file://": store})
+        registry = ObjectStoreRegistry({"file://": store})
 
         manifest_group = ManifestGroup(
             arrays={
@@ -373,7 +373,7 @@ class TestToVirtualXarray:
             attributes={"coordinates": "elevation t", "ham": "eggs"},
         )
 
-        manifest_store = ManifestStore(manifest_group, store_registry=store_registry)
+        manifest_store = ManifestStore(manifest_group, registry=registry)
 
         vds = manifest_store.to_virtual_dataset(loadable_variables=loadable_variables)
         assert set(vds.variables) == set(["T", "elevation", "t"])

--- a/virtualizarr/tests/test_parsers/test_kerchunk.py
+++ b/virtualizarr/tests/test_parsers/test_kerchunk.py
@@ -350,7 +350,7 @@ def test_parse_dict_via_memorystore(array_v3_metadata):
     manifeststore = parser("memory:///refs.json", registry=registry)
 
     assert isinstance(manifeststore, ManifestStore)
-    assert manifeststore._store_registry.map[UrlKey("memory", "")].store == memory_store
+    assert manifeststore._registry.map[UrlKey("memory", "")].store == memory_store
 
     # assert metadata parsed correctly
     expected_metadata = array_v3_metadata(


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
Some API signatures used `store_registry` to accept ObjectStoreRegistry instances, and some used `registry. This PR standardized on `registry` throughout the API.
- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
