### PR TITLE
Remove unused store_registry argument from KerchunkJSONParser.__init__

### DIFF
--- a/virtualizarr/parsers/kerchunk/json.py
+++ b/virtualizarr/parsers/kerchunk/json.py
@@ -13,7 +13,6 @@ class KerchunkJSONParser:
         group: str | None = None,
         fs_root: str | None = None,
         skip_variables: Iterable[str] | None = None,
-        store_registry: ObjectStoreRegistry | None = None,
     ):
         """
         Instantiate a parser with parser-specific parameters that can be used in the


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
This is not used or needed, so removing it from the parser configuration.

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
