### PR TITLE
Check chunk grid shape consistent upon ManifestArray init

### DIFF
--- a/virtualizarr/manifests/array.py
+++ b/virtualizarr/manifests/array.py
@@ -7,6 +7,7 @@ import xarray as xr
 from zarr.core.metadata.v3 import ArrayV3Metadata, RegularChunkGrid
 
 import virtualizarr.manifests.utils as utils
+from virtualizarr.utils import determine_chunk_grid_shape
 from virtualizarr.manifests.array_api import (
     MANIFESTARRAY_HANDLED_ARRAY_FUNCTIONS,
     _isnan,
@@ -64,7 +65,12 @@ class ManifestArray:
                 f"chunkmanifest arg must be of type ChunkManifest or dict, but got type {type(chunkmanifest)}"
             )
 
-        # TODO check that the metadata shape and chunkmanifest shape are consistent with one another
+        # check that the metadata shape and chunkmanifest shape are consistent with one another
+        metadata_chunk_grid_shape = determine_chunk_grid_shape(shape=metadata.shape, chunks=metadata.chunks)
+        if _chunkmanifest.shape_chunk_grid != metadata_chunk_grid_shape:
+            raise ValueError("Set of virtual chunk keys in manifest do not match shape of chunk grid implied by array metadata. \n"
+                             f"Keys in chunkmanifest imply a chunk grid shape of {_chunkmanifest.shape_chunk_grid} but the metadata contains shape={_metadata.shape} and chunks={_metadata.chunks} which imply a chunk grid shape of {metadata_chunk_grid_shape}")
+
         # TODO also cover the special case of scalar arrays
 
         self._metadata = _metadata

--- a/virtualizarr/tests/test_manifests/test_array.py
+++ b/virtualizarr/tests/test_manifests/test_array.py
@@ -48,6 +48,18 @@ class TestInit:
         assert marr.shape == shape
         assert marr.size == 5 * 2 * 20
         assert marr.ndim == 3
+    
+    def test_consistency_checks(self, array_v3_metadata):
+        chunks_dict = {
+            "0": {"path": "s3://bucket/foo.nc", "offset": 100, "length": 100},
+        }
+        manifest = ChunkManifest(entries=chunks_dict)
+        chunks = (1,)
+        shape = (2,)
+        metadata = array_v3_metadata(shape=shape, chunks=chunks)
+
+        with pytest.raises(ValueError, match="do not match shape of chunk grid"):
+            ManifestArray(metadata=metadata, chunkmanifest=manifest)
 
 
 class TestResultType:


### PR DESCRIPTION
Addresses this TODO:

https://github.com/zarr-developers/VirtualiZarr/blob/2e0b22822b51f1a9c8cbe08c791289e1fce895c3/virtualizarr/manifests/array.py#L67

I noticed that this should be disallowed when debugging https://github.com/zarr-developers/VirtualiZarr/issues/728#issuecomment-3110221034.

Funnily though this breaks some other tests, which potentially need to be changed to not create invalid ManifestArrays.

- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
