### PR TITLE
Fix indexing with nones

### DIFF
--- a/virtualizarr/manifests/array.py
+++ b/virtualizarr/manifests/array.py
@@ -366,7 +366,7 @@ def _possibly_expand_trailing_ellipsis(
     """
     final_dim_indexer = indexer[-1]
     if final_dim_indexer == ...:
-        if len(indexer) > ndim and ndim > 0:
+        if len(_strip_nones(indexer)) > ndim and ndim > 0:
             raise ValueError(
                 f"Invalid indexer for array. Indexer length must be less than or equal to the number of dimensions in the array, "
                 f"but indexer={indexer} has length {len(indexer)} and array has {ndim} dimensions."
@@ -379,3 +379,7 @@ def _possibly_expand_trailing_ellipsis(
         return tuple(tuple(indexer_as_list) + (slice(None),) * extra_slices_needed)
     else:
         return indexer
+
+
+def _strip_nones(indexer: tuple[Union[int, slice, EllipsisType, None, np.ndarray], ...]) -> tuple[Union[int, slice, EllipsisType, np.ndarray], ...]:
+    return tuple([ind for ind in indexer if ind is not None])

--- a/virtualizarr/tests/test_manifests/test_array.py
+++ b/virtualizarr/tests/test_manifests/test_array.py
@@ -444,6 +444,16 @@ class TestIndexing:
         marr = manifest_array(shape=(), chunks=())
         assert marr[...] == marr
 
+    def test_insert_newaxis_via_indexing_with_ellipsis(self, manifest_array):
+        # regression test for GH issue #728
+        marr = manifest_array(shape=(2,), chunks=(1,))
+        new_marr = marr[None, ...]
+        assert new_marr.shape == (1, 2)
+        assert new_marr.chunks == (1, 1)
+
+        # TODO
+        # new_marr = marr[None]
+
 
 def test_to_xarray(array_v3_metadata):
     chunks = (5, 10)


### PR DESCRIPTION
Ensures we obey the "(excluding `None`)" clause [here](https://data-apis.org/array-api/2024.12/API_specification/indexing.html#multi-axis-indexing:~:text=the%20number%20of%20provided%20single%2Daxis%20indexing%20expressions%20(excluding%20None)%20should%20equal%20N), instead of raising over-eagerly. We missed this from #612.

In general we should probably refactor the indexing code to follow all the rules in the array API, else xarray could change it's internals again in a way that bites us again (which is what happened here - see #596).

- [x] Closes #728
- [x] Tests added
- [x] Tests passing
- [x] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] ~~New functions/methods are listed in `api.rst`~~
- [ ] ~~New functionality has documentation~~
