### PR TITLE
Add comment on skip_signature=True in the s3 store example

### DIFF
--- a/docs/migration_guide.md
+++ b/docs/migration_guide.md
@@ -39,7 +39,7 @@ for reading the original data, but some parsers may accept an empty [ObjectStore
     store = S3Store(
         bucket=bucket,
         region="us-west-2",
-        skip_signature=True #required for this specific example data
+        skip_signature=True # required for this specific example data because the data is in a public bucket, so the S3Store shouldn't fetch and use credentials.
     )
     registry = ObjectStoreRegistry({f"s3://{bucket}": store})
     parser = HDFParser()

--- a/docs/migration_guide.md
+++ b/docs/migration_guide.md
@@ -39,7 +39,7 @@ for reading the original data, but some parsers may accept an empty [ObjectStore
     store = S3Store(
         bucket=bucket,
         region="us-west-2",
-        skip_signature=True
+        skip_signature=True #required for this specific example data
     )
     registry = ObjectStoreRegistry({f"s3://{bucket}": store})
     parser = HDFParser()


### PR DESCRIPTION
I am refactoring some of my code to virtualize NASA data to v2 at the moment, and just spent a bunch of minutes debugging a permission denied error due to me just copy/pasting the code in the example. 

Wondering if it would be instructive for users to know that this option is specific to the data used.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
