### PR TITLE
Fix test paths to make upstream Icechunk happy

### DIFF
--- a/virtualizarr/tests/utils.py
+++ b/virtualizarr/tests/utils.py
@@ -12,7 +12,8 @@ from virtualizarr.registry import ObjectStoreRegistry
 
 # Find location of pytest temporary data in what should be a cross-platform way. This should be the same as what pytest actually does - see https://docs.pytest.org/en/stable/how-to/tmp_path.html#temporary-directory-location-and-retention
 # The realpath call is there to resolve any symbolic links, such as from /var/ to /private/var/ on MacOS, as Icechunk needs the entire URL prefix without symlinks.
-PYTEST_TMP_DIRECTORY_URL_PREFIX = f"file://{os.path.realpath(tempfile.gettempdir())}"
+# Icechunk also needs the final / to create VirtualChunkContainers.
+PYTEST_TMP_DIRECTORY_URL_PREFIX = f"file://{os.path.realpath(tempfile.gettempdir())}/"
 
 
 def obstore_local(url: str) -> ObjectStore:


### PR DESCRIPTION
Next version of Icechunk will want VirtualChunkContainers urls to finish with a `/` character.

- [ ] Tests passing
