### PR TITLE
Always strip preceding / from path in ManifestStore

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -403,7 +403,7 @@ repo = icechunk.Repository.open_or_create(storage)
 # you need to explicitly grant permissions to icechunk to read from the locations of your archival files
 config = icechunk.RepositoryConfig.default()
 config.set_virtual_chunk_container(
-    icechunk.VirtualChunkContainer("s3://my-bucket", icechunk.s3_store(region="us-east-1", anonymous=True)),
+    icechunk.VirtualChunkContainer("s3://my-bucket/", icechunk.s3_store(region="us-east-1", anonymous=True)),
 )
 
 # open a writable icechunk session to be able to add new contents to the store

--- a/virtualizarr/manifests/store.py
+++ b/virtualizarr/manifests/store.py
@@ -195,10 +195,11 @@ class ManifestStore(Store):
         path_in_store = urlparse(path).path
         if hasattr(store, "prefix") and store.prefix:
             prefix = str(store.prefix).lstrip("/")
-            path_in_store = path_in_store.lstrip("/").removeprefix(prefix).lstrip("/")
         elif hasattr(store, "url"):
             prefix = urlparse(store.url).path.lstrip("/")
-            path_in_store = path_in_store.lstrip("/").removeprefix(prefix).lstrip("/")
+        else:
+            prefix = ""
+        path_in_store = path_in_store.lstrip("/").removeprefix(prefix).lstrip("/")
         # Transform the input byte range to account for the chunk location in the file
         chunk_end_exclusive = offset + length
         byte_range = _transform_byte_range(


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
Obstore expects the preceding '/' to be stripped.

- [ ] Closes #761
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
