### PR TITLE
Include serializer from ManifestStore in Icechunk virtual references

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -8,7 +8,7 @@
 
 ### Bug fixes
 
-- Fix handling of big-endian data in Icechunk by making sure that non-default zarr serializers are included in the zarr array metadata [#766](https://github.com/zarr-developers/VirtualiZarr/issues/766)). By [Max Jones](https://github.com/maxrjones)
+- Fix handling of big-endian data in Icechunk by making sure that non-default zarr serializers are included in the zarr array metadata [#766](https://github.com/zarr-developers/VirtualiZarr/issues/766). By [Max Jones](https://github.com/maxrjones)
 
 ### Documentation
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -8,6 +8,8 @@
 
 ### Bug fixes
 
+- Fix handling of big-endian data in Icechunk by making sure that non-default zarr serializers are included in the zarr array metadata [#766](https://github.com/zarr-developers/VirtualiZarr/issues/766)). By [Max Jones](https://github.com/maxrjones)
+
 ### Documentation
 
 ### Internal changes

--- a/virtualizarr/manifests/store.py
+++ b/virtualizarr/manifests/store.py
@@ -179,12 +179,14 @@ class ManifestStore(Store):
             key, marr.metadata.chunk_key_encoding.separator
         )
 
+        if manifest._paths.shape == (1,) and chunk_indexes == ():
+            # TODO: Kerchunk parsers (e.g., NetCDF3) are returning 1 dimensional arrays for scalar arrays, this should be addressed at the source of the issue rather than as a workaround
+            chunk_indexes = (0,)
         path = manifest._paths[chunk_indexes]
         if path == "":
             return None
         offset = manifest._offsets[chunk_indexes]
         length = manifest._lengths[chunk_indexes]
-
         # Get the configured object store instance that matches the path
         store, path_after_prefix = self._registry.resolve(path)
         if not store:

--- a/virtualizarr/manifests/store.py
+++ b/virtualizarr/manifests/store.py
@@ -179,9 +179,6 @@ class ManifestStore(Store):
             key, marr.metadata.chunk_key_encoding.separator
         )
 
-        if manifest._paths.shape == (1,) and chunk_indexes == ():
-            # TODO: Kerchunk parsers (e.g., NetCDF3) are returning 1 dimensional arrays for scalar arrays, this should be addressed at the source of the issue rather than as a workaround
-            chunk_indexes = (0,)
         path = manifest._paths[chunk_indexes]
         if path == "":
             return None

--- a/virtualizarr/writers/icechunk.py
+++ b/virtualizarr/writers/icechunk.py
@@ -339,7 +339,7 @@ def write_virtual_variable_to_icechunk(
     else:
         append_axis = None
         # TODO: Should codecs be an argument to zarr's AsyncrGroup.create_array?
-        filters, _, compressors = extract_codecs(metadata.codecs)
+        filters, serializer, compressors = extract_codecs(metadata.codecs)
         arr = group.require_array(
             name=name,
             shape=metadata.shape,
@@ -347,6 +347,7 @@ def write_virtual_variable_to_icechunk(
             dtype=metadata.data_type.to_native_dtype(),
             filters=filters,
             compressors=compressors,
+            serializer=serializer,
             dimension_names=var.dims,
             fill_value=metadata.fill_value,
         )


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
I think we need much more work around our handling of codecs (which would get much easier with https://github.com/zarr-developers/zarr-python/pull/3276), but this is a more immediate fix to support parsers that specify any serializer other than the default (e.g., big-endian bytes).

This makes your NetCDF3 example work @rsignell 

- [ ] Closes #762
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
