### PR TITLE
Fix usage with Icechunk>=1.1.0 due to validate_containers change

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,6 +170,7 @@ numpy = "==2.0.0"
 numcodecs = "==0.15.1"
 zarr = "==3.1.0"
 obstore = "==0.5.1"
+icechunk = "==1.0.0"
 
 # Define commands to run within the test environments
 [tool.pixi.feature.test.tasks]

--- a/virtualizarr/writers/icechunk.py
+++ b/virtualizarr/writers/icechunk.py
@@ -434,4 +434,6 @@ def write_manifest_virtual_refs(
         if path
     ]
 
-    store.set_virtual_refs(array_path=key_prefix, chunks=virtual_chunk_spec_list)
+    store.set_virtual_refs(
+        array_path=key_prefix, chunks=virtual_chunk_spec_list, validate_containers=False
+    )


### PR DESCRIPTION
Fixes #763 by using the default from icechunk < 1.1.0. Relates to #567 and #742. Publicly exposing the argument or changing the default could be done separately, but this is an important quick-fix IMO for preventing people from unknowingly creating useless Icechunk virtual zarr stores.


<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #763
- [x] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
