### PR TITLE
Extract endianness from Bytes codec in V2 metadata conversion

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -20,6 +20,8 @@
   By [Tom Nicholas](https://github.com/TomNicholas).
 - Fix handling of big-endian data in Icechunk by making sure that non-default zarr serializers are included in the zarr array metadata [#766](https://github.com/zarr-developers/VirtualiZarr/issues/766).
   By [Max Jones](https://github.com/maxrjones)
+- Fix handling of big-endian data in Kerchunk references [#769](https://github.com/zarr-developers/VirtualiZarr/issues/769).
+  By [Max Jones](https://github.com/maxrjones)
 
 ### Documentation
 

--- a/virtualizarr/utils.py
+++ b/virtualizarr/utils.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Iterable, Mapping, Optional, Sequence, Un
 import obstore as obs
 from zarr.abc.codec import ArrayBytesCodec
 from zarr.core.metadata import ArrayV2Metadata, ArrayV3Metadata
+from zarr.dtype import data_type_registry
 
 from virtualizarr.codecs import get_codec_config, zarr_codec_config_to_v2
 from virtualizarr.types.kerchunk import KerchunkStoreRefs
@@ -134,15 +135,26 @@ def convert_v3_to_v2_metadata(
     """
 
     # TODO: Check that all ArrayBytesCodecs should in fact be excluded for V2 metadata storage.
-    # TODO: Test round-tripping big endian since that is stored in the bytes codec in V3; it should be included in data type instead for V2.
     v2_codecs = [
         zarr_codec_config_to_v2(get_codec_config(codec))
         for codec in v3_metadata.codecs
         if not isinstance(codec, ArrayBytesCodec)
     ]
+    # TODO: Remove convert_v3_to_v2_metadata and always encode V3 metadata. This logic is based on the (default) Bytes codec's endian property, but other codec pipelines could be store endianness elsewhere.
+    big_endian = any(
+        isinstance(codec, ArrayBytesCodec)
+        and hasattr(codec, "endian")
+        and codec.endian.value == "big"
+        for codec in v3_metadata.codecs
+    )
+    if big_endian:
+        na_dtype = v3_metadata.data_type.to_native_dtype().newbyteorder(">")
+        dtype = data_type_registry.match_dtype(dtype=na_dtype)
+    else:
+        dtype = v3_metadata.data_type
     v2_metadata = ArrayV2Metadata(
         shape=v3_metadata.shape,
-        dtype=v3_metadata.data_type,
+        dtype=dtype,
         chunks=v3_metadata.chunks,
         fill_value=fill_value or v3_metadata.fill_value,
         filters=v2_codecs

--- a/virtualizarr/utils.py
+++ b/virtualizarr/utils.py
@@ -140,7 +140,9 @@ def convert_v3_to_v2_metadata(
         for codec in v3_metadata.codecs
         if not isinstance(codec, ArrayBytesCodec)
     ]
-    # TODO: Remove convert_v3_to_v2_metadata and always encode V3 metadata. This logic is based on the (default) Bytes codec's endian property, but other codec pipelines could be store endianness elsewhere.
+    # TODO: Remove convert_v3_to_v2_metadata and always encode V3 metadata.
+    # This logic is based on the (default) Bytes codec's endian property,
+    # but other codec pipelines could store endianness elsewhere.
     big_endian = any(
         isinstance(codec, ArrayBytesCodec)
         and hasattr(codec, "endian")


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
This PR complements #766 by adding to_kerchunk support (whereas #766 added to_icechunk support). For a more robust long-term solution that would eliminate the need for separate metadata pipelines between kerchunk and icechunk, see issue #768.

@rsignell I tested your workflow works using this PR (see https://github.com/maxrjones/test-scripts/blob/main/test-virtualizarr-netcdf3/test-virtualizarr.py).

- [x] Closes #750
- [x] Tests added
- [x] Tests passing
- [ ] Full type hint coverage
- [x] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
