### PR TITLE
account for `endian` being possibly `None`

### DIFF
--- a/virtualizarr/utils.py
+++ b/virtualizarr/utils.py
@@ -145,7 +145,7 @@ def convert_v3_to_v2_metadata(
     # but other codec pipelines could store endianness elsewhere.
     big_endian = any(
         isinstance(codec, ArrayBytesCodec)
-        and hasattr(codec, "endian")
+        and getattr(codec, "endian", None) is not None
         and codec.endian.value == "big"
         for codec in v3_metadata.codecs
     )


### PR DESCRIPTION
For some reason a dataset I've been working on produces `BytesCodec` instances where `endian` is `None`, which causes the translation from v3 to v2 metadata to fail.

No tests because I didn't check thoroughly on where these should be.

(I've seen that you're planning to migrate to v3 entirely, in which case this won't be necessary anymore. It's such a simple fix, though, that this might still be worth it)

- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation