### PR TITLE
Do not validate references for "empty" chunks.

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -11,6 +11,8 @@
 ### Documentation
 
 ### Internal changes
+- Change default Icechunk writing behavior to not validate or write "empty" chunks.
+  ([#791](https://github.com/zarr-developers/VirtualiZarr/pull/791))
 
 ## v2.1.1 (14th August 2025)
 

--- a/virtualizarr/tests/test_writers/test_icechunk.py
+++ b/virtualizarr/tests/test_writers/test_icechunk.py
@@ -731,7 +731,7 @@ def test_write_empty_chunk(
     vds = xr.Dataset({"a": ("x", marr)})
 
     # empty chunks should never be written
-    vds.vz.to_icechunk(icechunk_filestore, validate_containers=False)
+    vds.vz.to_icechunk(icechunk_filestore)
 
     # when opened they should be treated as fill_value
     roundtrip = xr.open_zarr(

--- a/virtualizarr/writers/icechunk.py
+++ b/virtualizarr/writers/icechunk.py
@@ -252,7 +252,8 @@ def validate_virtual_chunk_containers(
         # TODO this loop over every virtual reference is likely inefficient in python,
         # is there a way to push this down to Icechunk? (see https://github.com/earth-mover/icechunk/issues/1167)
         for ref in marr.manifest._paths.flat:
-            validate_single_ref(ref, supported_prefixes)
+            if ref:
+                validate_single_ref(ref, supported_prefixes)
 
 
 def validate_single_ref(ref: str, supported_prefixes: set[str]) -> None:


### PR DESCRIPTION
- [x] Tests passing

Currently, serializing a `ManifestArray` containing empty chunks to Icechunk requires explicitly passing `validate_containers=False` to `to_icechunk` which may be counterintuitive for some users.  ref https://github.com/zarr-developers/VirtualiZarr/issues/740.  This PR changes the current behavior to only perform reference validation for references with a `path`.
