### PR TITLE
Polish release notes for v2.1.2

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -2,20 +2,20 @@
 
 ## v2.1.2 (3rd September 2025)
 
-Patch release with bug fixes for the DMRPParser and Icechunk usage with empty chunks.
+Patch release with minor bug fixes for the DMRPParser and Icechunk writing behavior.
 
 ### Bug fixes
 
 - Enable `DMRPParser` to process scalar, dimensionless variables that lack chunks are present.
   ([#666](https://github.com/zarr-developers/VirtualiZarr/pull/757)).
-  By [Miguel Jimenez-Urias](https://github.com/Mikejmnez)
+  By [Miguel Jimenez-Urias](https://github.com/Mikejmnez).
 - Enable `DMRPParser` to parse flattened dmrpp metadata reference files, which contain container attributes.
   ([#581](https://github.com/zarr-developers/VirtualiZarr/pull/757)).
-  By [Miguel Jimenez-Urias](https://github.com/Mikejmnez)
+  By [Miguel Jimenez-Urias](https://github.com/Mikejmnez).
+- Support dtypes without an endianness ([#787](https://github.com/zarr-developers/VirtualiZarr/pull/787)). By [Justus Magin](https://github.com/keewis).
 
 ### Internal changes
-- Change default Icechunk writing behavior to not validate or write "empty" chunks.
-  ([#791](https://github.com/zarr-developers/VirtualiZarr/pull/791))
+- Change default Icechunk writing behavior to not validate or write "empty" chunks ([#791](https://github.com/zarr-developers/VirtualiZarr/pull/791)). By [Sean Harkins](https://github.com/sharkinsspatial).
 
 ## v2.1.1 (14th August 2025)
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,14 +1,17 @@
 # Release notes
 
-## v2.1.2 (unreleased)
+## v2.1.2 (3rd September 2025)
 
-### New Features
-
-### Breaking changes
+Patch release with bug fixes for the DMRPParser and Icechunk usage with empty chunks.
 
 ### Bug fixes
 
-### Documentation
+- Enable `DMRPParser` to process scalar, dimensionless variables that lack chunks are present.
+  ([#666](https://github.com/zarr-developers/VirtualiZarr/pull/757)).
+  By [Miguel Jimenez-Urias](https://github.com/Mikejmnez)
+- Enable `DMRPParser` to parse flattened dmrpp metadata reference files, which contain container attributes.
+  ([#581](https://github.com/zarr-developers/VirtualiZarr/pull/757)).
+  By [Miguel Jimenez-Urias](https://github.com/Mikejmnez)
 
 ### Internal changes
 - Change default Icechunk writing behavior to not validate or write "empty" chunks.
@@ -23,12 +26,6 @@ Extremely minor release to ensure compatibility with the soon-to-be released ver
 - Adjust for minor upcoming change in private xarray API `xarray.structure.combine._nested_combine`.
   ([#779](https://github.com/zarr-developers/VirtualiZarr/pull/779)).
   By [Tom Nicholas](https://github.com/TomNicholas).
-- Enable `DMRPParser` to process scalar, dimensionless variables that lack chunks are present.
-  ([#666](https://github.com/zarr-developers/VirtualiZarr/pull/757)).
-  By [Miguel Jimenez-Urias](https://github.com/Mikejmnez)
-- Enable `DMRPParser` to parse flattened dmrpp metadata reference files, which contain container attributes.
-  ([#581](https://github.com/zarr-developers/VirtualiZarr/pull/757)).
-  By [Miguel Jimenez-Urias](https://github.com/Mikejmnez)
 
 ## v2.1.0 (14th August 2025)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 requires-python = ">=3.11"
 dynamic = ["version"]
 dependencies = [
-    "xarray>=2025.3.0",
+    "xarray>=2025.03.0",
     "numpy>=2.0.0",
     "universal-pathlib",
     "numcodecs>=0.15.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,6 +170,7 @@ numpy = "==2.0.0"
 numcodecs = "==0.15.1"
 zarr = "==3.1.0"
 obstore = "==0.5.1"
+icechunk = "==1.1.2"
 
 # Define commands to run within the test environments
 [tool.pixi.feature.test.tasks]


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
It'd be nice to release today to unblock the earthaccess team

- [ ] Closes #782 
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
