### PR TITLE
Support in-lined Kerchunk references

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -9,6 +9,7 @@ from typing import Any, Callable, Iterable, Mapping, Optional
 import h5py  # type: ignore[import]
 import numpy as np
 import pytest
+import ujson
 import xarray as xr
 from obstore.store import LocalStore
 from xarray.core.variable import Variable
@@ -289,11 +290,16 @@ def netcdf4_virtual_dataset(netcdf4_file):
 
 
 @pytest.fixture
-def netcdf4_inlined_ref(netcdf4_file):
+def netcdf4_inlined_ref(tmp_path, netcdf4_file):
     """Create an inlined reference from a NetCDF4 file."""
     from kerchunk.hdf import SingleHdf5ToZarr
 
-    return SingleHdf5ToZarr(netcdf4_file, inline_threshold=1000).translate()
+    ref_filepath = tmp_path / "ref.json"
+    refs = SingleHdf5ToZarr(netcdf4_file, inline_threshold=1000).translate()
+    with open(ref_filepath, "w") as json_file:
+        ujson.dump(refs, json_file)
+
+    return f"file://{ref_filepath}"
 
 
 # HDF5 file fixtures

--- a/virtualizarr/manifests/manifest.py
+++ b/virtualizarr/manifests/manifest.py
@@ -19,6 +19,7 @@ VALID_URI_PREFIXES = {
     "file:///",
     "http://",
     "https://",
+    "memory://",
 }
 
 

--- a/virtualizarr/parsers/kerchunk/json.py
+++ b/virtualizarr/parsers/kerchunk/json.py
@@ -1,6 +1,7 @@
 from collections.abc import Iterable
 
 import ujson
+from obstore.store import MemoryStore
 
 from virtualizarr.manifests import ManifestStore
 from virtualizarr.parsers.kerchunk.translator import manifestgroup_from_kerchunk_refs
@@ -55,6 +56,8 @@ class KerchunkJSONParser:
         """
         store, path_after_prefix = registry.resolve(url)
 
+        cache = MemoryStore()
+
         # we need the whole thing so just get the entire contents in one request
         resp = store.get(path_after_prefix)
         content = resp.bytes().to_bytes()
@@ -65,5 +68,8 @@ class KerchunkJSONParser:
             group=self.group,
             fs_root=self.fs_root,
             skip_variables=self.skip_variables,
+            cache=cache,
         )
+
+        registry.register("memory://kerchunk/", cache)
         return ManifestStore(group=manifestgroup, registry=registry)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
Currently supports inlined data using a cache in the ManifestStore.

TODO: 

- [ ] Automatically load in-lined data in `ManifestStore.to_virtual_dataset()`
- [ ] Closes #489 
- [ ] Closes #636
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
