### PR TITLE
Update usage.md: use 'file_url'

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -158,7 +158,7 @@ here we used the [HDFParser][virtualizarr.parsers.HDFParser].
 ```python exec="on" session="usage" source="material-block"
 parser = HDFParser()
 vds = open_virtual_dataset(
-  url=f"{bucket}/{path}",
+  url=file_url,
   parser=parser,
   registry=registry,
 )


### PR DESCRIPTION
 

neither of 'bucket',  'path' are defined in this code

- [x] minor doc fix