### PR TITLE
Add `decode_timedelta` argument to open_virtual_dataset

### DIFF
--- a/virtualizarr/manifests/store.py
+++ b/virtualizarr/manifests/store.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import re
 from collections.abc import AsyncGenerator, Iterable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal, TypeAlias
+from typing import TYPE_CHECKING, Literal, TypeAlias, Mapping
 from urllib.parse import urlparse
+
+from xarray.coders import CFDatetimeCoder, CFTimedeltaCoder
 
 from zarr.abc.store import (
     ByteRequest,
@@ -281,7 +283,8 @@ class ManifestStore(Store):
         self,
         group="",
         loadable_variables: Iterable[str] | None = None,
-        decode_times: bool | None = None,
+        decode_times: bool | CFDatetimeCoder | Mapping[str, bool | CFDatetimeCoder] | None = None,
+        decode_timedelta: bool | CFTimedeltaCoder | Mapping[str, bool | CFTimedeltaCoder] | None = None,
     ) -> "xr.Dataset":
         """
         Create a "virtual" [xarray.Dataset][] containing the contents of one zarr group.
@@ -294,6 +297,8 @@ class ManifestStore(Store):
         ----------
         group : str
         loadable_variables : Iterable[str], optional
+        decode_times : bool, optional
+        decode_timedelta : bool, optional
 
         Returns
         -------
@@ -312,6 +317,7 @@ class ManifestStore(Store):
             group=group,
             loadable_variables=loadable_variables,
             decode_times=decode_times,
+            decode_timedelta=decode_timedelta,
         )
 
 


### PR DESCRIPTION
I have started an implementation here by simply following through the code and adding `decode_timedelta` wherever `decode_times` was passed along. 

I noticed that the type hints only allowed for `bool|None` previously, but xarray [allows passing CFTime/TimedeltaCoder and per variable mappings](https://github.com/pydata/xarray/blob/64704605a4912946d2835e54baa2905b8b4396a9/xarray/backends/api.py#L386-L391). I have added these here to all relevant functions for now, but can revert this if I am missing the point of it only being `bool|None`. 

What I am missing here are additional tests. I might need a bit of help/input to make sense of what exactly we should test here. 


<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #749
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
