### PR TITLE
accept a user-instance of concurrent.futures class for parallel

### DIFF
--- a/virtualizarr/parallel.py
+++ b/virtualizarr/parallel.py
@@ -32,6 +32,8 @@ def get_executor(
         return SerialExecutor
     elif inspect.isclass(parallel) and issubclass(parallel, Executor):
         return parallel
+    elif isinstance(parallel, Executor):
+        return parallel
     else:
         raise ValueError(
             f"Unrecognized argument to ``parallel``: {parallel}"

--- a/virtualizarr/xarray.py
+++ b/virtualizarr/xarray.py
@@ -237,15 +237,23 @@ def open_virtual_mfdataset(
         open_func = _open
 
     executor = get_executor(parallel=parallel)
-    with executor() as exec:
-        # wait for all the workers to finish, and send their resulting virtual datasets back to the client for concatenation there
+    # wait for all the workers to finish, and send their resulting virtual datasets back to the client for concatenation there
+    # we accept an instance of the class, or the class
+    if isinstance(executor, Executor):
         virtual_datasets = list(
-            exec.map(
+            executor.map(
                 open_func,
                 paths1d,
             )
         )
-
+    else:
+        with executor() as exec:
+            virtual_datasets = list(
+                exec.map(
+                    open_func,
+                    paths1d,
+                )
+            )
     # TODO add file closers
 
     # Combine all datasets, closing them in case of a ValueError


### PR DESCRIPTION
Very much a work-in-progress, I'm unclear about type hints and the documentation for this. 

- [ ] Draft, to close #801
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functionality has documentation

it's awkward having a with clause and a direct map() call in an if/else but I can't see how to avoid that without also redesigning how the abstractions of lithops and dask currently work. 

Here's a public example


```python
from obstore.store import from_url
from virtualizarr import open_virtual_mfdataset
from virtualizarr.parsers import HDFParser
from virtualizarr.registry import ObjectStoreRegistry
from concurrent.futures import ThreadPoolExecutor


bucket  = 'https://www.ncei.noaa.gov'
store = from_url(bucket)
registry = ObjectStoreRegistry({bucket: store})
parser = HDFParser()

path = [f"data/sea-surface-temperature-optimum-interpolation/v2.1/access/avhrr/198109/{file}" for
                file in ["oisst-avhrr-v02r01.19810901.nc", "oisst-avhrr-v02r01.19810902.nc"]]

file_url = [f"{bucket}/{p}" for p in path]

combined_vds = open_virtual_mfdataset(
    file_url,
    registry=registry,
    parser=parser,
    parallel = ThreadPoolExecutor(max_workers = 2),  ## or "dask", ThreadPoolExecutor, etc. as before
    combine="nested",
    concat_dim="time"
)
```