### PR TITLE
Add supports_consolidated_metadata to ManifestStore

### DIFF
--- a/virtualizarr/manifests/store.py
+++ b/virtualizarr/manifests/store.py
@@ -277,6 +277,11 @@ class ManifestStore(Store):
         for k in self._group.arrays.keys():
             yield k
 
+    @property
+    def supports_consolidated_metadata(self) -> bool:
+        # docstring inherited
+        return False
+
     def to_virtual_dataset(
         self,
         group="",


### PR DESCRIPTION
I was just experimenting with using `ManifestStore`s directly and got tired of typing `consolidated=False`. 

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
