### PR TITLE
Remove `ZARR_DEFAULT_FILL_VALUE` lookup

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -10,6 +10,7 @@ import h5py  # type: ignore[import]
 import numpy as np
 import pytest
 import xarray as xr
+import zarr
 from obstore.store import LocalStore
 from xarray.core.variable import Variable
 
@@ -73,11 +74,15 @@ def local_registry():
 
 
 @pytest.fixture(params=["int8", "uint8", "float32"])
-def zarr_store_scalar(tmpdir, request):
-    import zarr
-
+def zarr_array_fill_value(request):
     store = zarr.storage.MemoryStore()
-    zarr_store_scalar = zarr.create_array(store=store, shape=(), dtype=request.param)
+    return zarr.create_array(store=store, shape=(), dtype=request.param)
+
+
+@pytest.fixture()
+def zarr_store_scalar():
+    store = zarr.storage.MemoryStore()
+    zarr_store_scalar = zarr.create_array(store=store, shape=(), dtype="int8")
     zarr_store_scalar[()] = 42
     return zarr_store_scalar
 

--- a/conftest.py
+++ b/conftest.py
@@ -72,12 +72,12 @@ def local_registry():
     return ObjectStoreRegistry({"file://": LocalStore()})
 
 
-@pytest.fixture()
-def zarr_store_scalar(tmpdir):
+@pytest.fixture(params=["int8", "uint8", "float32"])
+def zarr_store_scalar(tmpdir, request):
     import zarr
 
     store = zarr.storage.MemoryStore()
-    zarr_store_scalar = zarr.create_array(store=store, shape=(), dtype="int8")
+    zarr_store_scalar = zarr.create_array(store=store, shape=(), dtype=request.param)
     zarr_store_scalar[()] = 42
     return zarr_store_scalar
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,5 +1,18 @@
 # Release notes
 
+
+
+## v2.1.3 (Upcoming)
+
+
+### Bug fixes
+
+- `ZarrParser` no longer uses `ZARR_DEFAULT_FILL_VALUE` lookup to infer missing `fill_value`.
+  ([#666](https://github.com/zarr-developers/VirtualiZarr/pull/812)).
+  By [Raphael Hagen](https://github.com/norlandrhagen).
+
+### Internal changes
+
 ## v2.1.2 (3rd September 2025)
 
 Patch release with minor bug fixes for the DMRPParser and Icechunk writing behavior.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -11,7 +11,7 @@
 - `ZarrParser` no longer uses `ZARR_DEFAULT_FILL_VALUE` lookup to infer missing `fill_value`.
   ([#666](https://github.com/zarr-developers/VirtualiZarr/pull/812)).
   By [Raphael Hagen](https://github.com/norlandrhagen).
-  
+
 ### Documentation
 
 ### Internal changes

--- a/virtualizarr/parsers/zarr.py
+++ b/virtualizarr/parsers/zarr.py
@@ -5,7 +5,6 @@ from collections.abc import Iterable
 from pathlib import Path  # noqa
 from typing import TYPE_CHECKING, Any, Hashable
 
-import numpy as np
 from zarr.api.asynchronous import open_group as open_group_async
 from zarr.core.metadata import ArrayV3Metadata
 from zarr.storage import ObjectStore
@@ -19,18 +18,6 @@ from virtualizarr.manifests import (
 from virtualizarr.manifests.manifest import validate_and_normalize_path_to_uri  # noqa
 from virtualizarr.registry import ObjectStoreRegistry
 from virtualizarr.vendor.zarr.core.common import _concurrent_map
-
-FillValueT = bool | str | float | int | list | None
-
-ZARR_DEFAULT_FILL_VALUE: dict[str, FillValueT] = {
-    # numpy dtypes's hierarchy lets us avoid checking for all the widths
-    # https://numpy.org/doc/stable/reference/arrays.scalars.html
-    np.dtype("bool").kind: False,
-    np.dtype("int").kind: 0,
-    np.dtype("float").kind: 0.0,
-    np.dtype("complex").kind: [0.0, 0.0],
-    np.dtype("datetime64").kind: 0,
-}
 
 if TYPE_CHECKING:
     import zarr
@@ -77,12 +64,7 @@ async def build_chunk_manifest(zarr_array: zarr.AsyncArray, path: str) -> ChunkM
 
 
 def get_metadata(zarr_array: zarr.AsyncArray[Any]) -> ArrayV3Metadata:
-    fill_value = zarr_array.metadata.fill_value
-    if fill_value is not None:
-        fill_value = ZARR_DEFAULT_FILL_VALUE[zarr_array.metadata.fill_value.dtype.kind]
-
     zarr_format = zarr_array.metadata.zarr_format
-
     if zarr_format == 2:
         # TODO: Once we want to support V2, we will have to deconstruct the
         # zarr_array codecs etc. and reconstruct them with create_v3_array_metadata

--- a/virtualizarr/tests/test_parsers/test_zarr.py
+++ b/virtualizarr/tests/test_parsers/test_zarr.py
@@ -121,7 +121,7 @@ def test_scalar_get_chunk_mapping_prefix(zarr_store_scalar: zarr.Array):
     assert chunk_map["c"]["length"] == 10
 
 
-def test_get_metadata(zarr_store_scalar: zarr.Array):
+def test_get_metadata(zarr_array_fill_value: zarr.Array):
     # Check that the `get_metadata` function is assigning fill_values
-    zarr_array_metadata = get_metadata(zarr_array=zarr_store_scalar)
-    assert zarr_array_metadata.fill_value == zarr_store_scalar.metadata.fill_value
+    zarr_array_metadata = get_metadata(zarr_array=zarr_array_fill_value)
+    assert zarr_array_metadata.fill_value == zarr_array_fill_value.metadata.fill_value

--- a/virtualizarr/tests/test_parsers/test_zarr.py
+++ b/virtualizarr/tests/test_parsers/test_zarr.py
@@ -9,6 +9,8 @@ from virtualizarr.parsers import ZarrParser
 from virtualizarr.parsers.zarr import get_chunk_mapping_prefix, get_metadata
 from virtualizarr.registry import ObjectStoreRegistry
 
+ZarrArrayType = zarr.AsyncArray | zarr.Array
+
 
 @pytest.mark.parametrize(
     "zarr_store",
@@ -106,7 +108,7 @@ class TestOpenVirtualDatasetZarr:
                 assert expected == actual
 
 
-def test_scalar_get_chunk_mapping_prefix(zarr_store_scalar: zarr.Array):
+def test_scalar_get_chunk_mapping_prefix(zarr_store_scalar: ZarrArrayType):
     # Use a scalar zarr store with a /c/ representing the scalar:
     # https://zarr-specs.readthedocs.io/en/latest/v3/chunk-key-encodings/default/index.html#description
 
@@ -121,7 +123,7 @@ def test_scalar_get_chunk_mapping_prefix(zarr_store_scalar: zarr.Array):
     assert chunk_map["c"]["length"] == 10
 
 
-def test_get_metadata(zarr_array_fill_value: zarr.Array):
+def test_get_metadata(zarr_array_fill_value: ZarrArrayType):
     # Check that the `get_metadata` function is assigning fill_values
     zarr_array_metadata = get_metadata(zarr_array=zarr_array_fill_value)
     assert zarr_array_metadata.fill_value == zarr_array_fill_value.metadata.fill_value

--- a/virtualizarr/tests/test_parsers/test_zarr.py
+++ b/virtualizarr/tests/test_parsers/test_zarr.py
@@ -1,11 +1,12 @@
 import numpy as np
 import pytest
+import zarr
 from obstore.store import LocalStore
 
 from virtualizarr import open_virtual_dataset
 from virtualizarr.manifests import ManifestArray
 from virtualizarr.parsers import ZarrParser
-from virtualizarr.parsers.zarr import get_chunk_mapping_prefix
+from virtualizarr.parsers.zarr import get_chunk_mapping_prefix, get_metadata
 from virtualizarr.registry import ObjectStoreRegistry
 
 
@@ -105,7 +106,7 @@ class TestOpenVirtualDatasetZarr:
                 assert expected == actual
 
 
-def test_scalar_get_chunk_mapping_prefix(zarr_store_scalar):
+def test_scalar_get_chunk_mapping_prefix(zarr_store_scalar: zarr.Array):
     # Use a scalar zarr store with a /c/ representing the scalar:
     # https://zarr-specs.readthedocs.io/en/latest/v3/chunk-key-encodings/default/index.html#description
 
@@ -118,3 +119,9 @@ def test_scalar_get_chunk_mapping_prefix(zarr_store_scalar):
     )
     assert chunk_map["c"]["offset"] == 0
     assert chunk_map["c"]["length"] == 10
+
+
+def test_get_metadata(zarr_store_scalar: zarr.Array):
+    # Check that the `get_metadata` function is assigning fill_values
+    zarr_array_metadata = get_metadata(zarr_array=zarr_store_scalar)
+    assert zarr_array_metadata.fill_value == zarr_store_scalar.metadata.fill_value


### PR DESCRIPTION
Towards https://github.com/zarr-developers/VirtualiZarr/issues/811.

In the zarr-parser I used the `ZARR_DEFAULT_FILL_VALUE` lookup dict, but the `fill_value` was never used / reassigned in the `ArrayV3Metadata`. I think it's only purpose was causing bugs like #811. 


- [x] Closes #xxxx
- [x] Tests added
- [x] Tests passing




