### PR TITLE
Fix typing in ManifestStore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 requires-python = ">=3.11"
 dynamic = ["version"]
@@ -134,7 +135,7 @@ requires = [
     "check-manifest",
 ]
 
-[tool.pixi.project]
+[tool.pixi.workspace]
 channels = ["conda-forge"]
 platforms = ["win-64", "linux-64", "osx-64", "osx-arm64"]
 
@@ -149,6 +150,10 @@ python = "3.11.*"
 # Define a feature set for Python 3.12
 [tool.pixi.feature.py312.dependencies]
 python = "3.12.*"
+
+# Define a feature set for Python 3.13
+[tool.pixi.feature.py313.dependencies]
+python = "3.13.*"
 
 # Define a feature set for S3 testing with MinIO
 [tool.pixi.feature.minio.pypi-dependencies]
@@ -188,14 +193,14 @@ run-tests-html-cov = { cmd = "pytest -n auto --run-network-tests --verbose --cov
 [tool.pixi.environments]
 min-deps = ["dev", "test", "hdf", "hdf5-lib"] # VirtualiZarr/conftest.py using h5py, so the minimum set of dependencies for testing still includes hdf libs
 # Inherit from min-deps to get all the test commands, along with optional dependencies
-test = ["dev", "test", "remote", "hdf", "netcdf3", "fits", "icechunk", "kerchunk", "kerchunk_parquet", "hdf5-lib"]
+test = ["dev", "test", "remote", "hdf", "netcdf3", "fits", "icechunk", "kerchunk", "kerchunk_parquet", "hdf5-lib", "py313"]
 test-py311 = ["dev", "test", "remote", "hdf", "netcdf3", "fits", "icechunk", "kerchunk", "kerchunk_parquet", "hdf5-lib", "py311"] # test against python 3.11
 test-py312 = ["dev", "test", "remote", "hdf", "netcdf3", "fits", "icechunk", "kerchunk", "kerchunk_parquet", "hdf5-lib", "py312"] # test against python 3.12
 minio = ["dev", "remote", "hdf", "netcdf3", "fits", "icechunk", "kerchunk", "hdf5-lib", "py312", "minio"]
 minimum-versions = ["dev", "test", "remote", "hdf", "netcdf3", "fits", "icechunk", "kerchunk", "kerchunk_parquet", "hdf5-lib", "minimum-versions"]
-upstream = ["dev", "test", "hdf", "hdf5-lib", "netcdf3", "upstream", "icechunk-dev"]
-all = ["dev", "test", "remote", "hdf", "netcdf3", "fits", "icechunk", "kerchunk", "kerchunk_parquet", "hdf5-lib", "all_parsers", "all_writers"]
-docs = ["docs", "dev", "remote", "hdf", "netcdf3", "fits", "icechunk", "kerchunk", "kerchunk_parquet", "hdf5-lib",]
+upstream = ["dev", "test", "hdf", "hdf5-lib", "netcdf3", "upstream", "icechunk-dev", "py313"]
+all = ["dev", "test", "remote", "hdf", "netcdf3", "fits", "icechunk", "kerchunk", "kerchunk_parquet", "hdf5-lib", "all_parsers", "all_writers", "py313"]
+docs = ["docs", "dev", "remote", "hdf", "netcdf3", "fits", "icechunk", "kerchunk", "kerchunk_parquet", "hdf5-lib", "py313"]
 
 # Define commands to run within the docs environment
 [tool.pixi.feature.docs.tasks]

--- a/virtualizarr/manifests/store.py
+++ b/virtualizarr/manifests/store.py
@@ -175,9 +175,10 @@ class ManifestStore(Store):
         marr = self._group.arrays[var]
         manifest = marr.manifest
 
-        chunk_indexes = parse_manifest_index(
-            key, marr.metadata.chunk_key_encoding.separator
+        separator: Literal[".", "/"] = getattr(
+            marr.metadata.chunk_key_encoding, "separator", "."
         )
+        chunk_indexes = parse_manifest_index(key, separator)
 
         path = manifest._paths[chunk_indexes]
         if path == "":
@@ -246,11 +247,6 @@ class ManifestStore(Store):
 
     async def delete(self, key: str) -> None:
         raise NotImplementedError
-
-    @property
-    def supports_partial_writes(self) -> bool:
-        # docstring inherited
-        return False
 
     async def set_partial_values(
         self, key_start_values: Iterable[tuple[str, int, BytesLike]]


### PR DESCRIPTION
Minor changes to reflect upstream changes in zarr-python.

Also specifies 3.13 as the test environment because icechunk doesn't seem to be installable with python 3.14 yet.