### PR TITLE
Add example of virtualizing GOES using caching and request splitting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,7 +161,6 @@ cython_debug/
 virtualizarr/_version.py
 docs/generated/
 docs/jupyter_execute/
-examples/
 
 # Created by https://www.toptal.com/developers/gitignore/api/visualstudiocode
 # Edit at https://www.toptal.com/developers/gitignore?templates=visualstudiocode

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,11 +1,18 @@
 # End-to-end examples
 
+The following examples demonstrate the use of VirtualiZarr to create virtual datasets of various kinds.
+
+## V2 Examples
+
+These examples use the VirtualiZarr 2.x API with `obstore` for cloud storage access:
+
+1. [Virtualizing GOES-16 satellite data (basic)](https://github.com/zarr-developers/VirtualiZarr/blob/main/examples/V2/goes_basic.py) - Virtualizes a GOES-16 file using a standard obstore. Use as a baseline for performance comparison.
+2. [Virtualizing GOES-16 satellite data with optimized store wrappers](https://github.com/zarr-developers/VirtualiZarr/blob/main/examples/V2/goes_with_caching_stores.py) - Demonstrates using `CachingReadableStore` and `SplittingReadableStore` from `obspec-utils` to optimize metadata access when virtualizing remote HDF5/NetCDF files.
+
+## V1 Examples
+
 !!! note
-    The examples listed here use a pre-2.0 release of VirtualiZarr.
-
-
-
-The following examples demonstrate the use of VirtualiZarr to create virtual datasets of various kinds:
+    The V1 examples listed here use a pre-2.0 release of VirtualiZarr.
 
 1. [Appending new daily NOAA SST data to Icechunk](https://github.com/zarr-developers/VirtualiZarr/blob/main/examples/V1/append/noaa-cdr-sst.ipynb)
 2. [Parallel reference generation using Coiled Functions](https://github.com/zarr-developers/VirtualiZarr/blob/main/examples/V1/coiled/terraclimate.ipynb)

--- a/examples/V2/README.md
+++ b/examples/V2/README.md
@@ -1,0 +1,36 @@
+# V2 Examples
+
+These examples use the VirtualiZarr 2.x API with `obstore` for cloud storage access.
+
+## Examples
+
+### [goes_basic.py](goes_basic.py)
+
+Virtualizes a GOES-16 satellite file using a standard obstore without any optimizations. Use this as a baseline for performance comparison.
+
+```bash
+uv run --script examples/V2/goes_basic.py
+```
+
+### [goes_with_caching_stores.py](goes_with_caching_stores.py)
+
+Virtualizes the same GOES-16 file using `CachingReadableStore` and `SplittingReadableStore` from `obspec-utils` to optimize metadata access.
+
+```bash
+uv run --script examples/V2/goes_with_caching_stores.py
+```
+
+## Performance Comparison
+
+Run both scripts and compare the "Virtualization time" printed at the end of each:
+
+```bash
+uv run --script examples/V2/goes_basic.py
+uv run --script examples/V2/goes_with_caching_stores.py
+```
+
+The timing is measured internally to exclude dependency installation overhead. Running on a laptop in North Carolina, the basic approach takes 47s while the caching + splitting approach takes 9s.
+
+## Requirements
+
+These examples use [uv](https://docs.astral.sh/uv/) inline script metadata for dependency management. Each script specifies its own dependencies and can be run directly with `uv run`.

--- a/examples/V2/goes_basic.py
+++ b/examples/V2/goes_basic.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "virtualizarr",
+#     "obstore",
+#     "xarray",
+#     "numpy",
+#     "h5py",
+# ]
+# ///
+"""
+Virtualizing GOES-16 satellite data with a basic object store.
+
+This example demonstrates virtualizing a GOES-16 file using a standard obstore
+without any caching or parallel fetch optimizations. Compare this with
+`goes_with_caching_stores.py` to see the performance difference.
+
+## Usage
+
+Run this example with uv:
+
+    uv run --script examples/V2/goes_basic.py
+
+To compare performance with the optimized version, run both scripts and compare
+the "Virtualization time" printed at the end of each.
+
+"""
+
+import time
+
+from obstore.store import from_url
+
+import virtualizarr as vz
+from virtualizarr.registry import ObjectStoreRegistry
+
+
+def per_band_var_names(var_name: str) -> list[str]:
+    """Generate variable names for all 16 GOES ABI bands."""
+    return [f"{var_name}_C{i:02}" for i in range(1, 17)]
+
+
+def main():
+    # --- Configuration ---
+    bucket = "s3://noaa-goes16"
+    url = (
+        "s3://noaa-goes16/ABI-L2-MCMIPF/2024/099/18/"
+        "OR_ABI-L2-MCMIPF-M6_G16_s20240991800204_e20240991809524_c20240991810005.nc"
+    )
+
+    # Variables to drop (band statistics we don't need for this example)
+    drop_variables = (
+        per_band_var_names("band_id")
+        + per_band_var_names("min_reflectance_factor")
+        + per_band_var_names("max_reflectance_factor")
+        + per_band_var_names("mean_reflectance_factor")
+        + per_band_var_names("std_dev_reflectance_factor")
+        + per_band_var_names("min_brightness_temperature")
+        + per_band_var_names("max_brightness_temperature")
+        + per_band_var_names("mean_brightness_temperature")
+        + per_band_var_names("std_dev_brightness_temperature")
+        + per_band_var_names("outlier_pixel_count")
+    )
+
+    # Variables to load into memory (low-dimensional coordinates and metadata)
+    loadable_vars = [
+        "y",
+        "x",
+        "t",
+        "band",
+        "x_image",
+        "y_image",
+        "x_image_bounds",
+        "y_image_bounds",
+        "time_bounds",
+        "goes_imager_projection",
+        "nominal_satellite_subpoint_lat",
+        "nominal_satellite_subpoint_lon",
+        "nominal_satellite_height",
+        "geospatial_lat_lon_extent",
+        "percent_uncorrectable_GRB_errors",
+        "percent_uncorrectable_L0_errors",
+        "dynamic_algorithm_input_data_container",
+        "algorithm_product_version_container",
+    ] + per_band_var_names("band_wavelength")
+
+    # --- Create the base object store (no caching or splitting) ---
+    # This is a public S3 bucket, so we use skip_signature=True
+    start_time = time.perf_counter()
+    store = from_url(bucket, region="us-east-1", skip_signature=True)
+
+    # --- Create the registry with the basic store ---
+    registry = ObjectStoreRegistry({bucket: store})
+
+    # --- Configure the HDF5 parser ---
+    parser = vz.parsers.HDFParser(drop_variables=drop_variables)
+
+    # --- Open the virtual dataset (timed) ---
+    print(f"Opening virtual dataset from: {url}")
+
+    vds = vz.open_virtual_dataset(
+        url,
+        registry=registry,
+        parser=parser,
+        loadable_variables=loadable_vars,
+    )
+    elapsed = time.perf_counter() - start_time
+
+    # Show the size of virtual references vs actual data
+    print(f"Size of virtual references: {vds.vz.nbytes:,} bytes")
+    print(f"Size of actual data (if loaded): {vds.nbytes:,} bytes")
+    print("-" * 10)
+
+    print("-" * 10)
+    print(f"Virtualization time: {elapsed:.2f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/V2/goes_with_caching_stores.py
+++ b/examples/V2/goes_with_caching_stores.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "virtualizarr @ git+https://github.com/maxrjones/VirtualiZarr@obspec-utils-readablefile-protocol",
+#     "obstore",
+#     "obspec-utils",
+#     "xarray",
+#     "numpy",
+#     "h5py",
+# ]
+# ///
+"""
+Virtualizing GOES-16 satellite data with optimized store wrappers.
+
+This example demonstrates how to use CachingReadableStore and SplittingReadableStore
+from obspec-utils to optimize file access when virtualizing remote data files.
+
+## Store Wrappers
+
+When virtualizing remote files, VirtualiZarr needs to read metadata from each file.
+For files stored in cloud object storage, this can involve many small HTTP requests,
+which are slow due to network latency.
+
+Two store wrappers from obspec-utils help optimize this:
+
+1. **SplittingReadableStore**: Accelerates downloading large files by splitting a
+   single `get()` request into multiple parallel `get_ranges()` calls. This takes
+   advantage of cloud storage's high per-request bandwidth.
+
+2. **CachingReadableStore**: Caches entire files in memory after first access.
+   Subsequent accesses (including range requests) are served from the cache.
+   Uses LRU eviction when the cache exceeds its maximum size.
+
+## Composition Pattern
+
+These wrappers are designed to be composed together:
+
+```
+SplittingReadableStore  ->  CachingReadableStore  ->  VirtualiZarr
+     (fast fetch)              (cache result)         (virtualize)
+```
+
+The SplittingReadableStore fetches the file quickly via parallel requests,
+then CachingReadableStore stores the result for reuse during virtualization.
+
+## Usage
+
+Run this example with uv:
+
+    uv run --script examples/V2/goes_with_caching_stores.py
+
+"""
+
+import time
+
+from obspec_utils.cache import CachingReadableStore
+from obspec_utils.obspec import BufferedStoreReader
+from obspec_utils.registry import ObjectStoreRegistry
+from obspec_utils.splitting import SplittingReadableStore
+from obstore.store import from_url
+
+import virtualizarr as vz
+
+
+def per_band_var_names(var_name: str) -> list[str]:
+    """Generate variable names for all 16 GOES ABI bands."""
+    return [f"{var_name}_C{i:02}" for i in range(1, 17)]
+
+
+def main():
+    # --- Configuration ---
+    bucket = "s3://noaa-goes16"
+    url = (
+        "s3://noaa-goes16/ABI-L2-MCMIPF/2024/099/18/"
+        "OR_ABI-L2-MCMIPF-M6_G16_s20240991800204_e20240991809524_c20240991810005.nc"
+    )
+
+    # Variables to drop (band statistics we don't need for this example)
+    drop_variables = (
+        per_band_var_names("band_id")
+        + per_band_var_names("min_reflectance_factor")
+        + per_band_var_names("max_reflectance_factor")
+        + per_band_var_names("mean_reflectance_factor")
+        + per_band_var_names("std_dev_reflectance_factor")
+        + per_band_var_names("min_brightness_temperature")
+        + per_band_var_names("max_brightness_temperature")
+        + per_band_var_names("mean_brightness_temperature")
+        + per_band_var_names("std_dev_brightness_temperature")
+        + per_band_var_names("outlier_pixel_count")
+    )
+
+    # Variables to load into memory (low-dimensional coordinates and metadata)
+    loadable_vars = [
+        "y",
+        "x",
+        "t",
+        "band",
+        "x_image",
+        "y_image",
+        "x_image_bounds",
+        "y_image_bounds",
+        "time_bounds",
+        "goes_imager_projection",
+        "nominal_satellite_subpoint_lat",
+        "nominal_satellite_subpoint_lon",
+        "nominal_satellite_height",
+        "geospatial_lat_lon_extent",
+        "percent_uncorrectable_GRB_errors",
+        "percent_uncorrectable_L0_errors",
+        "dynamic_algorithm_input_data_container",
+        "algorithm_product_version_container",
+    ] + per_band_var_names("band_wavelength")
+
+    # --- Create the base object store ---
+    # This is a public S3 bucket, so we use skip_signature=True
+    start_time = time.perf_counter()
+    base_store = from_url(bucket, region="us-east-1", skip_signature=True)
+
+    # --- Wrap with SplittingReadableStore for parallel fetching ---
+    # This splits large file fetches into parallel range requests.
+    # Default settings (12 MB chunks, 18 concurrent requests) work well for cloud storage.
+    splitting_store = SplittingReadableStore(base_store)
+
+    # --- Wrap with CachingReadableStore for in-memory caching ---
+    # This caches entire files after first access. When VirtualiZarr reads
+    # metadata from different parts of the file, all reads are served from cache.
+    # Default max_size is 256 MB, which is sufficient for most single-file cases.
+    caching_store = CachingReadableStore(splitting_store, max_size=512 * 1024 * 1024)
+
+    # --- Create the registry with the wrapped store ---
+    registry = ObjectStoreRegistry({bucket: caching_store})
+
+    # --- Configure the HDF5 parser ---
+    parser = vz.parsers.HDFParser(
+        drop_variables=drop_variables, reader_factory=BufferedStoreReader
+    )
+
+    # --- Open the virtual dataset (timed) ---
+    print(f"Opening virtual dataset from: {url}")
+    print(f"Cache size before: {caching_store.cache_size} bytes")
+
+    vds = vz.open_virtual_dataset(
+        url,
+        registry=registry,
+        parser=parser,
+        loadable_variables=loadable_vars,
+    )
+    elapsed = time.perf_counter() - start_time
+
+    print(f"Cache size after: {caching_store.cache_size:,} bytes")
+    print(f"Cached paths: {caching_store.cached_paths}")
+    print("-" * 10)
+
+    # Show the size of virtual references vs actual data
+    print(f"Size of virtual references: {vds.vz.nbytes:,} bytes")
+    print(f"Size of actual data (if loaded): {vds.nbytes:,} bytes")
+    print("-" * 10)
+
+    # --- Cleanup ---
+    # Clear the cache when done (optional - will be garbage collected anyway)
+    caching_store.clear_cache()
+    print("-" * 10)
+    print(f"Virtualization time: {elapsed:.2f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/V2/goes_with_caching_stores.py
+++ b/examples/V2/goes_with_caching_stores.py
@@ -2,7 +2,7 @@
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
-#     "virtualizarr @ git+https://github.com/maxrjones/VirtualiZarr@obspec-utils-readablefile-protocol",
+#     "virtualizarr @ git+https://github.com/zarr-developers/VirtualiZarr@main",
 #     "obstore",
 #     "obspec-utils",
 #     "xarray",

--- a/examples/V2/goes_with_caching_stores.py
+++ b/examples/V2/goes_with_caching_stores.py
@@ -2,7 +2,7 @@
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
-#     "virtualizarr @ git+https://github.com/zarr-developers/VirtualiZarr@main",
+#     "virtualizarr>=0.2.4",
 #     "obstore",
 #     "obspec-utils",
 #     "xarray",


### PR DESCRIPTION
This PR shows how to cache entire files before virtualizing.

Full explanation: for data formats that use b-link trees (like non-cloud-optimized version of HDF5), you'll probably want to cache the entire file up front. If you also want to load many variables, you'll want to cache the file's contents at the store level rather than at the parser/file reader level so that it's accessible by ManifestStore as well as the parser. This PR adds an example of how to do that using new features in [obspec-utils](https://obspec-utils.readthedocs.io/en/latest/). It relies on the sequence of PRs discussed in #844, which makes VirtualiZarr work with any ReadableStore using duck-type rather than only the stores implemented in obstore.

It reduces the amount of time to virtualize a single GOES-16 file on my laptop from ~47s to ~8s ⚡ 

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
