### PR TITLE
WIP: Support complex64 _FillValue

### DIFF
--- a/virtualizarr/tests/test_parsers/conftest.py
+++ b/virtualizarr/tests/test_parsers/conftest.py
@@ -476,3 +476,19 @@ def big_endian_dtype_hdf5_file(tmpdir):
     dset = f["data"]
     dset[...] = 10
     return filepath
+
+
+@pytest.fixture()
+def complex64_hdf5_file(tmp_path: Path) -> str:
+    filepath = str(tmp_path / "complex64.nc")
+
+    with h5py.File(filepath, "w") as f:
+        data = np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex64)
+        fill_value = np.complex64(-9999 - 9999j)
+        dset = f.create_dataset(name="data", data=data, chunks=True)
+        dim_scale = f.create_dataset(name="x", data=np.arange(3), chunks=True)
+        dim_scale.make_scale()
+        dset.dims[0].attach_scale(dim_scale)
+        dset.attrs["_FillValue"] = fill_value
+
+    return filepath


### PR DESCRIPTION
I'll open a PR upstream in Xarray to add support there, but wanted to share this PR for anyone who wants to try out virtualizing the first NISAR files before that lands:

```python
#!/usr/bin/env -S uv run
# /// script
# requires-python = ">=3.11"
# dependencies = [
#     "earthaccess",
#     "virtualizarr[hdf] @ git+https://github.com/maxrjones/VirtualiZarr@c-dtype",
#     "obspec-utils @ git+https://github.com/virtual-zarr/obspec-utils@main",
#     "aiohttp",
# ]
# ///
"""MVCE: Virtualize a NISAR HDF5 file."""

from urllib.parse import urlparse
import earthaccess
import virtualizarr as vz
from obspec_utils.registry import ObjectStoreRegistry
from obspec_utils.stores import AiohttpStore

# URL of the NISAR granule
url = "https://nisar.asf.earthdatacloud.nasa.gov/NISAR/NISAR_L2_GCOV_BETA_V1/NISAR_L2_PR_GCOV_003_005_D_077_4005_DHDH_A_20251017T132451_20251017T132526_X05007_N_F_J_001/NISAR_L2_PR_GCOV_003_005_D_077_4005_DHDH_A_20251017T132451_20251017T132526_X05007_N_F_J_001.h5"

# Authenticate and create store
earthaccess.login()
parsed = urlparse(url)
base_url = f"{parsed.scheme}://{parsed.netloc}"
token = earthaccess.get_edl_token()["access_token"]

store = AiohttpStore(base_url, headers={"Authorization": f"Bearer {token}"})
registry = ObjectStoreRegistry({base_url: store})

# Virtualize the file
parser = vz.parsers.HDFParser()
manifest_store = parser(url, registry=registry)

# Count arrays recursively
def count_arrays(group):
    n = len(group.arrays)
    for g in group.groups.values():
        n += count_arrays(g)
    return n

print(f"Total arrays: {count_arrays(manifest_store._group)}")
```
- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
