### PR TITLE
Support indexing when it removes a dimension of length 1

### DIFF
--- a/virtualizarr/manifests/indexing.py
+++ b/virtualizarr/manifests/indexing.py
@@ -168,7 +168,7 @@ def apply_selection_1d(
         if slice_is_no_op(indexer_1d, axis_length=length):
             pass
         else:
-            NotImplementedError(
+            raise NotImplementedError(
                 f"Unsupported indexer. Indexing within a ManifestArray using ints or slices is not yet supported (see GitHub issue #51), but received {indexer_1d}"
             )
     elif isinstance(indexer_1d, int):


### PR DESCRIPTION
This is to support `xr.DataArray.squeeze`. It implements the following comment that was in manifests/indexing.py:

> \# TODO cover possibility of indexing into a length-1 dimension (which just removes that dimension)?

I'll raise a couple points as in-line comments.

todo:
- [ ] Convert the removed coordinate to a scalar attribute
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
