### PR TITLE
Correct Scaling docs. 

### DIFF
--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -97,14 +97,14 @@ VirtualiZarr comes with a small selection of executors you can choose from when 
 The simplest executor is the [`SerialExecutor`][virtualizarr.parallel.SerialExecutor], which executes all the [`open_virtual_dataset`][virtualizarr.open_virtual_dataset] calls in serial, not in parallel.
 It is the default executor.
 
-### Threads or Processes
+### Threads
 
-One way to parallelize creating virtual references from a single machine is to across multiple threads or processes.
-For this you can use the [`ThreadPoolExecutor`][concurrent.futures.ThreadPoolExecutor] or ~[`ProcessPoolExecutor`][concurrent.futures.ProcessPoolExecutor]~[^1] class from the [`concurrent.futures`][] module in the python standard library.
+One way to parallelize creating virtual references from a single machine is to use multiple threads.
+For this you can use the [`ThreadPoolExecutor`][concurrent.futures.ThreadPoolExecutor] class from the [`concurrent.futures`][] module in the python standard library.
 You simply pass the executor class directly via the `parallel` kwarg to [`open_virtual_mfdataset`][virtualizarr.open_virtual_mfdataset].
 
-!!! warning
-    [^1]: `ProcessPoolExecutor` does not currently work with VirtualiZarr. For progress on a fix, see [PR #889](https://github.com/zarr-developers/VirtualiZarr/pull/889).
+!!! note
+    We are also working on adding support for [`ProcessPoolExecutor`][concurrent.futures.ProcessPoolExecutor], see [PR #889](https://github.com/zarr-developers/VirtualiZarr/pull/889).
 
 ```python
 from concurrent.futures import ThreadPoolExecutor

--- a/virtualizarr/tests/test_xarray.py
+++ b/virtualizarr/tests/test_xarray.py
@@ -1,6 +1,6 @@
 import functools
 from collections.abc import Mapping
-from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from pathlib import Path
 from typing import Callable
 

--- a/virtualizarr/tests/test_xarray.py
+++ b/virtualizarr/tests/test_xarray.py
@@ -1,6 +1,6 @@
 import functools
 from collections.abc import Mapping
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
 from pathlib import Path
 from typing import Callable
 
@@ -891,6 +891,7 @@ class TestOpenVirtualMFDataset:
         [
             False,
             ThreadPoolExecutor,
+            ProcessPoolExecutor,
             pytest.param("dask", marks=requires_dask),
             pytest.param("lithops", marks=requires_lithops),
         ],

--- a/virtualizarr/tests/test_xarray.py
+++ b/virtualizarr/tests/test_xarray.py
@@ -891,7 +891,13 @@ class TestOpenVirtualMFDataset:
         [
             False,
             ThreadPoolExecutor,
-            pytest.param(ProcessPoolExecutor, marks=pytest.mark.xfail(reason="See https://github.com/zarr-developers/VirtualiZarr/pull/889", strict=True)),
+            pytest.param(
+                ProcessPoolExecutor,
+                marks=pytest.mark.xfail(
+                    reason="See https://github.com/zarr-developers/VirtualiZarr/pull/889",
+                    strict=True,
+                ),
+            ),
             pytest.param("dask", marks=requires_dask),
             pytest.param("lithops", marks=requires_lithops),
         ],

--- a/virtualizarr/tests/test_xarray.py
+++ b/virtualizarr/tests/test_xarray.py
@@ -891,7 +891,7 @@ class TestOpenVirtualMFDataset:
         [
             False,
             ThreadPoolExecutor,
-            ProcessPoolExecutor,
+            pytest.param(ProcessPoolExecutor, marks=pytest.mark.xfail(reason="See https://github.com/zarr-developers/VirtualiZarr/pull/889", strict=True)),
             pytest.param("dask", marks=requires_dask),
             pytest.param("lithops", marks=requires_lithops),
         ],


### PR DESCRIPTION
This PR will incorporate some of the findings from #889 since I am stalled on that one. 

My process here:
- [x] Add `parallel=ProcessPoolExecutor` as testing option to confirm that it generally fails (my assumption from the initial motivation of #889)
- [x] Adjust docs:
    - Remove recommendation of ProcessPoolExecutor
    - Warn that using ThreadPoolExecutor + HDFParser will basically result in serial processing
    - Suggest to use local lithops or dask until #889 is fixed.  