### PR TITLE
update test file and associated dmrpp

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -199,6 +199,9 @@ def netcdf4_file(tmp_path: Path) -> str:
     """Create a NetCDF4 file with air temperature data."""
     filepath = tmp_path / "air.nc"
     with xr.tutorial.open_dataset("air_temperature") as ds:
+        ds["time"].encoding["_FillValue"] = None
+        ds["lat"].encoding["_FillValue"] = None
+        ds["lon"].encoding["_FillValue"] = None
         ds.to_netcdf(filepath, format="NETCDF4")
     return str(filepath)
 

--- a/virtualizarr/tests/test_parsers/test_dmrpp.py
+++ b/virtualizarr/tests/test_parsers/test_dmrpp.py
@@ -1,4 +1,3 @@
-import platform
 import textwrap
 from contextlib import nullcontext
 from pathlib import Path
@@ -29,15 +28,30 @@ DMRPP_XML_STRINGS = {
     "netcdf4_file": textwrap.dedent(
         """\
         <?xml version="1.0" encoding="ISO-8859-1"?>
-        <Dataset xmlns="http://xml.opendap.org/ns/DAP/4.0#" xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#" dapVersion="4.0" dmrVersion="1.0" name="air.nc" dmrpp:href="OPeNDAP_DMRpp_DATA_ACCESS_URL" dmrpp:version="3.21.1-451">
+        <Dataset xmlns="http://xml.opendap.org/ns/DAP/4.0#" xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#" dapVersion="4.0" dmrVersion="1.0" name="air.nc" dmrpp:href="OPeNDAP_DMRpp_DATA_ACCESS_URL" dmrpp:version="3.21.0-46">
+            <Dimension name="time" size="2920"/>
             <Dimension name="lat" size="25"/>
             <Dimension name="lon" size="53"/>
-            <Dimension name="time" size="2920"/>
+            <Float32 name="time">
+                <Dim name="/time"/>
+                <Attribute name="standard_name" type="String">
+                    <Value>time</Value>
+                </Attribute>
+                <Attribute name="long_name" type="String">
+                    <Value>Time</Value>
+                </Attribute>
+                <Attribute name="units" type="String">
+                    <Value>hours since 1800-01-01</Value>
+             </Attribute>
+                <Attribute name="calendar" type="String">
+                    <Value>standard</Value>
+                </Attribute>
+                <dmrpp:chunks fillValue="9.96921e+36" byteOrder="LE">
+                    <dmrpp:chunk offset="7757599" nBytes="11680"/>
+                </dmrpp:chunks>
+            </Float32>
             <Float32 name="lat">
                 <Dim name="/lat"/>
-                <Attribute name="_FillValue" type="Float32">
-                    <Value>NaN</Value>
-                </Attribute>
                 <Attribute name="standard_name" type="String">
                     <Value>latitude</Value>
                 </Attribute>
@@ -50,15 +64,12 @@ DMRPP_XML_STRINGS = {
                 <Attribute name="axis" type="String">
                     <Value>Y</Value>
                 </Attribute>
-                <dmrpp:chunks fillValue="nan" byteOrder="LE">
-                    <dmrpp:chunk offset="5179" nBytes="100"/>
+                <dmrpp:chunks fillValue="9.96921e+36" byteOrder="LE">
+                    <dmrpp:chunk offset="7750843" nBytes="100"/>
                 </dmrpp:chunks>
             </Float32>
             <Float32 name="lon">
                 <Dim name="/lon"/>
-                <Attribute name="_FillValue" type="Float32">
-                    <Value>NaN</Value>
-                </Attribute>
                 <Attribute name="standard_name" type="String">
                     <Value>longitude</Value>
                 </Attribute>
@@ -71,29 +82,8 @@ DMRPP_XML_STRINGS = {
                 <Attribute name="axis" type="String">
                     <Value>X</Value>
                 </Attribute>
-                <dmrpp:chunks fillValue="nan" byteOrder="LE">
-                    <dmrpp:chunk offset="5279" nBytes="212"/>
-                </dmrpp:chunks>
-            </Float32>
-            <Float32 name="time">
-                <Dim name="/time"/>
-                <Attribute name="_FillValue" type="Float32">
-                    <Value>NaN</Value>
-                </Attribute>
-                <Attribute name="standard_name" type="String">
-                    <Value>time</Value>
-                </Attribute>
-                <Attribute name="long_name" type="String">
-                    <Value>Time</Value>
-                </Attribute>
-                <Attribute name="units" type="String">
-                    <Value>hours since 1800-01-01</Value>
-                </Attribute>
-                <Attribute name="calendar" type="String">
-                    <Value>standard</Value>
-                </Attribute>
-                <dmrpp:chunks fillValue="nan" byteOrder="LE">
-                    <dmrpp:chunk offset="7757499" nBytes="11680"/>
+                <dmrpp:chunks fillValue="9.96921e+36" byteOrder="LE">
+                    <dmrpp:chunk offset="7752991" nBytes="212"/>
                 </dmrpp:chunks>
             </Float32>
             <Int16 name="air">
@@ -161,20 +151,17 @@ DMRPP_XML_STRINGS = {
                 <Value>http://www.esrl.noaa.gov/psd/data/gridded/data.ncep.reanalysis.html</Value>
             </Attribute>
             <Attribute name="build_dmrpp_metadata" type="Container">
-                <Attribute name="created" type="String">
-                    <Value>2025-07-16T18:48:42Z</Value>
-                </Attribute>
                 <Attribute name="build_dmrpp" type="String">
-                    <Value>3.21.1-451</Value>
+                    <Value>3.21.0-46</Value>
                 </Attribute>
                 <Attribute name="bes" type="String">
-                    <Value>3.21.1-451</Value>
+                    <Value>3.21.0-46</Value>
                 </Attribute>
                 <Attribute name="libdap" type="String">
-                    <Value>libdap-3.21.1-178</Value>
+                    <Value>libdap-3.21.0-27</Value>
                 </Attribute>
                 <Attribute name="invocation" type="String">
-                    <Value>build_dmrpp -f /usr/share/hyrax/air.nc -r air.nc.dmr -u OPeNDAP_DMRpp_DATA_ACCESS_URL -M</Value>
+                    <Value>build_dmrpp -c /tmp/bes_conf_BzHu -f ///usr/share/hyrax/air.nc -r /tmp/dmr__Tm4R9h -u OPeNDAP_DMRpp_DATA_ACCESS_URL -M</Value>
                 </Attribute>
             </Attribute>
         </Dataset>
@@ -487,10 +474,10 @@ def test_split_groups(hdf5_groups_file, group_path):
     assert result_tags == expected_tags
 
 
-@pytest.mark.xfail(
-    platform.system() == "Linux",
-    reason="See https://github.com/zarr-developers/VirtualiZarr/issues/904.",
-)
+# @pytest.mark.xfail(
+#     platform.system() == "Linux",
+#     reason="See https://github.com/zarr-developers/VirtualiZarr/issues/904.",
+# )
 @pytest.mark.parametrize(
     "group,warns",
     [


### PR DESCRIPTION
# What I did
<!-- Please describe what you did and why -->

<!-- Feel free to remove check-list items that aren't relevant to your change -->

- [x] Closes #904 
- [x] ~Tests added~ updated tests
- [x] Tests passing (local machine macOS)
- [x] Full type hint coverage
- [ ] Changes are documented in `docs/releases.md`

This is an attempt to enable a dmrpp test to run on Linux. There seems to be an issue with the `time` coordinate dimension. When writing the source file to my local machine with xarray, I get a `SerializationWarning` similar to that in https://github.com/pydata/xarray/issues/6840 (same file used!). Based on this issue https://github.com/pydata/xarray/issues/10305, the time dimension should not have a `_FillValue`. Even though there is none explicitly set, when I store the file and look at the headers, I see that by default the `time` coordinate (and `lat`,` lon` as well) have an associated `_FillValue` added to then. This seems to go against CF conventions:
```
CF coordinate variables are not supposed to have a `_FillValue` defined:
```
https://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/cf-conventions.html#missing-data

    Missing data is not allowed in coordinate variables.


So decided to get started there. I updated the `dmrpp` building it using the updated file  which no longer has the `_FillValue` attribute appear in coordinates `time`, `lat`, and `lon`. (`dmrpp` build tool I used is from over a year ago so it should be as "old" as the previous one). It does assign a `fill_value` attr to the associated chunk tags for each coordinate dimension. But tests passed on my macOS so decided to give it a go... 
