### PR TITLE
Update `kerchunk` writer `refs_to_dataframe` to deal with `ArrowStringArray` from new ZarrParser deps.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ icechunk = [
 ]
 zarr = ["arro3-core", "pyarrow"]
 
-kerchunk = ["fastparquet"]
+kerchunk = ["fastparquet", "pandas"]
 
 all_writers = [
     "virtualizarr[icechunk]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,8 @@ all_parsers = [
 icechunk = [
     "icechunk>=1.1.2",
 ]
+zarr = ["arro3-core", "pyarrow"]
+
 kerchunk = ["fastparquet"]
 
 all_writers = [

--- a/virtualizarr/accessor.py
+++ b/virtualizarr/accessor.py
@@ -192,6 +192,7 @@ class _VirtualiZarrDatasetAccessor:
 
             return None
         elif format == "parquet":
+            import pandas as pd
             from kerchunk.df import refs_to_dataframe
 
             if isinstance(filepath, Path):
@@ -199,14 +200,19 @@ class _VirtualiZarrDatasetAccessor:
             elif isinstance(filepath, str):
                 url = filepath
 
-            # refs_to_dataframe is responsible for writing to parquet.
-            # at no point does it create a full in-memory dataframe.
-            refs_to_dataframe(
-                refs,
-                url=url,
-                record_size=record_size,
-                categorical_threshold=categorical_threshold,
-            )
+            # The zarr-parser performance update PR #892 adds pyarrow and arro3-core as deps.
+            # These break the `kerchunk` refs_to_dataframe behavior.
+            # It seems like pyarrow makes pandas default to an ArrowStringArray
+            # which fastparquet cannot zero-copy encode.
+            # TODO: remove once fastparquet or kerchunk handle ArrowStringArray.
+
+            with pd.option_context("future.infer_string", False):
+                refs_to_dataframe(
+                    refs,
+                    url=url,
+                    record_size=record_size,
+                    categorical_threshold=categorical_threshold,
+                )
             return None
         else:
             raise ValueError(f"Unrecognized output format: {format}")


### PR DESCRIPTION
# What I did
https://github.com/zarr-developers/VirtualiZarr/pull/892 added two new deps, `arro3-core` and `pyarrow` These broke the Kerchunk parquet tests:

`ValueError: Error converting column "path" to bytes using encoding UTF8. Original error: Unable to avoid copy while creating an array as requested.`

Adding a pandas context seemed to resolve this. `pd.option_context("future.infer_string", False)`

Acceptance criteria:
<!-- Feel free to remove check-list items that aren't relevant to your change -->

- [x] Tests passing
- [x] Full type hint coverage


