### PR TITLE
feat: configurable chunk separator

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -4,6 +4,10 @@
 
 ### New Features
 
+- Support configurable chunk separator.
+  ([#917](https://github.com/zarr-developers/VirtualiZarr/pull/917)).
+  By [Max Jones](https://github.com/maxrjones).
+
 ### Breaking changes
 
 - Minimum required version of `obspec_utils` is now `0.9.0`.

--- a/virtualizarr/manifests/array.py
+++ b/virtualizarr/manifests/array.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Any, Callable, Union
+from typing import Any, Callable, Union, cast
 
 import numpy as np
 import xarray as xr
@@ -12,6 +12,7 @@ from virtualizarr.manifests.array_api import (
 )
 from virtualizarr.manifests.indexing import T_Indexer, index
 from virtualizarr.manifests.manifest import ChunkManifest
+from virtualizarr.manifests.utils import ChunkKeySeparator
 
 
 class ManifestArray:
@@ -57,7 +58,10 @@ class ManifestArray:
         if isinstance(chunkmanifest, ChunkManifest):
             _chunkmanifest = chunkmanifest
         elif isinstance(chunkmanifest, dict):
-            separator = getattr(_metadata.chunk_key_encoding, "separator", ".")
+            separator = cast(
+                ChunkKeySeparator,
+                getattr(_metadata.chunk_key_encoding, "separator", "."),
+            )
             _chunkmanifest = ChunkManifest(entries=chunkmanifest, separator=separator)
         else:
             raise TypeError(

--- a/virtualizarr/manifests/array.py
+++ b/virtualizarr/manifests/array.py
@@ -57,7 +57,8 @@ class ManifestArray:
         if isinstance(chunkmanifest, ChunkManifest):
             _chunkmanifest = chunkmanifest
         elif isinstance(chunkmanifest, dict):
-            _chunkmanifest = ChunkManifest(entries=chunkmanifest)
+            separator = getattr(_metadata.chunk_key_encoding, "separator", ".")
+            _chunkmanifest = ChunkManifest(entries=chunkmanifest, separator=separator)
         else:
             raise TypeError(
                 f"chunkmanifest arg must be of type ChunkManifest or dict, but got type {type(chunkmanifest)}"

--- a/virtualizarr/manifests/manifest.py
+++ b/virtualizarr/manifests/manifest.py
@@ -556,10 +556,10 @@ def validate_chunk_keys(
 ) -> None:
     if not chunk_keys:
         return
-
+    pattern = compiled_chunk_pattern(separator)
     # Check if all keys have the correct form
     for key in chunk_keys:
-        if not re.match(compiled_chunk_pattern(separator), key):
+        if not re.match(pattern, key):
             raise ValueError(f"Invalid format for chunk key: '{key}'")
 
     # Check if all keys have the same number of dimensions

--- a/virtualizarr/manifests/manifest.py
+++ b/virtualizarr/manifests/manifest.py
@@ -14,7 +14,11 @@ from typing import TYPE_CHECKING, Any, NewType, TypedDict, cast
 
 import numpy as np
 
-from virtualizarr.manifests.utils import compiled_chunk_pattern, parse_manifest_index
+from virtualizarr.manifests.utils import (
+    ChunkKeySeparator,
+    compiled_chunk_pattern,
+    parse_manifest_index,
+)
 from virtualizarr.types import ChunkKey
 
 if TYPE_CHECKING:
@@ -190,7 +194,12 @@ class ChunkManifest:
     _offsets: np.ndarray[Any, np.dtype[np.uint64]]
     _lengths: np.ndarray[Any, np.dtype[np.uint64]]
 
-    def __init__(self, entries: dict, shape: tuple[int, ...] | None = None) -> None:
+    def __init__(
+        self,
+        entries: dict,
+        shape: tuple[int, ...] | None = None,
+        separator: ChunkKeySeparator = ".",
+    ) -> None:
         """
         Create a ChunkManifest from a dictionary mapping zarr chunk keys to byte ranges.
 
@@ -207,15 +216,18 @@ class ChunkManifest:
                 "0.1.1": {"path": "s3://bucket/foo.nc", "offset": 400, "length": 100},
             }
             ```
+        separator
+            The chunk key separator, as specified by the array's chunk_key_encoding
+            metadata. Either "." (default/v2 encoding) or "/" (default encoding).
         """
         if shape is None and not entries:
             raise ValueError("need a chunk grid shape if no chunks given")
 
         # TODO do some input validation here first?
-        validate_chunk_keys(entries.keys())
+        validate_chunk_keys(entries.keys(), separator)
 
         if shape is None:
-            shape = get_chunk_grid_shape(entries.keys())
+            shape = get_chunk_grid_shape(entries.keys(), separator)
 
         # Initializing to empty implies that entries with path='' are treated as missing chunks
         paths = cast(  # `np.empty` apparently is type hinted as if the output could have Any dtype
@@ -237,7 +249,7 @@ class ChunkManifest:
             path, offset, length = entry.values()
             entry = ChunkEntry.with_validation(path=path, offset=offset, length=length)  # type: ignore[attr-defined]
 
-            split_key = parse_manifest_index(key)
+            split_key = parse_manifest_index(key, separator)
             paths[split_key] = entry["path"]
             offsets[split_key] = entry["offset"]
             lengths[split_key] = entry["length"]
@@ -534,39 +546,45 @@ def join(inds: Iterable[Any]) -> ChunkKey:
     return cast(ChunkKey, ".".join(str(i) for i in list(inds)))
 
 
-def get_ndim_from_key(key: str) -> int:
+def get_ndim_from_key(key: str, separator: ChunkKeySeparator = ".") -> int:
     """Get number of dimensions implied by key, e.g. '4.5.6' -> 3"""
-    return len(parse_manifest_index(key))
+    return len(parse_manifest_index(key, separator))
 
 
-def validate_chunk_keys(chunk_keys: Iterable[ChunkKey]):
+def validate_chunk_keys(
+    chunk_keys: Iterable[ChunkKey], separator: ChunkKeySeparator = "."
+) -> None:
     if not chunk_keys:
         return
 
     # Check if all keys have the correct form
     for key in chunk_keys:
-        if not re.match(compiled_chunk_pattern("."), key):
+        if not re.match(compiled_chunk_pattern(separator), key):
             raise ValueError(f"Invalid format for chunk key: '{key}'")
 
     # Check if all keys have the same number of dimensions
     first_key, *other_keys = list(chunk_keys)
-    ndim = get_ndim_from_key(first_key)
+    ndim = get_ndim_from_key(first_key, separator)
     for key in other_keys:
-        other_ndim = get_ndim_from_key(key)
+        other_ndim = get_ndim_from_key(key, separator)
         if other_ndim != ndim:
             raise ValueError(
                 f"Inconsistent number of dimensions between chunk key {key} and {first_key}: {other_ndim} vs {ndim}"
             )
 
 
-def get_chunk_grid_shape(chunk_keys: Iterable[ChunkKey]) -> tuple[int, ...]:
+def get_chunk_grid_shape(
+    chunk_keys: Iterable[ChunkKey], separator: ChunkKeySeparator = "."
+) -> tuple[int, ...]:
     # find max chunk index along each dimension
     chunk_keys = tuple(chunk_keys)
 
     if chunk_keys == ("c",):
         # Scalar array, cannot be split
         return ()
-    zipped_indices = zip(*map(parse_manifest_index, chunk_keys))
+    zipped_indices = zip(
+        *map(lambda key: parse_manifest_index(key, separator), chunk_keys)
+    )
     chunk_grid_shape = tuple(
         max(indices_along_one_dim) + 1 for indices_along_one_dim in zipped_indices
     )

--- a/virtualizarr/tests/test_manifests/test_manifest.py
+++ b/virtualizarr/tests/test_manifests/test_manifest.py
@@ -148,6 +148,26 @@ class TestCreateManifest:
         with pytest.raises(ValueError, match="Inconsistent number of dimensions"):
             ChunkManifest(entries=chunks)
 
+    def test_slash_separator(self):
+        """Chunk keys using '/' separator should be accepted when separator='/'."""
+        chunks = {
+            "0/0": {"path": "/foo.nc", "offset": 100, "length": 100},
+            "0/1": {"path": "/foo.nc", "offset": 200, "length": 100},
+            "1/0": {"path": "/foo.nc", "offset": 300, "length": 100},
+            "1/1": {"path": "/foo.nc", "offset": 400, "length": 100},
+        }
+        manifest = ChunkManifest(entries=chunks, separator="/")
+        assert manifest.shape_chunk_grid == (2, 2)
+        assert manifest.ndim_chunk_grid == 2
+
+    def test_slash_separator_rejected_without_separator_param(self):
+        """Chunk keys using '/' should fail validation when separator is '.' (the default)."""
+        chunks = {
+            "0/0": {"path": "/foo.nc", "offset": 100, "length": 100},
+        }
+        with pytest.raises(ValueError, match="Invalid format for chunk key"):
+            ChunkManifest(entries=chunks)
+
     def test_remove_chunks_with_empty_paths(self):
         chunks = {
             "0.0.0": {"path": "", "offset": 0, "length": 100},


### PR DESCRIPTION
# What I did

The chunk key encoding is an [extension point](https://zarr-specs.readthedocs.io/en/latest/v3/chunk-key-encodings/index.html), so this PR makes it configurable.
Acceptance criteria:
<!-- Feel free to remove check-list items that aren't relevant to your change -->

- [ ] Closes #911 
- [ ] Tests added
- [ ] Tests passing
- [ ] No test coverage regression
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.md`
- [ ] New functions/methods are listed in an appropriate `*.md` file under `docs/api`
- [ ] New functionality has documentation
