### PR TITLE
Run minimum-versions CI on all PRs

### DIFF
--- a/.github/workflows/minimum-versions.yml
+++ b/.github/workflows/minimum-versions.yml
@@ -7,7 +7,7 @@ on:
     - 'docs/**'
   pull_request:
     branches: [ "main" ]
-    types: [opened, reopened, synchronize, labeled]
+    types: [opened, reopened, synchronize]
     paths-ignore:
     - 'docs/**'
   schedule:
@@ -20,12 +20,6 @@ concurrency:
 jobs:
   test-minimum-versions:
     name: minimum-versions-build
-    if: |
-      always()
-      && (
-          (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
-          || contains( github.event.pull_request.labels.*.name, 'test-upstream')
-      )
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
## Summary
- Removes the `test-upstream` label gate from the minimum-versions workflow so it runs on every PR
- Removes the now-unnecessary `labeled` event type from the PR trigger
- The upstream workflow remains gated behind `test-upstream` since building Icechunk is slow

Closes #929

## Test plan
- [x] Verify minimum-versions CI runs automatically on this PR (no label needed)
- [ ] Verify upstream CI still requires the `test-upstream` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)