### PR TITLE
Test python 3.12, 3.13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [test-py311, test-py312, test-py312, test-py314, min-deps, minio]
+        environment: [test-py311, test-py312, test-py313, test-py314, min-deps, minio]
     steps:
       - uses: actions/checkout@v4
       - uses: prefix-dev/setup-pixi@v0.9.3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [test-py311, test-py314, min-deps, minio]
+        environment: [test-py311, test-py312, test-py312, test-py314, min-deps, minio]
     steps:
       - uses: actions/checkout@v4
       - uses: prefix-dev/setup-pixi@v0.9.3

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -52,6 +52,8 @@
   By [Tom Nicholas](https://github.com/TomNicholas).
 - Completely rewrote the `ZarrParser` to use numpy string arrays for efficiency ([#927](https://github.com/zarr-developers/VirtualiZarr/pull/927)).
   By [Tom Nicholas](https://github.com/TomNicholas).
+- Testing across all supported python versions ([#927](https://github.com/zarr-developers/VirtualiZarr/pull/932)).
+  By [Julius Busecke](https://github.com/jbusecke)
 
 ## v2.4.0 (24th January 2026)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,6 +163,10 @@ python = "3.11.*"
 
 # Define a feature set for Python 3.13
 [tool.pixi.feature.py313.dependencies]
+python = "3.12.*"
+
+# Define a feature set for Python 3.13
+[tool.pixi.feature.py313.dependencies]
 python = "3.13.*"
 
 # Define a feature set for Python 3.14
@@ -209,6 +213,7 @@ min-deps = ["dev", "test", "hdf", "hdf5-lib"] # VirtualiZarr/conftest.py using h
 # Inherit from min-deps to get all the test commands, along with optional dependencies
 test = ["dev", "test", "remote", "hdf", "netcdf3", "fits", "icechunk", "kerchunk", "kerchunk_parquet", "hdf5-lib", "zarr", "py314"]
 test-py311 = ["dev", "test", "remote", "hdf", "netcdf3", "fits", "icechunk", "kerchunk", "kerchunk_parquet", "hdf5-lib", "tiff", "zarr","py311"] # test against python 3.11
+test-py312 = ["dev", "test", "remote", "hdf", "netcdf3", "fits", "icechunk", "kerchunk", "kerchunk_parquet", "hdf5-lib", "tiff", "zarr", "py312"] # test against python 3.13
 test-py313 = ["dev", "test", "remote", "hdf", "netcdf3", "fits", "icechunk", "kerchunk", "kerchunk_parquet", "hdf5-lib", "tiff", "zarr", "py313"] # test against python 3.13
 test-py314 = ["dev", "test", "remote", "hdf", "netcdf3", "fits", "icechunk", "kerchunk", "kerchunk_parquet", "hdf5-lib", "zarr", "py314"] # test against python 3.14
 minio = ["dev", "remote", "hdf", "netcdf3", "fits", "icechunk", "kerchunk", "hdf5-lib", "py314", "zarr", "minio"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,8 +161,8 @@ virtualizarr = { path = ".", editable = true }
 [tool.pixi.feature.py311.dependencies]
 python = "3.11.*"
 
-# Define a feature set for Python 3.13
-[tool.pixi.feature.py313.dependencies]
+# Define a feature set for Python 3.12
+[tool.pixi.feature.py312.dependencies]
 python = "3.12.*"
 
 # Define a feature set for Python 3.13


### PR DESCRIPTION
# What I did
<!-- Please describe what you did and why -->

Noticed that python 3.12 and 3.13 are not tested in #925.

Acceptance criteria:
<!-- Feel free to remove check-list items that aren't relevant to your change -->
- [x] Tests passing
- [x] No test coverage regression
- [x] Full type hint coverage
- [x] Changes are documented in `docs/releases.md`
