### PR TITLE
Fix bug in v2 zarr parser which interprets empty dimension list as truthy

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -40,6 +40,8 @@
 - Fix `ZarrParser` not using the store-relative path when the zarr store is nested inside the object store root
   ([#913](https://github.com/zarr-developers/VirtualiZarr/pull/913)).
   By [Tom Nicholas](https://github.com/TomNicholas).
+- Fix `ZarrParser` not correctly parsing scalar variables from v2 native zarr stores ([#936](https://github.com/zarr-developers/VirtualiZarr/pull/936)).
+  By [Julius Buseceke](https://github.com/jbusecke)
 
 ### Documentation
 

--- a/virtualizarr/parsers/zarr.py
+++ b/virtualizarr/parsers/zarr.py
@@ -348,7 +348,7 @@ def _convert_v2_to_v3_dict(metadata: ArrayV2Metadata) -> dict:
     # to V3's dimension_names, so we do it manually.
     attrs = cast(dict, v3_dict.get("attributes", {}))
     dim_names = attrs.get("_ARRAY_DIMENSIONS")
-    if v3_dict.get("dimension_names") is None and dim_names:
+    if v3_dict.get("dimension_names") is None and dim_names is not None:
         v3_dict["dimension_names"] = dim_names
 
     # _ARRAY_DIMENSIONS is a V2 convention that gets promoted to dimension_names in V3,

--- a/virtualizarr/tests/test_parsers/test_zarr.py
+++ b/virtualizarr/tests/test_parsers/test_zarr.py
@@ -243,6 +243,17 @@ def test_v2_metadata_with_dimensions():
     assert metadata.dimension_names == ("x", "y")
 
 
+@requires_v2_migration
+def test_v2_metadata_with_scalar_dimensions():
+    """Test V2 metadata conversion for scalar array with _ARRAY_DIMENSIONS=[]."""
+    store = zarr.storage.MemoryStore()
+    array = zarr.create(shape=(), chunks=(), dtype="int64", store=store, zarr_format=2)
+    array.attrs["_ARRAY_DIMENSIONS"] = []
+
+    metadata = metadata_as_v3(zarr.open(store, mode="r").metadata)
+    assert metadata.dimension_names == ()
+
+
 def test_v3_metadata_separator_normalized():
     """Test that metadata_as_v3 normalizes V3 chunk_key_encoding separator to '.'."""
     store = zarr.storage.MemoryStore()


### PR DESCRIPTION
# What I did
See #935 

Acceptance criteria:
<!-- Feel free to remove check-list items that aren't relevant to your change -->

- [x] Closes #935
- [x] Tests added
- [x] Tests passing
- [x] No test coverage regression
- [x] Full type hint coverage
- [x] Changes are documented in `docs/releases.md`
