### PR TITLE
Corrections to  `docs/releases.md`

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -154,6 +154,12 @@ This release moves the `ObjectStoreRegistry` to a separate package `obspec_utils
 - Return None for Zarr V2/consolidated metadata requests.
   ([#827](https://github.com/zarr-developers/VirtualiZarr/pull/827)).
   By [Max Jones](https://github.com/maxrjones)
+- Raise informative error on Zarr V2 parsing with Zarr-Python<3.1.3
+  ([#829](https://github.com/zarr-developers/VirtualiZarr/pull/829)).
+  By [Max Jones](https://github.com/maxrjones).
+- Revert "Remove unnecessary dtype conversion in icechunk writer"
+  ([#805](https://github.com/zarr-developers/VirtualiZarr/pull/805)).
+  By [Tom Nicholas](https://github.com/TomNicholas).
 
 ### Documentation
 


### PR DESCRIPTION
I told Claude to fix errors in `releases.md`.


   - Fix wrong PR link text in release notes (#927→#932, #565→#822)                                                                                              
   - Move PR #818 from v2.2.0 to unreleased section (it was merged after v2.4.0)
   - Add missing bug fix entries to unreleased section (#880, #868, #924, #916)
   - Add missing documentation entries to unreleased section (#918, #893, #937)
   - Add missing internal change to unreleased section (#909)
   - Add missing documentation entries to v2.4.0 (#855, #856)
   - Add missing entries to v2.2.0 (#829, #805)