### PR TITLE
fix: allow Azure urls

### DIFF
--- a/virtualizarr/manifests/manifest.py
+++ b/virtualizarr/manifests/manifest.py
@@ -11,6 +11,7 @@ from collections.abc import (
 )
 from pathlib import PosixPath
 from typing import Any, NewType, TypedDict, cast
+from urllib.parse import urlparse
 
 import numpy as np
 
@@ -21,18 +22,10 @@ from virtualizarr.manifests.utils import (
 )
 from virtualizarr.types import ChunkKey
 
-# doesn't guarantee that writers actually handle these
-VALID_URI_PREFIXES = {
-    "s3://",
-    "gs://",
-    "azure://",
-    "r2://",
-    "cos://",
-    "minio://",
-    "file:///",
-    "http://",
-    "https://",
-}
+
+def _is_uri(path: str) -> bool:
+    """Check if a path is a URI by looking for a scheme."""
+    return bool(urlparse(path).scheme)
 
 
 class ChunkEntry(TypedDict):
@@ -76,7 +69,7 @@ def validate_and_normalize_path_to_uri(path: str, fs_root: str | None = None) ->
     if path == "":
         # (empty paths are allowed through as they represent missing chunks)
         return path
-    elif any(path.startswith(prefix) for prefix in VALID_URI_PREFIXES):
+    elif _is_uri(path):
         return path  # path is already in URI form
     else:
         # must be a posix filesystem path (absolute or relative)

--- a/virtualizarr/tests/test_manifests/test_manifest.py
+++ b/virtualizarr/tests/test_manifests/test_manifest.py
@@ -54,6 +54,20 @@ class TestPathValidation:
             length=100,
         )
 
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "az://container/path/to/file.nc",
+            "abfs://container/path/to/file.nc",
+            "abfss://container/path/to/file.nc",
+            "gcs://bucket/path/to/file.nc",
+        ],
+    )
+    def test_allow_object_store_urls(self, url):
+        """Regression test for https://github.com/zarr-developers/VirtualiZarr/issues/771"""
+        chunkentry = ChunkEntry.with_validation(path=url, offset=100, length=100)
+        assert chunkentry["path"] == url
+
 
 class TestConvertingRelativePathsUsingFSRoot:
     def test_fs_root_must_be_absolute(self):


### PR DESCRIPTION
This PR uses urlparse for url detection, so that we don't maintain an allowlist of valid URL schemes.

Acceptance criteria:
<!-- Feel free to remove check-list items that aren't relevant to your change -->

- [ ] Closes #771 
- [ ] Tests added
- [ ] Tests passing
- [ ] No test coverage regression
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.md`
- [ ] New functions/methods are listed in an appropriate `*.md` file under `docs/api`
- [ ] New functionality has documentation
