### PR TITLE
Add sharding support

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -16,7 +16,6 @@ Some reasons are:
 - Virtualization allows arbitrary differences in metadata compared to the original files - this is mostly a useful feature but it could become out-of-sync or misleading.
 - It creates significant extra work for someone later down the line, and that person will almost certainly know less about the details of the dataset than the data provider does at write time.
 - Chunk sizes matter, and it's generally good to force data providers to think up-front about about what chunk sizes would be optimal for expected user queries.
-- Some other types of optimizations (particularly sharding) are not supported for virtual stores.
 - For static datasets, native Zarr stores scale effortlessly to arbitrary numbers of chunks today, without having to even think about things like [manifest splitting](https://icechunk.io/en/latest/performance/#splitting-manifests).
 
 ### Can my specific data be virtualized?

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -4,6 +4,10 @@
 
 ### New Features
 
+- Support for sharded Zarr V3 arrays in `ZarrParser`.
+  ([#946](https://github.com/zarr-developers/VirtualiZarr/pull/946)).
+  By [Tom Nicholas](https://github.com/TomNicholas).
+
 ### Breaking changes
 
 ### Bug fixes

--- a/virtualizarr/parsers/zarr.py
+++ b/virtualizarr/parsers/zarr.py
@@ -13,7 +13,6 @@ import obstore
 import zarr
 from obspec_utils.registry import ObjectStoreRegistry
 from zarr.api.asynchronous import open_group as open_group_async
-from zarr.codecs import ShardingCodec
 from zarr.core.chunk_grids import RegularChunkGrid
 from zarr.core.metadata import ArrayV2Metadata, ArrayV3Metadata
 from zarr.storage import ObjectStore

--- a/virtualizarr/parsers/zarr.py
+++ b/virtualizarr/parsers/zarr.py
@@ -268,15 +268,6 @@ async def construct_manifest_array(
     """Construct a ManifestArray from a zarr array."""
     array_v3_metadata = metadata_as_v3(zarr_array.metadata)
 
-    # This is the only restriction on what Zarr Arrays cannot be virtualized
-    if any(isinstance(codec, ShardingCodec) for codec in array_v3_metadata.codecs):
-        raise NotImplementedError(
-            f"Zarr V3 arrays with sharding are not yet supported, but array {path} uses the ShardingCodec."
-            "Sharding stores multiple chunks in a single storage object with non-zero offsets, "
-            "which VirtualiZarr does not currently handle. "
-            "Reading sharded arrays without proper offset handling would result in corrupted data."
-        )
-
     if not isinstance(array_v3_metadata.chunk_grid, RegularChunkGrid):
         raise NotImplementedError(
             f"Only RegularChunkGrid is supported, but array {zarr_array.path} "
@@ -393,6 +384,9 @@ async def build_chunk_manifest(
     missing, Zarr will return the fill_value for those regions when the array is read.
     """
 
+    # For sharded arrays, chunk_grid.chunk_shape is the shard shape (not the inner
+    # chunk shape, which lives inside the ShardingCodec config). So this grid describes
+    # the number of shard files on disk, which is exactly what we want for the manifest.
     chunk_grid_shape = determine_chunk_grid_shape(
         metadata.shape, cast(RegularChunkGrid, metadata.chunk_grid).chunk_shape
     )

--- a/virtualizarr/tests/test_parsers/test_zarr.py
+++ b/virtualizarr/tests/test_parsers/test_zarr.py
@@ -498,17 +498,16 @@ def test_sharded_array_roundtrip(tmpdir):
     """Test that a sharded Zarr V3 array can be virtualized and read back correctly."""
     filepath = f"{tmpdir}/test_sharded.zarr"
 
-    # Create a Zarr V3 group with a sharded array containing real data
-    root = zarr.open_group(store=filepath, mode="w", zarr_format=3)
-    data = np.arange(100 * 100, dtype="float32").reshape(100, 100)
-    arr = root.create_array(
-        name="data",
-        shape=(100, 100),
-        chunks=(10, 10),
-        shards=(50, 50),
-        dtype="float32",
+    # Create a small sharded dataset via xarray
+    ds = xr.Dataset(
+        {"data": (("x", "y"), np.arange(12 * 12, dtype="float32").reshape(12, 12))},
     )
-    arr[:] = data
+    ds.to_zarr(
+        filepath,
+        encoding={"data": {"chunks": (3, 3), "shards": (6, 6)}},
+        consolidated=False,
+        zarr_format=3,
+    )
 
     # Parse with VirtualiZarr
     store = LocalStore(prefix=filepath)

--- a/virtualizarr/tests/test_parsers/test_zarr.py
+++ b/virtualizarr/tests/test_parsers/test_zarr.py
@@ -494,30 +494,36 @@ def test_parser_with_nested_store_path(tmpdir, zarr_format):
             xr.testing.assert_identical(actual, expected)
 
 
-def test_sharded_array_raises_error(tmpdir):
-    """Test that attempting to virtualize a sharded Zarr V3 array raises NotImplementedError."""
+def test_sharded_array_roundtrip(tmpdir):
+    """Test that a sharded Zarr V3 array can be virtualized and read back correctly."""
     filepath = f"{tmpdir}/test_sharded.zarr"
 
-    # Create a Zarr V3 group with a sharded array
+    # Create a Zarr V3 group with a sharded array containing real data
     root = zarr.open_group(store=filepath, mode="w", zarr_format=3)
-    root.create_array(
+    data = np.arange(100 * 100, dtype="float32").reshape(100, 100)
+    arr = root.create_array(
         name="data",
         shape=(100, 100),
         chunks=(10, 10),
-        shards=(50, 50),  # This adds sharding
+        shards=(50, 50),
         dtype="float32",
     )
+    arr[:] = data
 
-    # Attempt to open with VirtualiZarr should raise NotImplementedError
+    # Parse with VirtualiZarr
     store = LocalStore(prefix=filepath)
     registry = ObjectStoreRegistry({f"file://{filepath}": store})
     parser = ZarrParser()
+    manifeststore = parser(url=filepath, registry=registry)
 
-    with pytest.raises(
-        NotImplementedError,
-        match="Zarr V3 arrays with sharding are not yet supported",
-    ):
-        parser(url=filepath, registry=registry)
+    # Read back via ManifestStore and compare to original
+    with xr.open_dataset(
+        filepath, engine="zarr", consolidated=False, zarr_format=3
+    ) as expected:
+        with xr.open_dataset(
+            manifeststore, engine="zarr", consolidated=False, zarr_format=3
+        ) as actual:
+            xr.testing.assert_identical(actual, expected)
 
 
 @requires_minio


### PR DESCRIPTION
Allows parsing sharded zarr v3 stores using the `ZarrParser`. Turns out this restriction was totally unecessary - all I had to do was remove the `NotImplementedError` and it immediately worked!

Acceptance criteria:
<!-- Feel free to remove check-list items that aren't relevant to your change -->

- [x] Closes #944
- [x] Tests added
- [x] Tests passing
- [x] No test coverage regression
- [x] Full type hint coverage
- [x] Changes are documented in `docs/releases.md`
- [x] New functionality has documentation

cc @norlandrhagen @maxrjones 