### PR TITLE
fix: preserve shard shape when writing to icechunk

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -12,6 +12,10 @@
 
 ### Bug fixes
 
+- Fix icechunk writer using inner chunk shape instead of shard shape for sharded arrays.
+  ([#952](https://github.com/zarr-developers/VirtualiZarr/pull/952)).
+  By [Tom Nicholas](https://github.com/TomNicholas).
+
 ### Documentation
 
 ### Internal changes

--- a/virtualizarr/tests/test_writers/test_icechunk.py
+++ b/virtualizarr/tests/test_writers/test_icechunk.py
@@ -1004,7 +1004,11 @@ def test_write_empty_chunk(
 
 
 def test_sharded_array_roundtrip_icechunk(icechunk_repo, tmp_path):
-    """Test that a sharded Zarr V3 array preserves shard and chunk shapes through icechunk."""
+    """
+    Test that a sharded Zarr V3 array preserves shard and chunk shapes through icechunk.
+    
+    Regression test for https://github.com/zarr-developers/VirtualiZarr/issues/951.
+    """
     from obstore.store import LocalStore
     from obspec_utils.registry import ObjectStoreRegistry
 

--- a/virtualizarr/tests/test_writers/test_icechunk.py
+++ b/virtualizarr/tests/test_writers/test_icechunk.py
@@ -9,10 +9,9 @@ import pytest
 import xarray as xr
 import xarray.testing as xrt
 import zarr
-from zarr.core.metadata import ArrayV3Metadata
-
-from obstore.store import LocalStore
 from obspec_utils.registry import ObjectStoreRegistry
+from obstore.store import LocalStore
+from zarr.core.metadata import ArrayV3Metadata
 
 from virtualizarr import open_virtual_dataset
 from virtualizarr.manifests import ChunkManifest, ManifestArray
@@ -1011,7 +1010,7 @@ def test_write_empty_chunk(
 def test_sharded_array_roundtrip_icechunk(icechunk_repo, tmp_path):
     """
     Test that a sharded Zarr V3 array preserves shard and chunk shapes through icechunk.
-    
+
     Regression test for https://github.com/zarr-developers/VirtualiZarr/issues/951.
     """
     filepath = str(tmp_path / "test_sharded.zarr")

--- a/virtualizarr/tests/test_writers/test_icechunk.py
+++ b/virtualizarr/tests/test_writers/test_icechunk.py
@@ -1001,3 +1001,50 @@ def test_write_empty_chunk(
     expected_values = np.full(shape=(5,), fill_value=10, dtype=np.dtype("int32"))
     expected = xr.Variable(data=expected_values, dims=["x"])
     xrt.assert_identical(roundtrip["a"].variable, expected)
+
+
+def test_sharded_array_roundtrip_icechunk(icechunk_repo, tmp_path):
+    """Test that a sharded Zarr V3 array preserves shard and chunk shapes through icechunk."""
+    from obstore.store import LocalStore
+    from obspec_utils.registry import ObjectStoreRegistry
+
+    from virtualizarr import open_virtual_dataset
+    from virtualizarr.parsers.zarr import ZarrParser
+
+    filepath = str(tmp_path / "test_sharded.zarr")
+
+    # Create a sharded zarr store
+    data = np.arange(12 * 12, dtype="float32").reshape(12, 12)
+    ds = xr.Dataset({"data": (("x", "y"), data)})
+    ds.to_zarr(
+        filepath,
+        encoding={"data": {"chunks": (3, 3), "shards": (6, 6)}},
+        consolidated=False,
+        zarr_format=3,
+    )
+
+    # Verify original shapes
+    original_arr = zarr.open_array(filepath + "/data", mode="r")
+    assert original_arr.shards == (6, 6)
+    assert original_arr.chunks == (3, 3)
+
+    # Virtualize with ZarrParser
+    store = LocalStore(prefix=filepath)
+    registry = ObjectStoreRegistry({f"file://{filepath}": store})
+    parser = ZarrParser()
+    vds = open_virtual_dataset(url=filepath, registry=registry, parser=parser)
+
+    # Write to icechunk
+    session = icechunk_repo.writable_session("main")
+    vds.vz.to_icechunk(session.store, validate_containers=False)
+    session.commit("test")
+
+    # Read back from icechunk and verify shapes are preserved
+    ro_session = icechunk_repo.readonly_session("main")
+    ic_arr = zarr.open_array(ro_session.store, path="data", mode="r")
+    assert ic_arr.shards == (6, 6), f"Expected shard shape (6,6), got {ic_arr.shards}"
+    assert ic_arr.chunks == (3, 3), f"Expected chunk shape (3,3), got {ic_arr.chunks}"
+
+    # Verify data values match
+    ic_ds = xr.open_zarr(ro_session.store, zarr_format=3, consolidated=False)
+    npt.assert_array_equal(ic_ds["data"].values, data)

--- a/virtualizarr/tests/test_writers/test_icechunk.py
+++ b/virtualizarr/tests/test_writers/test_icechunk.py
@@ -11,7 +11,12 @@ import xarray.testing as xrt
 import zarr
 from zarr.core.metadata import ArrayV3Metadata
 
+from obstore.store import LocalStore
+from obspec_utils.registry import ObjectStoreRegistry
+
+from virtualizarr import open_virtual_dataset
 from virtualizarr.manifests import ChunkManifest, ManifestArray
+from virtualizarr.parsers.zarr import ZarrParser
 from virtualizarr.tests.utils import PYTEST_TMP_DIRECTORY_URL_PREFIX
 
 icechunk = pytest.importorskip("icechunk")
@@ -1009,12 +1014,6 @@ def test_sharded_array_roundtrip_icechunk(icechunk_repo, tmp_path):
     
     Regression test for https://github.com/zarr-developers/VirtualiZarr/issues/951.
     """
-    from obstore.store import LocalStore
-    from obspec_utils.registry import ObjectStoreRegistry
-
-    from virtualizarr import open_virtual_dataset
-    from virtualizarr.parsers.zarr import ZarrParser
-
     filepath = str(tmp_path / "test_sharded.zarr")
 
     # Create a sharded zarr store

--- a/virtualizarr/writers/icechunk.py
+++ b/virtualizarr/writers/icechunk.py
@@ -581,14 +581,6 @@ def write_manifest_virtual_refs(
         for grid_index, entry in manifest.iter_refs()
     ]
 
-    print(f"  write_manifest_virtual_refs: arr_name={arr_name}, num_specs={len(virtual_chunk_spec_list)}")
-    if arr_name == "embeddings":
-        target = [0, 0, 48, 97]
-        match = [s for s in virtual_chunk_spec_list if s.index == target]
-        print(f"  chunk [0,0,48,97]: found={len(match)}")
-        if match:
-            print(f"  location={match[0].location!r}, offset={match[0].offset}, length={match[0].length}")
-
     store.set_virtual_refs(
         array_path=key_prefix,
         chunks=virtual_chunk_spec_list,

--- a/virtualizarr/writers/icechunk.py
+++ b/virtualizarr/writers/icechunk.py
@@ -443,8 +443,6 @@ def write_virtual_variable_to_icechunk(
     last_updated_at: Optional[datetime] = None,
 ) -> None:
     """Write a single virtual variable into an icechunk store"""
-    from zarr import Array
-
     from virtualizarr.codecs import extract_codecs
 
     ma = cast(ManifestArray, var.data)
@@ -513,12 +511,12 @@ def write_virtual_variable_to_icechunk(
             chunk_offsets.append(start // chunk_size)
     else:
         chunk_offsets = [0 for _ in dims]
-        # TODO: Should codecs be an argument to zarr's AsyncrGroup.create_array?
-        filters, serializer, compressors = extract_codecs(metadata.codecs)
+        filters, serializer, compressors = extract_codecs(metadata.inner_codecs)
         arr = group.require_array(
             name=name,
             shape=metadata.shape,
-            chunks=metadata.chunk_grid.chunk_shape,
+            chunks=metadata.chunks,
+            shards=metadata.shards,
             dtype=metadata.data_type.to_native_dtype(),
             filters=filters,
             compressors=compressors,

--- a/virtualizarr/writers/icechunk.py
+++ b/virtualizarr/writers/icechunk.py
@@ -518,7 +518,7 @@ def write_virtual_variable_to_icechunk(
         arr = group.require_array(
             name=name,
             shape=metadata.shape,
-            chunks=metadata.chunks,
+            chunks=metadata.chunk_grid.chunk_shape,
             dtype=metadata.data_type.to_native_dtype(),
             filters=filters,
             compressors=compressors,
@@ -580,6 +580,14 @@ def write_manifest_virtual_refs(
         )
         for grid_index, entry in manifest.iter_refs()
     ]
+
+    print(f"  write_manifest_virtual_refs: arr_name={arr_name}, num_specs={len(virtual_chunk_spec_list)}")
+    if arr_name == "embeddings":
+        target = [0, 0, 48, 97]
+        match = [s for s in virtual_chunk_spec_list if s.index == target]
+        print(f"  chunk [0,0,48,97]: found={len(match)}")
+        if match:
+            print(f"  location={match[0].location!r}, offset={match[0].offset}, length={match[0].length}")
 
     store.set_virtual_refs(
         array_path=key_prefix,

--- a/virtualizarr/writers/icechunk.py
+++ b/virtualizarr/writers/icechunk.py
@@ -7,7 +7,7 @@ from xarray.backends.zarr import ZarrStore as XarrayZarrStore
 from xarray.backends.zarr import encode_zarr_attr_value
 from zarr import Array, Group
 
-from virtualizarr.codecs import get_codecs, extract_codecs
+from virtualizarr.codecs import extract_codecs, get_codecs
 from virtualizarr.manifests import ChunkManifest, ManifestArray
 from virtualizarr.manifests.utils import (
     check_compatible_encodings,

--- a/virtualizarr/writers/icechunk.py
+++ b/virtualizarr/writers/icechunk.py
@@ -7,7 +7,7 @@ from xarray.backends.zarr import ZarrStore as XarrayZarrStore
 from xarray.backends.zarr import encode_zarr_attr_value
 from zarr import Array, Group
 
-from virtualizarr.codecs import get_codecs
+from virtualizarr.codecs import get_codecs, extract_codecs
 from virtualizarr.manifests import ChunkManifest, ManifestArray
 from virtualizarr.manifests.utils import (
     check_compatible_encodings,
@@ -443,7 +443,6 @@ def write_virtual_variable_to_icechunk(
     last_updated_at: Optional[datetime] = None,
 ) -> None:
     """Write a single virtual variable into an icechunk store"""
-    from virtualizarr.codecs import extract_codecs
 
     ma = cast(ManifestArray, var.data)
     metadata = ma.metadata


### PR DESCRIPTION
## Summary
- Fixes the icechunk writer using `metadata.chunks` (inner chunk shape) instead of `metadata.chunk_grid.chunk_shape` (shard shape) when creating arrays, causing sharded arrays to lose their shard configuration
- Adds a regression test that creates a sharded zarr store, virtualizes it, writes to icechunk, and verifies both shard and chunk shapes are preserved

Closes #951

## Test plan
- [x] New test `test_sharded_array_roundtrip_icechunk` passes
- [x] Existing icechunk writer tests unaffected (pre-existing `test_write_loadable_variable` failure is unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)