### PR TITLE
fix: V3 ZarrParser scalar variable behavior

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -11,6 +11,9 @@
 ### Breaking changes
 
 ### Bug fixes
+- Fixes Zarr V3 Scalar Bug.
+  ([#956](https://github.com/zarr-developers/VirtualiZarr/pull/956)).
+  By [Raphael Hagen](https://github.com/norlandrhagen)
 
 ### Documentation
 

--- a/virtualizarr/manifests/array.py
+++ b/virtualizarr/manifests/array.py
@@ -280,6 +280,8 @@ class ManifestArray:
         # The xarray data model stores dimension names and arbitrary extra metadata outside of the wrapped array class,
         # so to avoid that information being duplicated we strip it from the ManifestArray before wrapping it.
         dims = self.metadata.dimension_names
+        if dims is None and self.metadata.shape == ():
+            dims = ()
         attrs = self.metadata.attributes
         stripped_metadata = utils.copy_and_replace_metadata(
             self.metadata, new_dimension_names=None, new_attributes={}

--- a/virtualizarr/manifests/array.py
+++ b/virtualizarr/manifests/array.py
@@ -280,8 +280,6 @@ class ManifestArray:
         # The xarray data model stores dimension names and arbitrary extra metadata outside of the wrapped array class,
         # so to avoid that information being duplicated we strip it from the ManifestArray before wrapping it.
         dims = self.metadata.dimension_names
-        if dims is None and self.metadata.shape == ():
-            dims = ()
         attrs = self.metadata.attributes
         stripped_metadata = utils.copy_and_replace_metadata(
             self.metadata, new_dimension_names=None, new_attributes={}

--- a/virtualizarr/parsers/zarr.py
+++ b/virtualizarr/parsers/zarr.py
@@ -303,9 +303,9 @@ def metadata_as_v3(metadata: ArrayV3Metadata | ArrayV2Metadata) -> ArrayV3Metada
     else:
         v3_dict = metadata.to_dict()
 
-    # For V3 scalar arrays, dimension_names is null per spec but xarray requires an
-    # iterable. Normalize to [] so it round-trips as () after from_dict, matching
-    # what the V2 path produces via _ARRAY_DIMENSIONS: [].
+    # For V3 scalar arrays, dimension_names is null, which causes a `TypeError`:
+    # `TypeError: 'NoneType' object is not iterable`
+    # This normalizes it to match Zarr V2 scalar behavior.
     if v3_dict.get("dimension_names") is None and v3_dict.get("shape") == ():
         v3_dict["dimension_names"] = []
 

--- a/virtualizarr/parsers/zarr.py
+++ b/virtualizarr/parsers/zarr.py
@@ -303,6 +303,12 @@ def metadata_as_v3(metadata: ArrayV3Metadata | ArrayV2Metadata) -> ArrayV3Metada
     else:
         v3_dict = metadata.to_dict()
 
+    # For V3 scalar arrays, dimension_names is null per spec but xarray requires an
+    # iterable. Normalize to [] so it round-trips as () after from_dict, matching
+    # what the V2 path produces via _ARRAY_DIMENSIONS: [].
+    if v3_dict.get("dimension_names") is None and v3_dict.get("shape") == ():
+        v3_dict["dimension_names"] = []
+
     # Normalize chunk_key_encoding to DefaultChunkKeyEncoding with "." separator.
     # The ManifestStore expects dot-separated keys (e.g. "0.0.0"), so we enforce
     # this regardless of what the on-disk store uses.

--- a/virtualizarr/tests/test_parsers/test_zarr.py
+++ b/virtualizarr/tests/test_parsers/test_zarr.py
@@ -254,6 +254,15 @@ def test_v2_metadata_with_scalar_dimensions():
     assert metadata.dimension_names == ()
 
 
+def test_v3_metadata_with_scalar_dimensions():
+    """Test that V3 scalar arrays get dimension_names normalized from None to ()."""
+    store = zarr.storage.MemoryStore()
+    zarr.create(shape=(), chunks=(), dtype="int64", store=store, zarr_format=3)
+
+    metadata = metadata_as_v3(zarr.open(store, mode="r").metadata)
+    assert metadata.dimension_names == ()
+
+
 def test_v3_metadata_separator_normalized():
     """Test that metadata_as_v3 normalizes V3 chunk_key_encoding separator to '.'."""
     store = zarr.storage.MemoryStore()
@@ -410,15 +419,6 @@ def test_parser_scalar_roundtrip_matches_xarray(tmpdir, zarr_format):
             manifeststore, engine="zarr", consolidated=False, zarr_format=3
         ) as actual:
             xr.testing.assert_identical(actual, expected)
-
-    # Also test the open_virtual_dataset path
-    vds = open_virtual_dataset(
-        url=filepath,
-        parser=parser,
-        registry=registry,
-    )
-    assert vds["data"].dims == ()
-    assert vds["data"].shape == ()
 
 
 def test_run_async_without_running_loop():

--- a/virtualizarr/tests/test_parsers/test_zarr.py
+++ b/virtualizarr/tests/test_parsers/test_zarr.py
@@ -411,6 +411,15 @@ def test_parser_scalar_roundtrip_matches_xarray(tmpdir, zarr_format):
         ) as actual:
             xr.testing.assert_identical(actual, expected)
 
+    # Also test the open_virtual_dataset path
+    vds = open_virtual_dataset(
+        url=filepath,
+        parser=parser,
+        registry=registry,
+    )
+    assert vds["data"].dims == ()
+    assert vds["data"].shape == ()
+
 
 def test_run_async_without_running_loop():
     """Test _run_async works normally when no event loop is running."""


### PR DESCRIPTION
# What I did
Updates the `ZarrParser` to so that V3 scalar datasets don't break. 

Acceptance criteria:
<!-- Feel free to remove check-list items that aren't relevant to your change -->

- [x] Closes [#895](https://github.com/zarr-developers/VirtualiZarr/issues/895)
- [x] Tests passing
- [x] No test coverage regression
- [x] Full type hint coverage
- [x] Changes are documented in `docs/releases.md`

