### PR TITLE
Fix mypy error in FITSParser for optional reader_options

### DIFF
--- a/virtualizarr/parsers/fits.py
+++ b/virtualizarr/parsers/fits.py
@@ -31,7 +31,7 @@ class FITSParser:
 
         self.group = group
         self.skip_variables = skip_variables
-        self.reader_options = reader_options
+        self.reader_options = reader_options or {}
 
     def __call__(
         self,


### PR DESCRIPTION
## Summary
- `FITSParser.__init__` accepts `reader_options: Optional[dict] = None`, but line 60 uses `**self.reader_options` which mypy flags as `arg-type` since the value could be `None`
- Default to `{}` on assignment, consistent with `NetCDF3Parser` (line 33)

## Test plan
- [x] `mypy virtualizarr` passes without this error