### PR TITLE
Fix flaky region test dimension ordering

### DIFF
--- a/virtualizarr/tests/test_writers/test_icechunk.py
+++ b/virtualizarr/tests/test_writers/test_icechunk.py
@@ -845,11 +845,9 @@ class TestRegion:
                 zarr_format=3,
             ) as ds,
         ):
-            is_written = ds["y"].isin(my_vds["y"]).broadcast_like(ds)
-            xrt.assert_allclose(
-                is_written,
-                ds["foo"] != 0,
-            )
+            actual = ds["foo"] != 0
+            expected = ds["y"].isin(my_vds["y"]).broadcast_like(actual).transpose(*actual.dims)
+            xrt.assert_allclose(expected, actual)
 
     def test_write_region_auto_without_dimension(
         self,

--- a/virtualizarr/tests/test_writers/test_icechunk.py
+++ b/virtualizarr/tests/test_writers/test_icechunk.py
@@ -846,7 +846,9 @@ class TestRegion:
             ) as ds,
         ):
             actual = ds["foo"] != 0
-            expected = ds["y"].isin(my_vds["y"]).broadcast_like(actual).transpose(*actual.dims)
+            expected = (
+                ds["y"].isin(my_vds["y"]).broadcast_like(actual).transpose(*actual.dims)
+            )
             xrt.assert_allclose(expected, actual)
 
     def test_write_region_auto_without_dimension(


### PR DESCRIPTION
Proper fix for #928 (hopefully)

## Summary
- `test_write_region_writes_whole_unspecified_dim` intermittently fails in `minimum-versions` CI with transposed arrays
- The written data is correct — the issue is that `broadcast_like(ds)` (broadcasting a 1D coordinate against a **Dataset**) can return dimensions in a different order than `ds["foo"]`
- Fix: broadcast against the actual DataArray being compared and explicitly transpose to match its dims

Closes #928

## Test plan
- [x] Test passes locally
- [ ] Verify `minimum-versions` CI job passes