### PR TITLE
perf: use set_virtual_refs_arr for faster icechunk writes

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -17,7 +17,7 @@
 ### Internal changes
 
 - Use `set_virtual_refs_arr` for ~3x faster virtual ref writing to icechunk.
-  Requires icechunk >= 2.0.2.
+  Requires icechunk >= 2.0.3.
   ([#967](https://github.com/zarr-developers/VirtualiZarr/pull/967)).
   By [Tom Nicholas](https://github.com/TomNicholas).
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -12,6 +12,11 @@
 
 ### Internal changes
 
+- Use `set_virtual_refs_arr` for ~3x faster virtual ref writing to icechunk.
+  Requires icechunk >= 2.0.2.
+  ([#967](https://github.com/zarr-developers/VirtualiZarr/pull/967)).
+  By [Tom Nicholas](https://github.com/TomNicholas).
+
 ## v2.5.1 (9th April 2026)
 
 Adds support for sharded Zarr V3 arrays, and includes several other bug fixes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ all_parsers = [
 
 # writers
 icechunk = [
-    "icechunk>=2.0.2",
+    "icechunk>=2.0.3",
 ]
 
 
@@ -188,7 +188,7 @@ numpy = "==2.1.0"
 numcodecs = "==0.15.1"
 zarr = "==3.1.0"
 obstore = "==0.7.0"
-icechunk = "==2.0.2"
+icechunk = "==2.0.3"
 
 # Define commands to run within the test environments
 [tool.pixi.feature.test.tasks]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ all_parsers = [
 
 # writers
 icechunk = [
-    "icechunk>=1.1.2",
+    "icechunk>=2.0.2",
 ]
 
 
@@ -193,7 +193,7 @@ numpy = "==2.1.0"
 numcodecs = "==0.15.1"
 zarr = "==3.1.0"
 obstore = "==0.7.0"
-icechunk = "==1.1.2"
+icechunk = "==2.0.2"
 
 # Define commands to run within the test environments
 [tool.pixi.feature.test.tasks]

--- a/virtualizarr/writers/icechunk.py
+++ b/virtualizarr/writers/icechunk.py
@@ -560,14 +560,14 @@ def write_manifest_virtual_refs(
         last_updated_at = datetime.now(timezone.utc) + timedelta(seconds=1)
 
     # Pass manifest arrays directly to Rust, avoiding per-chunk Python object creation.
-    # Requires icechunk with set_virtual_refs_arr (earth-mover/icechunk#2049).
+    # Empty paths represent missing chunks and are skipped on the Rust side.
     store.set_virtual_refs_arr(
         array_path=key_prefix,
         chunk_grid_shape=manifest.shape_chunk_grid,
         locations=manifest._paths.flatten().tolist(),
         offsets=manifest._offsets.flatten(),
         lengths=manifest._lengths.flatten(),
-        validate_containers=False,  # we already validated these before setting any refs
+        validate_containers=False,
         arr_offset=list(chunk_index_offsets) if any(chunk_index_offsets) else None,
         checksum=last_updated_at,
     )

--- a/virtualizarr/writers/icechunk.py
+++ b/virtualizarr/writers/icechunk.py
@@ -568,6 +568,6 @@ def write_manifest_virtual_refs(
         offsets=manifest._offsets.flatten(),
         lengths=manifest._lengths.flatten(),
         validate_containers=False,
-        arr_offset=list(chunk_index_offsets) if any(chunk_index_offsets) else None,
+        arr_offset=chunk_index_offsets if any(chunk_index_offsets) else None,
         checksum=last_updated_at,
     )

--- a/virtualizarr/writers/icechunk.py
+++ b/virtualizarr/writers/icechunk.py
@@ -545,17 +545,11 @@ def write_manifest_virtual_refs(
     last_updated_at: Optional[datetime] = None,
 ) -> None:
     """Write all the virtual references for one array manifest at once."""
-    from icechunk import VirtualChunkSpec
 
     if group.name == "/":
         key_prefix = arr_name
     else:
         key_prefix = f"{group.name}/{arr_name}"
-
-    # loop over every reference in the ChunkManifest for that array
-    # TODO inefficient: this should be replaced with something that sets all (new) references for the array at once
-    # but Icechunk need to expose a suitable API first
-    # See https://github.com/earth-mover/icechunk/issues/401 for performance benchmark
 
     if last_updated_at is None:
         # Icechunk rounds timestamps to the nearest second, but filesystems have higher precision,
@@ -565,21 +559,15 @@ def write_manifest_virtual_refs(
         # In practice this should only really come up in synthetic examples, e.g. tests and docs.
         last_updated_at = datetime.now(timezone.utc) + timedelta(seconds=1)
 
-    virtual_chunk_spec_list = [
-        VirtualChunkSpec(
-            index=[
-                index + offset for index, offset in zip(grid_index, chunk_index_offsets)
-            ],
-            location=entry["path"],
-            offset=entry["offset"],
-            length=entry["length"],
-            last_updated_at_checksum=last_updated_at,
-        )
-        for grid_index, entry in manifest.iter_refs()
-    ]
-
-    store.set_virtual_refs(
+    # Pass manifest arrays directly to Rust, avoiding per-chunk Python object creation.
+    # Requires icechunk with set_virtual_refs_arr (earth-mover/icechunk#2049).
+    store.set_virtual_refs_arr(
         array_path=key_prefix,
-        chunks=virtual_chunk_spec_list,
+        chunk_grid_shape=manifest.shape_chunk_grid,
+        locations=manifest._paths.flatten().tolist(),
+        offsets=manifest._offsets.flatten(),
+        lengths=manifest._lengths.flatten(),
         validate_containers=False,  # we already validated these before setting any refs
+        arr_offset=list(chunk_index_offsets) if any(chunk_index_offsets) else None,
+        checksum=last_updated_at,
     )


### PR DESCRIPTION
## Summary

- Replaces the Python loop that creates per-chunk `VirtualChunkSpec` objects with a single call to `store.set_virtual_refs_arr()`, passing the manifest's numpy arrays directly to Rust
- ~2.8x faster for writing virtual refs against object storage (12.4s → 4.5s for 6 vars × 520k chunks each against Arraylake)

Depends on earth-mover/icechunk#2049.