### PR TITLE
build!: drop Python 3.11 support, require Python >= 3.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [test-py311, test-py312, test-py313, test-py314, min-deps, minio]
+        environment: [test-py312, test-py313, test-py314, min-deps, minio]
     steps:
       - uses: actions/checkout@v4
       - uses: prefix-dev/setup-pixi@v0.9.3
@@ -71,11 +71,11 @@ jobs:
       - uses: prefix-dev/setup-pixi@v0.9.3
         with:
           pixi-version: v0.59.0
-          environments: test-py311
+          environments: test-py312
 
       - name: Running Flaky Tests
         run: |
-          pixi run -e test-py311 run-flaky-tests
+          pixi run -e test-py312 run-flaky-tests
 
   check-docs:
     name: check-docs

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -6,6 +6,10 @@
 
 ### Breaking changes
 
+- Dropped support for Python 3.11. Python 3.12+ is now required, matching icechunk 2.x.
+  ({pr}`968`).
+  By [Tom Nicholas](https://github.com/TomNicholas).
+
 ### Bug fixes
 
 ### Documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,12 +14,11 @@ classifiers = [
     "Topic :: Scientific/Engineering",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dynamic = ["version"]
 dependencies = [
     "xarray>=2025.06.0",  # first version compatible with zarr 3.1.x fill value dtype handling
@@ -157,10 +156,6 @@ platforms = ["linux-64", "osx-64", "osx-arm64"]
 [tool.pixi.pypi-dependencies]
 virtualizarr = { path = ".", editable = true }
 
-# Define a feature set for Python 3.11
-[tool.pixi.feature.py311.dependencies]
-python = "3.11.*"
-
 # Define a feature set for Python 3.12
 [tool.pixi.feature.py312.dependencies]
 python = "3.12.*"
@@ -213,12 +208,11 @@ run-flaky-tests = { cmd = "pytest -m flaky --run-flaky --run-network-tests --ver
 min-deps = ["dev", "test", "hdf", "hdf5-lib"] # VirtualiZarr/conftest.py using h5py, so the minimum set of dependencies for testing still includes hdf libs
 # Inherit from min-deps to get all the test commands, along with optional dependencies
 test = ["dev", "test", "remote", "hdf", "netcdf3", "fits", "icechunk", "kerchunk", "kerchunk_parquet", "hdf5-lib", "zarr", "py314"]
-test-py311 = ["dev", "test", "remote", "hdf", "netcdf3", "fits", "icechunk", "kerchunk", "kerchunk_parquet", "hdf5-lib", "tiff", "zarr","py311"] # test against python 3.11
 test-py312 = ["dev", "test", "remote", "hdf", "netcdf3", "fits", "icechunk", "kerchunk", "kerchunk_parquet", "hdf5-lib", "tiff", "zarr", "py312"] # test against python 3.13
 test-py313 = ["dev", "test", "remote", "hdf", "netcdf3", "fits", "icechunk", "kerchunk", "kerchunk_parquet", "hdf5-lib", "tiff", "zarr", "py313"] # test against python 3.13
 test-py314 = ["dev", "test", "remote", "hdf", "netcdf3", "fits", "icechunk", "kerchunk", "kerchunk_parquet", "hdf5-lib", "zarr", "py314"] # test against python 3.14
 minio = ["dev", "remote", "hdf", "netcdf3", "fits", "icechunk", "kerchunk", "hdf5-lib", "py314", "zarr", "minio"]
-minimum-versions = ["dev", "test", "remote", "hdf", "netcdf3", "fits", "icechunk", "kerchunk", "kerchunk_parquet", "hdf5-lib", "tiff", "zarr","minimum-versions", "py311"]
+minimum-versions = ["dev", "test", "remote", "hdf", "netcdf3", "fits", "icechunk", "kerchunk", "kerchunk_parquet", "hdf5-lib", "tiff", "zarr","minimum-versions", "py312"]
 upstream = ["dev", "test", "hdf", "hdf5-lib", "netcdf3", "upstream", "icechunk-dev", "zarr", "py313"]
 all = ["dev", "test", "remote", "hdf", "netcdf3", "fits", "icechunk", "kerchunk", "kerchunk_parquet", "hdf5-lib", "tiff", "zarr", "all_parsers", "all_writers", "py313"]
 docs = ["docs", "dev", "remote", "hdf", "netcdf3", "fits", "icechunk", "kerchunk", "kerchunk_parquet", "hdf5-lib", "tiff","zarr", "py313"]


### PR DESCRIPTION
## Summary

- Drop Python 3.11 support, require Python >= 3.12
- icechunk 2.x requires Python 3.12+, so VirtualiZarr must match
- Removes py311 pixi feature, test-py311 CI environment
- Updates minimum-versions env to use py312