### PR TITLE
docs: release notes for v2.6.0

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,23 +1,31 @@
 # Release notes
 
-## v2.5.2 (unreleased)
+## v2.6.0 (16th April 2026)
+
+Now requires icechunk 2.x, enabling a ~3x performance improvement for writing virtual references. Also drops support for Python 3.11.
 
 ### New Features
 
 ### Breaking changes
 
+- Now requires icechunk >= 2.0.3.
+  ([#967](https://github.com/zarr-developers/VirtualiZarr/pull/967)).
+  By [Tom Nicholas](https://github.com/TomNicholas).
 - Dropped support for Python 3.11. Python 3.12+ is now required, matching icechunk 2.x.
-  ({pr}`968`).
+  ([#969](https://github.com/zarr-developers/VirtualiZarr/pull/969)).
   By [Tom Nicholas](https://github.com/TomNicholas).
 
 ### Bug fixes
+
+- Fix scalar variable manifests getting shape `(1,)` instead of `()` from kerchunk references.
+  ([#965](https://github.com/zarr-developers/VirtualiZarr/pull/965)).
+  By [Tom Nicholas](https://github.com/TomNicholas).
 
 ### Documentation
 
 ### Internal changes
 
 - Use `set_virtual_refs_arr` for ~3x faster virtual ref writing to icechunk.
-  Requires icechunk >= 2.0.3.
   ([#967](https://github.com/zarr-developers/VirtualiZarr/pull/967)).
   By [Tom Nicholas](https://github.com/TomNicholas).
 


### PR DESCRIPTION
## Summary

Prepares release notes for **v2.6.0** (bumped from the previously templated v2.5.2, per EffVer — dropping Python 3.11 and requiring icechunk 2.x are both breaking changes that warrant a minor bump).

- Set release date to 16th April 2026 and add a top-line summary highlighting the icechunk 2.x requirement (which unlocks the ~3x virtual ref write perf improvement).
- Promote the icechunk >= 2.0.3 requirement from a note under Internal changes to its own Breaking change entry (#967).
- Add a missing Bug fix entry for #965 (scalar variable manifests from kerchunk refs).
- Fix incorrect PR reference `{pr}`968`` → `#969` for the Python 3.11 drop.

## Test plan

- [ ] Docs build renders new section correctly
- [ ] PR links resolve