### PR TITLE
fix: handle zero-length dimensions in HDFParser for zarr-python 3.2.0

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -8,6 +8,9 @@
 
 ### Bug fixes
 
+- Fix `HDFParser` failing on HDF5 datasets with a zero-length dimension under `zarr-python >= 3.2.0`, which forbids zero-length chunk dimensions. Chunk dimensions are now clamped to a minimum of 1 when falling back from dataset shape.
+  By [Tom Nicholas](https://github.com/TomNicholas).
+
 ### Documentation
 
 ### Internal changes

--- a/virtualizarr/parsers/hdf/hdf.py
+++ b/virtualizarr/parsers/hdf/hdf.py
@@ -56,7 +56,10 @@ def _construct_manifest_array(
     -------
     ManifestArray
     """
-    chunks = dataset.chunks or dataset.shape
+    # Clamp each dim to >= 1: zarr v3 allows shape=(0,) but forbids zero-length
+    # chunk dimensions (enforced by zarr-python >= 3.2.0). See
+    # https://github.com/zarr-developers/zarr-python/issues/3711.
+    chunks = dataset.chunks or tuple(max(s, 1) for s in dataset.shape)
     codecs = codecs_from_dataset(dataset)
     attrs = _extract_attrs(dataset)
     dtype = dataset.dtype


### PR DESCRIPTION
## Summary

- Zarr v3 allows `shape=(0,)` but forbids zero-length chunk dimensions, now enforced by zarr-python 3.2.0+ (see [zarr-developers/zarr-python#3711](https://github.com/zarr-developers/zarr-python/issues/3711)).
- `HDFParser` previously fell back to `dataset.shape` for the chunk shape when `dataset.chunks` was `None`, producing an invalid `chunk_shape=(0,)` for empty HDF5 datasets.
- Fix clamps each chunk dim to `>= 1`, so empty HDF5 datasets round-trip cleanly on both zarr 3.1.x and 3.2.0+.

Unblocks the `test_empty_dataset` failure noted in #957.

## Test plan

- [x] `test_empty_dataset` passes on zarr 3.1.6
- [x] `test_empty_dataset` passes on zarr `>=3.2.0` (verified that zarr accepts `shape=(0,), chunks=(1,)` on both dev and released builds; full upstream-zarr test run blocked until #957 lands and provides the `RegularChunkGridMetadata` import shim)
- [x] No regressions in `virtualizarr/tests/test_parsers/test_hdf/`