### PR TITLE
feat: write inlined ChunkManifest entries as kerchunk base64 inline refs

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
-- The kerchunk writer now serializes inlined `ChunkManifest` entries as kerchunk's `base64:`-prefixed inline form, rather than emitting broken `["__inlined__", 0, length]` triples. Together with the read-side support added in #979, this means a virtual dataset with inlined chunks can be round-tripped through `to_kerchunk(format="json")` and `KerchunkJSONParser` without losing data.
+- The kerchunk writer now serializes inlined `ChunkManifest` entries as kerchunk's `base64:`-prefixed inline form, rather than emitting broken `["__inlined__", 0, length]` triples. Together with the read-side support added in #979, this means a virtual dataset with inlined chunks can be round-tripped through both `to_kerchunk(format="json"/"parquet")` and the corresponding `KerchunkJSONParser`/`KerchunkParquetParser`.
   By [Tom Nicholas](https://github.com/TomNicholas).
 
 - `ChunkManifest` can now hold inlined chunks — raw chunk bytes carried directly in memory rather than as references to external files. Intended for parser authors (e.g., loading Kerchunk references with inlined data); not exposed via `loadable_variables`.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -4,6 +4,9 @@
 
 ### New Features
 
+- The kerchunk writer now serializes inlined `ChunkManifest` entries as kerchunk's `base64:`-prefixed inline form, rather than emitting broken `["__inlined__", 0, length]` triples. Together with the read-side support added in #979, this means a virtual dataset with inlined chunks can be round-tripped through `to_kerchunk(format="json")` and `KerchunkJSONParser` without losing data.
+  By [Tom Nicholas](https://github.com/TomNicholas).
+
 - `ChunkManifest` can now hold inlined chunks — raw chunk bytes carried directly in memory rather than as references to external files. Intended for parser authors (e.g., loading Kerchunk references with inlined data); not exposed via `loadable_variables`.
   ([#938](https://github.com/zarr-developers/VirtualiZarr/pull/938)).
   By [Max Jones](https://github.com/maxrjones) and [Tom Nicholas](https://github.com/TomNicholas).

--- a/virtualizarr/tests/test_writers/test_kerchunk.py
+++ b/virtualizarr/tests/test_writers/test_kerchunk.py
@@ -2,10 +2,13 @@ import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
+from obspec_utils.registry import ObjectStoreRegistry
+from obstore.store import LocalStore
 from xarray import Dataset
 from zarr.core.metadata.v2 import ArrayV2Metadata
 
 from virtualizarr.manifests import ChunkManifest, ManifestArray
+from virtualizarr.parsers import KerchunkJSONParser
 from virtualizarr.tests import requires_fastparquet, requires_kerchunk
 from virtualizarr.utils import convert_v3_to_v2_metadata, kerchunk_refs_as_json
 
@@ -186,11 +189,6 @@ class TestAccessor:
     def test_write_inlined_chunks_roundtrip(self, tmp_path, array_v3_metadata):
         # Write a manifest containing inlined chunks to JSON, then re-parse it
         # with KerchunkJSONParser; the inlined bytes should survive the round trip.
-        from obspec_utils.registry import ObjectStoreRegistry
-        from obstore.store import LocalStore
-
-        from virtualizarr.parsers import KerchunkJSONParser
-
         inlined = b"\x01\x02\x03\x04\x05\x06\x07\x08"
         manifest = ChunkManifest(
             entries={

--- a/virtualizarr/tests/test_writers/test_kerchunk.py
+++ b/virtualizarr/tests/test_writers/test_kerchunk.py
@@ -150,6 +150,79 @@ class TestAccessor:
             expected_ds_refs
         )
 
+    def test_write_inlined_chunks_to_dict(self, array_v3_metadata):
+        # ManifestArray with mixed inlined+virtual chunks should serialize the
+        # inlined positions as `base64:<b64>` strings and the virtual ones as
+        # `[path, offset, length]` triples.
+        manifest = ChunkManifest(
+            entries={
+                "0.0": {
+                    "path": "",
+                    "offset": 0,
+                    "length": 8,
+                    "data": b"\x01\x02\x03\x04\x05\x06\x07\x08",
+                },
+                "0.1": {"path": "file:///foo.nc", "offset": 100, "length": 8},
+            }
+        )
+        arr = ManifestArray(
+            chunkmanifest=manifest,
+            metadata=array_v3_metadata(
+                shape=(1, 2),
+                data_type=np.dtype("<i4"),
+                chunks=(1, 1),
+                codecs=[],
+                fill_value=None,
+            ),
+        )
+        ds = Dataset({"a": (["x", "y"], arr)})
+
+        result = ds.vz.to_kerchunk(format="dict")
+        refs = result["refs"]
+        assert refs["a/0.0"] == "base64:AQIDBAUGBwg="
+        assert refs["a/0.1"] == ["/foo.nc", 100, 8]
+
+    @requires_kerchunk
+    def test_write_inlined_chunks_roundtrip(self, tmp_path, array_v3_metadata):
+        # Write a manifest containing inlined chunks to JSON, then re-parse it
+        # with KerchunkJSONParser; the inlined bytes should survive the round trip.
+        from obspec_utils.registry import ObjectStoreRegistry
+        from obstore.store import LocalStore
+
+        from virtualizarr.parsers import KerchunkJSONParser
+
+        inlined = b"\x01\x02\x03\x04\x05\x06\x07\x08"
+        manifest = ChunkManifest(
+            entries={
+                "0.0": {"path": "", "offset": 0, "length": 8, "data": inlined},
+                "0.1": {"path": "file:///foo.nc", "offset": 100, "length": 8},
+            }
+        )
+        arr = ManifestArray(
+            chunkmanifest=manifest,
+            metadata=array_v3_metadata(
+                shape=(1, 2),
+                data_type=np.dtype("<i4"),
+                chunks=(1, 1),
+                codecs=[],
+                fill_value=None,
+            ),
+        )
+        ds = Dataset({"a": (["x", "y"], arr)})
+
+        filepath = tmp_path / "refs.json"
+        ds.vz.to_kerchunk(filepath, format="json")
+
+        registry = ObjectStoreRegistry({"file://": LocalStore()})
+        manifeststore = KerchunkJSONParser()(f"file://{filepath}", registry=registry)
+        roundtripped = manifeststore._group._members["a"]
+        assert roundtripped.manifest._inlined == {(0, 0): inlined}
+        assert roundtripped.manifest.dict()["0.1"] == {
+            "path": "file:///foo.nc",
+            "offset": 100,
+            "length": 8,
+        }
+
     @requires_fastparquet
     def test_accessor_to_kerchunk_parquet(self, tmp_path, array_v3_metadata):
         import ujson

--- a/virtualizarr/tests/test_writers/test_kerchunk.py
+++ b/virtualizarr/tests/test_writers/test_kerchunk.py
@@ -8,7 +8,7 @@ from xarray import Dataset
 from zarr.core.metadata.v2 import ArrayV2Metadata
 
 from virtualizarr.manifests import ChunkManifest, ManifestArray
-from virtualizarr.parsers import KerchunkJSONParser
+from virtualizarr.parsers import KerchunkJSONParser, KerchunkParquetParser
 from virtualizarr.tests import requires_fastparquet, requires_kerchunk
 from virtualizarr.utils import convert_v3_to_v2_metadata, kerchunk_refs_as_json
 
@@ -213,6 +213,42 @@ class TestAccessor:
 
         registry = ObjectStoreRegistry({"file://": LocalStore()})
         manifeststore = KerchunkJSONParser()(f"file://{filepath}", registry=registry)
+        roundtripped = manifeststore._group._members["a"]
+        assert roundtripped.manifest._inlined == {(0, 0): inlined}
+        assert roundtripped.manifest.dict()["0.1"] == {
+            "path": "file:///foo.nc",
+            "offset": 100,
+            "length": 8,
+        }
+
+    @requires_kerchunk
+    @requires_fastparquet
+    def test_write_inlined_chunks_roundtrip_parquet(self, tmp_path, array_v3_metadata):
+        # As above but via the parquet serialization.
+        inlined = b"\x01\x02\x03\x04\x05\x06\x07\x08"
+        manifest = ChunkManifest(
+            entries={
+                "0.0": {"path": "", "offset": 0, "length": 8, "data": inlined},
+                "0.1": {"path": "file:///foo.nc", "offset": 100, "length": 8},
+            }
+        )
+        arr = ManifestArray(
+            chunkmanifest=manifest,
+            metadata=array_v3_metadata(
+                shape=(1, 2),
+                data_type=np.dtype("<i4"),
+                chunks=(1, 1),
+                codecs=[],
+                fill_value=None,
+            ),
+        )
+        ds = Dataset({"a": (["x", "y"], arr)})
+
+        filepath = tmp_path / "refs"
+        ds.vz.to_kerchunk(filepath, format="parquet")
+
+        registry = ObjectStoreRegistry({"file://": LocalStore()})
+        manifeststore = KerchunkParquetParser()(str(filepath), registry=registry)
         roundtripped = manifeststore._group._members["a"]
         assert roundtripped.manifest._inlined == {(0, 0): inlined}
         assert roundtripped.manifest.dict()["0.1"] == {

--- a/virtualizarr/writers/kerchunk.py
+++ b/virtualizarr/writers/kerchunk.py
@@ -116,14 +116,19 @@ def variable_to_kerchunk_arr_refs(var: Variable, var_name: str) -> KerchunkArrRe
     if isinstance(var.data, ManifestArray):
         marr = var.data
 
-        arr_refs: dict[str, str | list[str | int]] = {
-            str(chunk_key): [
-                remove_file_uri_prefix(entry["path"]),
-                entry["offset"],
-                entry["length"],
-            ]
-            for chunk_key, entry in marr.manifest.dict().items()
-        }
+        arr_refs: dict[str, str | list[str | int]] = {}
+        for chunk_key, entry in marr.manifest.dict().items():
+            if "data" in entry:
+                # Inlined chunk: emit as kerchunk's `base64:<b64>` form.
+                arr_refs[str(chunk_key)] = (
+                    b"base64:" + base64.b64encode(entry["data"])
+                ).decode("utf-8")
+            else:
+                arr_refs[str(chunk_key)] = [
+                    remove_file_uri_prefix(entry["path"]),
+                    entry["offset"],
+                    entry["length"],
+                ]
         array_v2_metadata = convert_v3_to_v2_metadata(marr.metadata)
         zattrs = {**var.attrs, **var.encoding}
     else:


### PR DESCRIPTION
## Summary

Teaches the kerchunk writer to serialize inlined `ChunkManifest` entries as kerchunk's `base64:<b64>` inline form. Without this, the writer iterates manifest entries and emits `[path, offset, length]` triples for every chunk, which produces broken output for inlined chunks: the path becomes the `__inlined__` sentinel string and the actual bytes are silently dropped.

Combined with the read-side support added in #979, this PR makes the inlined-chunk round trip fully work for both JSON and parquet:

```python
ds.vz.to_kerchunk('refs.json', format='json')
ds_back = open_virtual_dataset('refs.json', filetype='kerchunk')  # bytes intact
```

The fix lives entirely in `variable_to_kerchunk_arr_refs`, so both `to_kerchunk(format="json")` and `to_kerchunk(format="parquet")` benefit from the single change (parquet builds the same refs dict before passing it to `kerchunk.df.refs_to_dataframe`).

This finally closes the original ask in #489.

## Test plan

- [x] Direct dict-output assertion: a manifest with one inlined + one virtual chunk produces `"a/0.0": "base64:AQIDBAUGBwg="` and `"a/0.1": ["/foo.nc", 100, 8]`.
- [x] JSON round trip: write to a JSON file, re-parse with `KerchunkJSONParser`, assert `_inlined` and virtual entries are recovered exactly.
- [x] Parquet round trip: same, via `format="parquet"` and `KerchunkParquetParser`.

Closes #489