### PR TITLE
fix: preserve scheme delimiter when fs_root is a URI in KerchunkParser

### DIFF
--- a/virtualizarr/manifests/manifest.py
+++ b/virtualizarr/manifests/manifest.py
@@ -116,7 +116,7 @@ def convert_relative_path_to_absolute(path: PosixPath, fs_root: str) -> str:
 
     # remote URI root (s3://, gs://, https://, ...) — just concat
     if _is_uri(fs_root):
-        return fs_root.rstrip("/") + "/" + str(path)
+        return fs_root.removesuffix("/") + "/" + str(path)
 
     # local posix root
     _fs_root = PosixPath(fs_root)

--- a/virtualizarr/tests/test_parsers/test_kerchunk.py
+++ b/virtualizarr/tests/test_parsers/test_kerchunk.py
@@ -290,10 +290,20 @@ def test_handle_relative_paths(refs_file_factory, local_registry):
         }
 
 
-def test_relative_path_to_absolute_cloud_url(refs_file_factory, local_registry):
+@pytest.mark.parametrize(
+    "fs_root, expected_path",
+    [
+        ("s3://some_bucket/", "s3://some_bucket/test1.nc"),
+        ("s3://some_bucket", "s3://some_bucket/test1.nc"),
+        ("s3://", "s3://test1.nc"),
+    ],
+)
+def test_relative_path_to_absolute_cloud_url(
+    refs_file_factory, local_registry, fs_root, expected_path
+):
     # regression test for https://github.com/zarr-developers/VirtualiZarr/issues/975
     refs_file = refs_file_factory(chunks={"a/0.0": ["test1.nc", 6144, 48]})
-    parser = KerchunkJSONParser(fs_root="s3://some_bucket/")
+    parser = KerchunkJSONParser(fs_root=fs_root)
     with open_virtual_dataset(
         url=refs_file,
         registry=local_registry,
@@ -302,7 +312,7 @@ def test_relative_path_to_absolute_cloud_url(refs_file_factory, local_registry):
         vda = vds["a"]
         assert vda.data.manifest.dict() == {
             "0.0": {
-                "path": "s3://some_bucket/test1.nc",
+                "path": expected_path,
                 "offset": 6144,
                 "length": 48,
             }


### PR DESCRIPTION
## Summary
- Follow-up to #976. `convert_relative_path_to_absolute` used `fs_root.rstrip("/")`, which strips *all* trailing slashes — so `fs_root="s3://"` collapsed to `"s3:"` and joined paths came out as `s3:/key` (single slash).
- Switch to `removesuffix("/")` so only a single trailing slash is dropped.
- Parametrize the existing cloud-URL regression test to also cover `fs_root="s3://"` (scheme-only) and `fs_root="s3://bucket"` (no trailing slash).

## Reproducer
```python
vds = vz.open_virtual_dataset(
    path,
    registry=registry,
    parser=KerchunkJSONParser(fs_root="s3://"),
)
# before: ValueError: Could not find an ObjectStore matching the url
#   s3:/noaa-oar-cefi-regional-mom6-pds/.../ALB.nep.full.hcast.monthly.raw.r20250912.199301-202506.nc
```

## Test plan
- [x] `uv run pytest virtualizarr/tests/test_parsers/test_kerchunk.py -k "test_relative_path_to_absolute_cloud_url or test_handle_relative_paths"` — 4 passed