### PR TITLE
chore: update typing for internal changes in Zarr-Python 3.2.0

### DIFF
--- a/virtualizarr/manifests/array.py
+++ b/virtualizarr/manifests/array.py
@@ -14,12 +14,8 @@ from virtualizarr.manifests.indexing import T_Indexer, index
 from virtualizarr.manifests.manifest import ChunkManifest
 from virtualizarr.manifests.utils import ChunkKeySeparator
 
-# Type-check against the min-deps name (RegularChunkGrid) while keeping a
-# runtime try/except so both zarr-python <=3.1.6 and >3.1.6 work. Version
-# sniffing is unreliable under hatch-vcs when installed from a git source
-# without fetched tags.
 if TYPE_CHECKING:
-    from zarr.core.metadata.v3 import RegularChunkGrid as RegularChunkGridMetadata
+    from zarr.core.metadata.v3 import RegularChunkGridMetadata
 else:
     try:
         from zarr.core.metadata.v3 import RegularChunkGridMetadata  # zarr-python>3.1.6

--- a/virtualizarr/parsers/zarr.py
+++ b/virtualizarr/parsers/zarr.py
@@ -28,12 +28,8 @@ from virtualizarr.manifests.manifest import (
 from virtualizarr.manifests.utils import ChunkKeySeparator
 from virtualizarr.utils import determine_chunk_grid_shape
 
-# Type-check against the min-deps name (RegularChunkGrid) while keeping a
-# runtime try/except so both zarr-python <=3.1.6 and >3.1.6 work. Version
-# sniffing is unreliable under hatch-vcs when installed from a git source
-# without fetched tags.
 if TYPE_CHECKING:
-    from zarr.core.metadata.v3 import RegularChunkGrid as RegularChunkGridMetadata
+    from zarr.core.metadata.v3 import RegularChunkGridMetadata
 else:
     try:
         from zarr.core.metadata.v3 import RegularChunkGridMetadata  # zarr-python>3.1.6


### PR DESCRIPTION
The mypy env now solves with Zarr-Python 3.2.0. This PR updates the TYPE_CHECKING block accordingly

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] No test coverage regression
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.md`
- [ ] New functions/methods are listed in an appropriate `*.md` file under `docs/api`
- [ ] New functionality has documentation
