### PR TITLE
fix: handle H5Dataset missing fillvalue attribute with dtype-based fallback

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,5 +1,11 @@
 # Release notes
 
+## Unreleased
+
+### Bug Fixes
+
+HDFParser now includes a `_get_fill_value` function which wraps `dataset.fillvalue` in a try/except AttributeError.
+
 ## v2.6.1 (3rd May 2026)
 
 Adds end-to-end support for inlined chunk references in `ChunkManifest` (read via Kerchunk parsers, write via Kerchunk and Icechunk writers), plus Zarr-Python 3.2.0 compatibility and several bug fixes.

--- a/virtualizarr/parsers/hdf/hdf.py
+++ b/virtualizarr/parsers/hdf/hdf.py
@@ -42,7 +42,7 @@ def _get_fill_value(dataset: H5Dataset):
     """
     try:
         raw = dataset.fillvalue
-    except AttributeError:
+    except RuntimeError:
         return np.ma.default_fill_value(dataset.dtype)
     if isinstance(raw, bytes):
         return raw.decode("utf-8", errors="replace")

--- a/virtualizarr/parsers/hdf/hdf.py
+++ b/virtualizarr/parsers/hdf/hdf.py
@@ -40,7 +40,10 @@ def _get_fill_value(dataset: H5Dataset):
     Extract the fill value from an h5py dataset, handling string/bytes dtypes
     that don't return numpy scalars from dataset.fillvalue.
     """
-    raw = dataset.fillvalue
+    try:
+        raw = dataset.fillvalue
+    except AttributeError:
+        return np.ma.default_fill_value(dataset.dtype)
     if isinstance(raw, bytes):
         return raw.decode("utf-8", errors="replace")
     elif isinstance(raw, str):

--- a/virtualizarr/tests/test_parsers/test_hdf/test_hdf.py
+++ b/virtualizarr/tests/test_parsers/test_hdf/test_hdf.py
@@ -242,17 +242,17 @@ def test_netcdf_over_https():
         np.testing.assert_allclose(ds["z"].max().to_numpy(), 817)
 
 
-def test_missing_fillvalue_attribute():
+def test_fillvalue_runtime_error():
     from virtualizarr.parsers.hdf.hdf import _get_fill_value
 
     dtype = np.dtype("float32")
 
-    class _NoFillValueDataset:
+    class _RuntimeErrorDataset:
         @property
         def fillvalue(self):
-            raise AttributeError("no fillvalue")
+            raise RuntimeError("Unable to get fill value")
 
-    dataset = _NoFillValueDataset()
+    dataset = _RuntimeErrorDataset()
     dataset.dtype = dtype  # type: ignore[attr-defined]
 
     result = _get_fill_value(dataset)

--- a/virtualizarr/tests/test_parsers/test_hdf/test_hdf.py
+++ b/virtualizarr/tests/test_parsers/test_hdf/test_hdf.py
@@ -240,3 +240,20 @@ def test_netcdf_over_https():
     ):
         np.testing.assert_allclose(ds["z"].min().to_numpy(), -6)
         np.testing.assert_allclose(ds["z"].max().to_numpy(), 817)
+
+
+def test_missing_fillvalue_attribute():
+    from virtualizarr.parsers.hdf.hdf import _get_fill_value
+
+    dtype = np.dtype("float32")
+
+    class _NoFillValueDataset:
+        @property
+        def fillvalue(self):
+            raise AttributeError("no fillvalue")
+
+    dataset = _NoFillValueDataset()
+    dataset.dtype = dtype  # type: ignore[attr-defined]
+
+    result = _get_fill_value(dataset)
+    assert result == np.ma.default_fill_value(dtype)


### PR DESCRIPTION
This PR handles H5Dataset missing fillvalue attribute with dtype-based fallback

Some `h5py.Dataset` objects do not expose a fillvalue attribute. This PR guards against `AttributeError` in `_get_fill_value` and fall back to `np.ma.default_fill_value` for the dataset's dtype. Adds a unit test covering this path.

# What I did

I discovered this issue when trying to use HDFParser with a GPM IMERG HH HDF5 file

##Acceptance criteria:

- ~Closes #xxx~ -- There are at least 24 open issues related to fill value and I don't know if this applies to any of them
- [x] Tests added
- [x] Tests passing
- [x] No test coverage regression
- [x] Full type hint coverage
- [x] Changes are documented in `docs/releases.md`
- ~New functions/methods are listed in an appropriate `*.md` file under `docs/api`~ n/a
- ~New functionality has documentation~ n/a

NB: I can open this as a separate PR to main, I just thought it fit in will with the new `_get_fill_value` created in this PR.