### PR TITLE
fix: also require kerchunk for test_read_netcdf3

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -13,6 +13,9 @@
 
 ### Internal changes
 
+- Mark `test_read_netcdf3` as also requiring `kerchunk`. It already had `@requires_scipy`, but `NetCDF3Parser` lazily imports `kerchunk.netCDF3`, so the test raised `ModuleNotFoundError` in any environment with scipy but not kerchunk (e.g. pixi `min-deps` once a transitive dep started pulling in scipy).
+  By [Tom Nicholas](https://github.com/TomNicholas).
+
 ## v2.6.1 (3rd May 2026)
 
 Adds end-to-end support for inlined chunk references in `ChunkManifest` (read via Kerchunk parsers, write via Kerchunk and Icechunk writers), plus Zarr-Python 3.2.0 compatibility and several bug fixes.

--- a/virtualizarr/tests/test_parsers/test_netcdf3.py
+++ b/virtualizarr/tests/test_parsers/test_netcdf3.py
@@ -8,6 +8,7 @@ from virtualizarr.tests import requires_kerchunk, requires_network, requires_sci
 from virtualizarr.tests.utils import obstore_http
 
 
+@requires_kerchunk
 @requires_scipy
 def test_read_netcdf3(netcdf3_file, array_v3_metadata, local_registry):
     filepath = str(netcdf3_file)


### PR DESCRIPTION
## Summary
- `test_read_netcdf3` only had `@requires_scipy`, but `NetCDF3Parser.__call__` lazily imports `kerchunk.netCDF3`. In any environment that has scipy without kerchunk, the test raised `ModuleNotFoundError` instead of being skipped. Surfaced by the `min-deps-build` job on #902 once a transitive dep started pulling in scipy there. Adds `@requires_kerchunk`.

## Test plan
- [ ] CI `min-deps-build` passes (scipy installed, kerchunk not — test should now skip).
- [ ] CI full test envs still run the test (both scipy and kerchunk present).