### PR TITLE
docs(parsers): align all parser docstrings with IcechunkParser

### DIFF
--- a/docs/api/parsers/kerchunk.md
+++ b/docs/api/parsers/kerchunk.md
@@ -1,4 +1,4 @@
-# Kerchunk References
+# Kerchunk
 
 ::: virtualizarr.parsers.KerchunkJSONParser
 ::: virtualizarr.parsers.KerchunkParquetParser

--- a/virtualizarr/parsers/dmrpp.py
+++ b/virtualizarr/parsers/dmrpp.py
@@ -21,22 +21,21 @@ from virtualizarr.types import ChunkKey
 
 
 class DMRPPParser:
+    """Create a [ManifestStore][virtualizarr.manifests.ManifestStore] from a DMR++ file.
+
+    Parameters
+    ----------
+    group
+        The group within the file to be used as the Zarr root group for the ManifestStore.
+    skip_variables
+        Variables in the file that will be ignored when creating the ManifestStore.
+    """
+
     def __init__(
         self,
         group: str | None = None,
         skip_variables: Iterable[str] | None = None,
     ):
-        """
-        Instantiate a parser with parser-specific parameters that can be used in the __call__ method.
-
-        Parameters
-        ----------
-        group
-            The group within the file to be used as the Zarr root group for the ManifestStore.
-        skip_variables
-            Variables in the file that will be ignored when creating the ManifestStore.
-        """
-
         self.group = group
         self.skip_variables = skip_variables
 
@@ -46,7 +45,7 @@ class DMRPPParser:
         registry: ObjectStoreRegistry,
     ) -> ManifestStore:
         """
-        Parse the metadata and byte offsets from a given DMR++ file to product a
+        Parse the metadata and byte offsets from a given DMR++ file to produce a
         VirtualiZarr ManifestStore.
 
         Parameters

--- a/virtualizarr/parsers/fits.py
+++ b/virtualizarr/parsers/fits.py
@@ -9,26 +9,24 @@ from virtualizarr.types.kerchunk import KerchunkStoreRefs
 
 
 class FITSParser:
+    """Create a [ManifestStore][virtualizarr.manifests.ManifestStore] from a FITS file.
+
+    Parameters
+    ----------
+    group
+        The group within the file to be used as the Zarr root group for the ManifestStore.
+    skip_variables
+        Variables in the file that will be ignored when creating the ManifestStore.
+    reader_options
+        Configuration options used internally for kerchunk's fsspec backend.
+    """
+
     def __init__(
         self,
         group: str | None = None,
         skip_variables: Iterable[str] | None = None,
         reader_options: Optional[dict] = None,
     ):
-        """
-        Instantiate a parser with parser-specific parameters that can be used in the
-        `__call__` method.
-
-        Parameters
-        ----------
-        group
-            The group within the file to be used as the Zarr root group for the ManifestStore.
-        skip_variables
-            Variables in the file that will be ignored when creating the ManifestStore.
-        reader_options
-            Configuration options used internally for kerchunk's fsspec backend.
-        """
-
         self.group = group
         self.skip_variables = skip_variables
         self.reader_options = reader_options or {}

--- a/virtualizarr/parsers/hdf/hdf.py
+++ b/virtualizarr/parsers/hdf/hdf.py
@@ -141,29 +141,28 @@ def _construct_manifest_group(
 
 
 class HDFParser:
+    """Create a [ManifestStore][virtualizarr.manifests.ManifestStore] from an HDF5/NetCDF4 file.
+
+    Parameters
+    ----------
+    group
+        Name of the group within the HDF5 file to virtualize.
+    drop_variables
+        Variables in the file that will be ignored when creating the ManifestStore
+        (default: `None`, do not ignore any variables).
+    reader_factory
+        A callable that creates a file-like reader from a store and path.
+        Must return an object implementing the
+        [ReadableFile][obspec_utils.protocols.ReadableFile] protocol.
+        Default is [BlockStoreReader][obspec_utils.readers.BlockStoreReader].
+    """
+
     def __init__(
         self,
         group: str | None = None,
         drop_variables: Iterable[str] | None = None,
         reader_factory: ReaderFactory = BlockStoreReader,
     ):
-        """
-        Instantiate a parser that can be used to virtualize HDF5/NetCDF4 files using the
-        `__call__` method.
-
-        Parameters
-        ----------
-        group
-            Name of the group within the HDF5 file to virtualize.
-        drop_variables
-            Variables in the file that will be ignored when creating the ManifestStore
-            (default: `None`, do not ignore any variables).
-        reader_factory
-            A callable that creates a file-like reader from a store and path.
-            Must return an object implementing the
-            [ReadableFile][obspec_utils.protocols.ReadableFile] protocol.
-            Default is [BlockStoreReader][obspec_utils.readers.BlockStoreReader].
-        """
         self.group = group
         self.drop_variables = drop_variables
         self.reader_factory = reader_factory

--- a/virtualizarr/parsers/kerchunk/json.py
+++ b/virtualizarr/parsers/kerchunk/json.py
@@ -8,26 +8,24 @@ from virtualizarr.parsers.kerchunk.translator import manifestgroup_from_kerchunk
 
 
 class KerchunkJSONParser:
+    """Create a [ManifestStore][virtualizarr.manifests.ManifestStore] from a Kerchunk JSON references file.
+
+    Parameters
+    ----------
+    group
+        The group within the Kerchunk JSON to be used as the Zarr root group for the ManifestStore.
+    fs_root
+        The qualifier to be used for Kerchunk chunk references containing relative paths.
+    skip_variables
+        Variables in the Kerchunk JSON that will be ignored when creating the ManifestStore.
+    """
+
     def __init__(
         self,
         group: str | None = None,
         fs_root: str | None = None,
         skip_variables: Iterable[str] | None = None,
     ):
-        """
-        Instantiate a parser with parser-specific parameters that can be used in the
-        `__call__` method.
-
-        Parameters
-        ----------
-        group
-            The group within the Kerchunk JSON to be used as the Zarr root group for the ManifestStore.
-        fs_root
-            The qualifier to be used for Kerchunk chunk references containing relative paths.
-        skip_variables
-            Variables in the Kerchunk JSON that will be ignored when creating the ManifestStore.
-        """
-
         self.group = group
         self.fs_root = fs_root
         self.skip_variables = skip_variables

--- a/virtualizarr/parsers/kerchunk/parquet.py
+++ b/virtualizarr/parsers/kerchunk/parquet.py
@@ -27,6 +27,20 @@ if TYPE_CHECKING:
 
 
 class KerchunkParquetParser:
+    """Create a [ManifestStore][virtualizarr.manifests.ManifestStore] from a Kerchunk Parquet references directory.
+
+    Parameters
+    ----------
+    group
+        The group within the input Kerchunk Parquet references to be used as the Zarr root group for the ManifestStore.
+    fs_root
+        The qualifier to be used for chunk references containing relative paths.
+    skip_variables
+        Variables in the Kerchunk Parquet references that will be ignored when creating the ManifestStore.
+    reader_options
+        Configuration options used internally for the fsspec backend.
+    """
+
     def __init__(
         self,
         group: str | None = None,
@@ -34,22 +48,6 @@ class KerchunkParquetParser:
         skip_variables: Iterable[str] | None = None,
         reader_options: dict | None = None,
     ):
-        """
-        Instantiate a parser for virtualizing Kerchunk's Parquet references into a Virtual Zarr store
-        using the `__call__` method.
-
-        Parameters
-        ----------
-        group
-            The group within the input Kerchunk Parquet references to be used as the Zarr root group for the ManifestStore.
-        fs_root
-            The qualifier to be used for chunk references containing relative paths.
-        skip_variables
-            Variables in the Kerchunk Parquet references that will be ignored when creating the ManifestStore.
-        reader_options
-            Configuration options used internally for the fsspec backend.
-        """
-
         self.group = group
         self.fs_root = fs_root
         self.skip_variables = skip_variables
@@ -61,7 +59,7 @@ class KerchunkParquetParser:
         registry: ObjectStoreRegistry,
     ) -> ManifestStore:
         """
-        Parse the metadata and byte offsets from a given Kerchunk Parquet directory to product a
+        Parse the metadata and byte offsets from a given Kerchunk Parquet directory to produce a
         VirtualiZarr ManifestStore.
 
         Parameters

--- a/virtualizarr/parsers/netcdf3.py
+++ b/virtualizarr/parsers/netcdf3.py
@@ -8,26 +8,24 @@ from virtualizarr.parsers.kerchunk.translator import manifestgroup_from_kerchunk
 
 
 class NetCDF3Parser:
+    """Create a [ManifestStore][virtualizarr.manifests.ManifestStore] from a NetCDF3 file.
+
+    Parameters
+    ----------
+    group
+        The group within the file to be used as the Zarr root group for the ManifestStore.
+    skip_variables
+        Variables in the file that will be ignored when creating the ManifestStore.
+    reader_options
+        Configuration options used internally for the kerchunk's fsspec backend.
+    """
+
     def __init__(
         self,
         group: str | None = None,
         skip_variables: Iterable[str] | None = None,
         reader_options: dict | None = None,
     ):
-        """
-        Instantiate a parser with parser-specific parameters that can be used in the
-        `__call__` method.
-
-        Parameters
-        ----------
-        group
-            The group within the file to be used as the Zarr root group for the ManifestStore.
-        skip_variables
-            Variables in the file that will be ignored when creating the ManifestStore.
-        reader_options
-            Configuration options used internally for the kerchunk's fsspec backend.
-        """
-
         self.group = group
         self.skip_variables = skip_variables
         self.reader_options = reader_options or {}
@@ -38,7 +36,7 @@ class NetCDF3Parser:
         registry: ObjectStoreRegistry,
     ) -> ManifestStore:
         """
-        Parse the metadata and byte offsets from a given NetCDF3 file to product a VirtualiZarr ManifestStore.
+        Parse the metadata and byte offsets from a given NetCDF3 file to produce a VirtualiZarr ManifestStore.
 
         Parameters
         ----------

--- a/virtualizarr/parsers/zarr.py
+++ b/virtualizarr/parsers/zarr.py
@@ -112,39 +112,22 @@ def join_url(base: str, key: str) -> str:
 
 
 class ZarrParser:
-    """
-    Parser for creating virtual references to existing Zarr stores.
+    """Create a [ManifestStore][virtualizarr.manifests.ManifestStore] from an existing Zarr store.
 
-    The ZarrParser creates lightweight virtual references to chunks in existing
-    Zarr stores without copying data. It supports both Zarr V2 and V3 formats,
-    automatically converting V2 metadata to V3 format.
+    Creates lightweight virtual references to chunks in an existing Zarr store
+    without copying data. Supports both Zarr V2 and V3 formats, automatically
+    converting V2 metadata to V3.
 
     Parameters
     ----------
-    group : str, optional
-        Path to a specific group within the Zarr store to use as the root.
-        Uses forward slashes for nested groups (e.g., "model/output").
-        Default is None, which uses the store's root group.
-    skip_variables : iterable of str, optional
-        Names of variables (arrays) to exclude when creating the virtual store.
-        Useful for filtering out auxiliary data or large variables that aren't
-        needed. Default is None, which includes all variables.
-
-    Attributes
-    ----------
-    group : str or None
-        The group path to use as root.
-    skip_variables : iterable of str or None
-        Variables to exclude from virtualization.
-
-    Methods
-    -------
-    __call__(url, registry)
-        Create a virtual representation of a Zarr store.
-
-    See Also
-    --------
-    virtualizarr.open_virtual_dataset : High-level function for opening virtual datasets.
+    group
+        Path to a specific group within the Zarr store to be used as the Zarr
+        root group for the ManifestStore. Uses forward slashes for nested
+        groups (e.g., "model/output"). Default is None, which uses the store's
+        root group.
+    skip_variables
+        Variables in the Zarr store that will be ignored when creating the
+        ManifestStore. Default is None, which includes all variables.
     """
 
     def __init__(
@@ -152,18 +135,6 @@ class ZarrParser:
         group: str | None = None,
         skip_variables: Iterable[str] | None = None,
     ):
-        """
-        Instantiate a parser with parser-specific parameters that can be used in the `__call__` method.
-
-        Parameters
-        ----------
-        group : str | None, optional (default: None)
-            The group within the original Zarr store to be used as the root group for
-            the ManifestStore (default: the Zarr store's root group).
-        skip_variables : Iterable[str] | None, optional (default: None)
-            Variables in the Zarr store that will be ignored when creating the
-            `ManifestStore` (default: None, do not ignore any variables).
-        """
         self.group = group
         self.skip_variables = skip_variables
 


### PR DESCRIPTION
## Summary
- Promote `KerchunkJSONParser`, `KerchunkParquetParser`, `DMRPPParser`, `FITSParser`, `NetCDF3Parser`, and `HDFParser` docstrings from `__init__` to the class level, with a `Create a ManifestStore from ...` opening line so the rendered API reference is consistent across parsers (matches `IcechunkParser`).
- Trim `ZarrParser`'s existing class docstring to the same shape and drop its now-redundant `__init__` docstring.
- Rename the docs page heading `Kerchunk References` → `Kerchunk`.
- Fix three `to product a` → `to produce a` typos in the Kerchunk Parquet, DMR++, and NetCDF3 parsers.

Docs-only / docstring-only change — no behavior change.

## Test plan
- [ ] `mkdocs serve` and confirm each parser page renders with the new class-level signatures.