### PR TITLE
Add ManifestArray.with_fill_value_only

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,5 +1,12 @@
 # Release notes
 
+## Unreleased
+
+### New Features
+
+- `ManifestArray.with_fill_value_only(fill_value)` — return a new `ManifestArray` with the same schema (shape, chunks, codecs, dimension names, attributes) as the original but with an empty chunk manifest and the given `fill_value`. Useful as a typed placeholder for a variable that is absent from one source but present in others.
+  By [Tom Nicholas](https://github.com/TomNicholas).
+
 ## v2.6.2 (18th May 2026)
 
 Adds an `IcechunkParser` for reading existing icechunk repositories as virtual datasets without copying data, chunk-aligned indexing on `ManifestArray` (so `xarray.Dataset.isel` works end-to-end on virtual datasets), and limited sub-chunk slicing for uncompressed arrays.

--- a/virtualizarr/manifests/array.py
+++ b/virtualizarr/manifests/array.py
@@ -1,3 +1,4 @@
+import dataclasses
 import warnings
 from typing import TYPE_CHECKING, Any, Callable, Union, cast
 
@@ -13,6 +14,7 @@ from virtualizarr.manifests.array_api import (
 from virtualizarr.manifests.indexing import T_Indexer, index
 from virtualizarr.manifests.manifest import ChunkManifest
 from virtualizarr.manifests.utils import ChunkKeySeparator
+from virtualizarr.utils import determine_chunk_grid_shape
 
 if TYPE_CHECKING:
     from zarr.core.metadata.v3 import RegularChunkGridMetadata
@@ -304,6 +306,32 @@ class ManifestArray:
         """
         renamed_manifest = self.manifest.rename_paths(new)
         return ManifestArray(metadata=self.metadata, chunkmanifest=renamed_manifest)
+
+    def with_fill_value_only(self, fill_value: Any) -> "ManifestArray":
+        """
+        Return a new ManifestArray with the same schema (shape, chunks, codecs,
+        dimension names, attributes) as this one, but with an empty chunk
+        manifest and the given ``fill_value``.
+
+        Reads from any chunk in the result return ``fill_value`` (see the Zarr V3
+        spec for missing-chunk semantics). This is useful as a typed placeholder
+        for a variable that is absent from one source but present in others — e.g.
+        concatenating with real data along a new axis without materializing chunks.
+
+        Parameters
+        ----------
+        fill_value
+            The scalar value to store on the metadata; every read from the
+            resulting array returns this value.
+        """
+        # dataclasses.replace bypasses the to_dict/from_dict roundtrip used in
+        # copy_and_replace_metadata, which can't accept raw NaN scalars (to_dict
+        # serializes NaN to the JSON string "NaN")
+        new_metadata = dataclasses.replace(self.metadata, fill_value=fill_value)
+        empty_manifest = ChunkManifest(
+            entries={}, shape=determine_chunk_grid_shape(self.shape, self.chunks)
+        )
+        return ManifestArray(metadata=new_metadata, chunkmanifest=empty_manifest)
 
     def to_virtual_variable(self) -> xr.Variable:
         """

--- a/virtualizarr/manifests/array_api.py
+++ b/virtualizarr/manifests/array_api.py
@@ -316,6 +316,8 @@ def full_like(
     Returns a numpy array instead of a ManifestArray.
 
     Only implemented to get past some checks deep inside xarray, see https://github.com/zarr-developers/VirtualiZarr/issues/29.
+    For creating a ManifestArray placeholder backed entirely by a fill_value, use
+    :meth:`ManifestArray.fill_value_placeholder` instead.
     """
     return np.full(
         shape=x.shape,

--- a/virtualizarr/tests/test_manifests/test_array.py
+++ b/virtualizarr/tests/test_manifests/test_array.py
@@ -707,6 +707,86 @@ class TestStackInlined:
         assert result.manifest._inlined[(1, 0)] is payload
 
 
+class TestWithFillValueOnly:
+    def test_returns_manifest_array_with_empty_manifest(self, array_v3_metadata):
+        # with_fill_value_only produces a ManifestArray with the same schema
+        # (shape, chunks, codecs) but an empty manifest — reads from any chunk
+        # will return fill_value
+        shape = (5, 2, 20)
+        chunks = (5, 1, 10)
+        codecs = [ARRAYBYTES_CODEC, ZLIB_CODEC]
+        metadata = array_v3_metadata(
+            shape=shape, chunks=chunks, data_type=np.dtype("float32"), codecs=codecs
+        )
+        marr = ManifestArray(
+            metadata=metadata,
+            chunkmanifest=ChunkManifest(
+                entries={
+                    "0.0.0": {"path": "/foo.nc", "offset": 0, "length": 100},
+                    "0.1.1": {"path": "/foo.nc", "offset": 100, "length": 100},
+                },
+            ),
+        )
+
+        result = marr.with_fill_value_only(np.float32("nan"))
+
+        assert isinstance(result, ManifestArray)
+        assert result.shape == shape
+        assert result.chunks == chunks
+        assert result.dtype == np.dtype("float32")
+        # manifest carries no entries — every chunk read will return fill_value
+        assert result.manifest.dict() == {}
+        # fill_value reflects the requested value
+        assert np.isnan(result.metadata.fill_value)
+        # metadata identical to input except for fill_value
+        input_md = marr.metadata.to_dict()
+        result_md = result.metadata.to_dict()
+        input_md.pop("fill_value")
+        result_md.pop("fill_value")
+        assert result_md == input_md
+
+    def test_non_nan_fill_value(self, array_v3_metadata):
+        metadata = array_v3_metadata(
+            shape=(4, 4), chunks=(2, 2), data_type=np.dtype("int32")
+        )
+        marr = ManifestArray(
+            metadata=metadata,
+            chunkmanifest=ChunkManifest(
+                entries={"0.0": {"path": "/foo.nc", "offset": 0, "length": 16}}
+            ),
+        )
+
+        result = marr.with_fill_value_only(7)
+
+        assert isinstance(result, ManifestArray)
+        assert result.metadata.fill_value == 7
+        assert result.manifest.dict() == {}
+
+    def test_preserves_existing_fill_value_when_passed(self, array_v3_metadata):
+        # the canonical "missing variable of known schema" use case: the
+        # placeholder should reuse the array's existing fill_value so its
+        # metadata is byte-identical to the source's
+        metadata = array_v3_metadata(
+            shape=(4, 4),
+            chunks=(2, 2),
+            data_type=np.dtype("float32"),
+            fill_value=np.float32("nan"),
+        )
+        marr = ManifestArray(
+            metadata=metadata,
+            chunkmanifest=ChunkManifest(
+                entries={"0.0": {"path": "/foo.nc", "offset": 0, "length": 16}}
+            ),
+        )
+
+        result = marr.with_fill_value_only(marr.metadata.fill_value)
+
+        # NaN != NaN breaks dataclass __eq__, so compare the serialized dicts
+        # where NaN becomes the JSON string "NaN"
+        assert result.metadata.to_dict() == marr.metadata.to_dict()
+        assert result.manifest.dict() == {}
+
+
 def test_refuse_combine(array_v3_metadata):
     # TODO test refusing to concatenate arrays that have conflicting shapes / chunk sizes
     chunks = (5, 1, 10)


### PR DESCRIPTION
## Summary

Adds a `ManifestArray.with_fill_value_only(fill_value)` instance method that returns a new `ManifestArray` with the same schema (shape, chunks, codecs, dimension names, attributes) as the source, but with an empty chunk manifest and the given `fill_value`. Every chunk in the result is "missing", so reads return `fill_value` (per the Zarr V3 missing-chunk semantics).

The motivating use case is creating a typed placeholder for a variable that is absent from one source but present in others — letting users substitute it in when combining heterogeneous datasets without materializing any chunks.

## Why not `xr.full_like`?

`xr.full_like(var, fill_value)` would be the natural API, but it's blocked upstream: xarray treats any duck array with a `.chunks` attribute as a chunked array (see `xarray.namedarray.pycompat.is_chunked_array`) and routes the call through `ChunkManager`, which fails before our `__array_function__` handler is reached. Unblocking it requires renaming `ChunkManager` → `ComputeManager` so `.chunks` no longer implies a parallel compute backend (pydata/xarray#9286).

Repurposing `np.full_like` directly is also off the table: xarray's internal `isnull` shortcut calls `np.full_like(int_array, dtype=bool, fill_value=False)` inside `array_equiv` and relies on the existing placeholder returning a numpy `ndarray`. So I went with a dedicated instance method instead. The existing `np.full_like` placeholder (numpy, see #29) is unchanged.

```python
placeholder = original_marr.with_fill_value_only(original_marr.metadata.fill_value)
```

## Notes

- `dataclasses.replace(metadata, fill_value=...)` is used instead of routing through `copy_and_replace_metadata`'s dict round-trip, because `ArrayV3Metadata.to_dict()` serializes NaN to the JSON string `"NaN"` which `from_dict` can't accept back as a raw scalar.
- One test compares metadata via `to_dict()` rather than direct `==` to work around zarr-developers/zarr-python#2929 (the dataclass-generated `__eq__` returns `False` when both metadata objects carry a NaN `fill_value`). That issue is marked closed but the bug still reproduces on zarr 3.2.1 — `closedByPullRequestsReferences` is empty, so it looks like it was closed without an actual fix landing. Worth reopening.

## Test plan

- [x] `np.full_like` placeholder still returns a numpy `ndarray` (existing behaviour preserved — `TestEquals::test_equals` etc. still pass)
- [x] `ManifestArray.with_fill_value_only(fill_value)` returns a `ManifestArray` with empty manifest and updated `fill_value` (`TestWithFillValueOnly`)
- [x] Metadata other than `fill_value` is preserved exactly (`test_returns_manifest_array_with_empty_manifest` compares `to_dict()` minus `fill_value`)
- [x] Passing the array's own `fill_value` round-trips metadata exactly — the canonical placeholder workflow (`test_preserves_existing_fill_value_when_passed`)
- [x] Full test suite: 516 passed, 27 skipped, 13 xfailed