### PR TITLE
feat(xarray): populate ds.encoding["source"] in open_virtual_dataset

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -6,6 +6,8 @@
 
 - `ManifestArray.with_fill_value_only(fill_value)` — return a new `ManifestArray` with the same schema (shape, chunks, codecs, dimension names, attributes) as the original but with an empty chunk manifest and the given `fill_value`. Useful as a typed placeholder for a variable that is absent from one source but present in others.
   By [Tom Nicholas](https://github.com/TomNicholas).
+- `open_virtual_dataset` and `open_virtual_datatree` now populate `ds.encoding["source"]` with the normalized source URI, mirroring [`xarray.open_dataset`][]'s behaviour. Parsers that have already set `encoding["source"]` are left untouched.
+  By [Tom Nicholas](https://github.com/TomNicholas).
 
 ## v2.6.2 (18th May 2026)
 

--- a/virtualizarr/tests/test_xarray.py
+++ b/virtualizarr/tests/test_xarray.py
@@ -540,6 +540,16 @@ class TestOpenVirtualDatasetAttrs:
                 "axis": "Y",
             }
 
+    def test_source_url_stored_in_encoding(self, netcdf4_file, local_registry):
+        # mirrors xarray.open_dataset behaviour of populating ds.encoding["source"]
+        parser = HDFParser()
+        with open_virtual_dataset(
+            url=netcdf4_file,
+            registry=local_registry,
+            parser=parser,
+        ) as vds:
+            assert vds.encoding["source"] == Path(netcdf4_file).as_uri()
+
 
 class TestDetermineCoords:
     def test_infer_one_dimensional_coords(self, netcdf4_file, local_registry):

--- a/virtualizarr/xarray.py
+++ b/virtualizarr/xarray.py
@@ -166,10 +166,16 @@ def open_virtual_datatree(
         registry=registry,
     )
 
-    return manifest_store.to_virtual_datatree(
+    vdt = manifest_store.to_virtual_datatree(
         loadable_variables=loadable_variables,
         decode_times=decode_times,
     )
+
+    # mirror xarray.open_datatree behaviour by recording the source url
+    if "source" not in vdt.encoding:
+        vdt.encoding["source"] = filepath
+
+    return vdt
 
 
 def open_virtual_dataset(
@@ -233,7 +239,13 @@ def open_virtual_dataset(
         loadable_variables=loadable_variables,
         decode_times=decode_times,
     )
-    return ds.drop_vars(list(drop_variables or ()))
+    ds = ds.drop_vars(list(drop_variables or ()))
+
+    # mirror xarray.open_dataset behaviour by recording the source url
+    if "source" not in ds.encoding:
+        ds.encoding["source"] = filepath
+
+    return ds
 
 
 def open_virtual_mfdataset(


### PR DESCRIPTION
## Summary

- `open_virtual_dataset` and `open_virtual_datatree` now set `ds.encoding["source"]` to the normalized source URI before returning, matching the behaviour of `xarray.open_dataset` / `xarray.open_datatree`.
- The assignment is guarded by `"source" not in <obj>.encoding` so parsers that have already populated the field are left untouched, mirroring xarray's [`_dataset_from_backend_dataset`](https://github.com/pydata/xarray/blob/main/xarray/backends/api.py) / `_datatree_from_backend_datatree`.
- The stored value is the URI returned by `validate_and_normalize_path_to_uri(url, ...)` (e.g. `file:///tmp/.../air.nc`, `s3://bucket/key`) — i.e. the same form that ends up in the manifests, not the raw user input.

## Test plan

- [x] New `test_source_url_stored_in_encoding` in `TestOpenVirtualDatasetAttrs` asserting `vds.encoding["source"] == Path(netcdf4_file).as_uri()`.
- [x] `uv run pytest virtualizarr/tests/test_xarray.py` — 60 passed, 3 skipped, 1 xfailed.