### PR TITLE
ci: exclude GOES-16 ingest notebook from lint hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     rev: v2.4.2
     hooks:
       - id: codespell
-        args: ["-L", "fo,ihs,kake,te", "-S", "fixture"]
+        args: ["-L", "fo,ihs,kake,te", "-S", "fixture,*goes-16-ingest.ipynb"]
   - repo: https://github.com/numpy/numpydoc
     rev: v1.10.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -266,9 +266,14 @@ line-length = 88
 indent-width = 4
 target-version = "py310"
 
+# force-exclude so the patterns below are honoured even when pre-commit
+# passes excluded files explicitly on the command line.
+force-exclude = true
 exclude = [
     "docs",
-    ".eggs"
+    ".eggs",
+    # Notebook ported verbatim from a blog post; not held to repo lint rules.
+    "examples/V2/goes-16-ingest.ipynb",
 ]
 
 [tool.ruff.lint]


### PR DESCRIPTION
Follow-up to #1012. The `examples/V2/goes-16-ingest.ipynb` notebook was ported verbatim from the [GOES-16 blog post](https://www.earthmover.io/blog/virtual-zarr) and trips the repo's lint hooks (F404/F821 in narrative cells, formatting, and a couple of codespell hits in prose). Rather than rewrite the author's notebook, exclude it from linting:

- **`pyproject.toml`** — add the notebook to `[tool.ruff] exclude` (covers both `ruff` lint and `ruff format`), and set `force-exclude = true` so the exclude is honoured when pre-commit passes the file explicitly.
- **`.pre-commit-config.yaml`** — add the notebook to codespell's `-S` skip list.

`pre-commit run --files examples/V2/goes-16-ingest.ipynb pyproject.toml .pre-commit-config.yaml` now passes.