### PR TITLE
Fix duplicate parametrization of zarr_store fixture under pytest>=9.1

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -66,7 +66,10 @@ def _xarray_subset():
     return ds.isel(time=slice(0, 10), lat=slice(0, 90), lon=slice(0, 180))
 
 
-@pytest.fixture(params=[2, 3])
+# params supplied indirectly by tests via the `zarr_versions` parametrize
+# decorator (see test_zarr.py); defining params here too would be a duplicate
+# parametrization, which pytest>=9.1 rejects.
+@pytest.fixture
 def zarr_store(tmpdir, request):
     ds = _xarray_subset()
     filepath = f"{tmpdir}/air.zarr"


### PR DESCRIPTION
## What

CI is broken on `main` (and all open PRs, e.g. #1017) because **pytest 9.1.0** — newly released and picked up by the conda `min-deps` environment — now raises a collection error:

```
test_zarr.py::TestOpenVirtualDatasetZarr::test_loadable_variables: duplicate parametrization of 'zarr_store'
```

## Why

The `zarr_store` parameter was parametrized twice:

1. The fixture in `conftest.py`: `@pytest.fixture(params=[2, 3])`
2. The `TestOpenVirtualDatasetZarr` class, which re-parametrizes the same argument indirectly via `@zarr_versions(param_name="zarr_store", indirect=True)` (this adds the `requires_v2_migration` mark and the `Zarr V2`/`Zarr V3` IDs).

Older pytest silently let the indirect parametrize override the fixture's own `params`. pytest 9.1.0 makes this a hard error. (Only `test_loadable_variables` is named because collection aborts at the first offending node — all four methods in the class were affected.)

## Fix

The indirect parametrize is the sole supplier of `request.param` (no test uses the fixture directly), so the fixture's own `params=[2, 3]` is redundant. Dropped it.

Verified:
- pytest 9.1.0: the class collects and all 8 tests pass, IDs preserved.
- pytest 9.0.3: full `test_zarr.py` still passes.