### PR TITLE
Speed up virtual chunk container validation with tuple startswith

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -31,6 +31,11 @@
   ([#1006](https://github.com/zarr-developers/VirtualiZarr/pull/1006)).
   By [Tom Nicholas](https://github.com/TomNicholas).
 
+### Internal changes
+
+- Speed up virtual chunk container validation when writing to Icechunk by passing the supported prefixes as a tuple to `str.startswith`, which runs the loop over prefixes in C rather than in a Python generator. The per-reference check is now ~2.6x faster in the common single-container case, which matters when writing manifests with millions of virtual references. The check is still a per-reference Python loop overall (see [icechunk#1167](https://github.com/earth-mover/icechunk/issues/1167) for pushing it down to Icechunk entirely).
+  By [Tom Nicholas](https://github.com/TomNicholas).
+
 ## v2.6.2 (18th May 2026)
 
 Adds an `IcechunkParser` for reading existing icechunk repositories as virtual datasets without copying data, chunk-aligned indexing on `ManifestArray` (so `xarray.Dataset.isel` works end-to-end on virtual datasets), and limited sub-chunk slicing for uncompressed arrays.

--- a/virtualizarr/writers/icechunk.py
+++ b/virtualizarr/writers/icechunk.py
@@ -274,15 +274,17 @@ def validate_virtual_chunk_containers(
         raise ValueError("No Virtual Chunk Containers set")
 
     # check all refs against existing virtual chunk containers
+    # passing a tuple to str.startswith runs the loop over prefixes in C
+    supported_prefixes_tuple = tuple(supported_prefixes)
     for marr in manifestarrays:
         # TODO this loop over every virtual reference is likely inefficient in python,
         # is there a way to push this down to Icechunk? (see https://github.com/earth-mover/icechunk/issues/1167)
         for ref in marr.manifest.iter_nonempty_paths():
-            validate_single_ref(ref, supported_prefixes)
+            validate_single_ref(ref, supported_prefixes_tuple)
 
 
-def validate_single_ref(ref: str, supported_prefixes: set[str]) -> None:
-    if not any(ref.startswith(prefix) for prefix in supported_prefixes):
+def validate_single_ref(ref: str, supported_prefixes: tuple[str, ...]) -> None:
+    if not ref.startswith(supported_prefixes):
         raise ValueError(
             f"No Virtual Chunk Container set which supports prefix of path {ref}"
         )


### PR DESCRIPTION
(This is just a micro-optimization)

## What

Speeds up `validate_virtual_chunk_containers` (called on every `vds.vz.to_icechunk()` write unless `validate_containers=False`) by passing the supported container prefixes as a **tuple** to `str.startswith`, instead of looping over them in a Python generator:

```python
# before
if not any(ref.startswith(prefix) for prefix in supported_prefixes):

# after
if not ref.startswith(supported_prefixes_tuple):
```

`str.startswith` natively accepts a tuple and runs the loop over prefixes in C, eliminating the per-reference generator construction, `any()` iteration, and per-prefix method dispatch.

## Why

This validation is a Python loop over **every virtual reference** in the dataset (see the existing TODO referencing [icechunk#1167](https://github.com/earth-mover/icechunk/issues/1167)). For manifests with millions of refs the per-reference cost is the bottleneck.

Benchmarked on the real `StringDType` paths array:

| refs | prefixes | before | after |
|------|----------|--------|-------|
| 10M  | 1        | ~2.26 s | ~0.87 s (**~2.6×**) |
| 10M  | 3        | ~2.6 s  | ~2.3 s |

The win is largest in the common single-container case; with more prefixes the actual string comparison work dominates, so it's closer to a wash (but never worse).

## What this is *not*

I also checked whether the loop could be pushed into C via numpy. It can't, today: `np.strings.startswith` / `slice` / `astype` on `StringDType` are **slower** than the Python loop (only the `==`/`!=` comparison ufuncs are optimized). The real order-of-magnitude fix remains pushing the check down into Icechunk/Rust per [icechunk#1167](https://github.com/earth-mover/icechunk/issues/1167); this PR is a cheap, low-risk interim win.

## Tests

Behavior and error messages are unchanged. Existing tests `test_validate_containers` and `test_raise_if_zero_chunk_containers` pass.
