### PR TITLE
build: bump minimum zarr to >=3.1.6

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -37,6 +37,8 @@
 
 ### Internal changes
 
+- Bump the minimum supported `zarr` to `>=3.1.6`. Earlier versions mis-strip keys when listing the contents of a nested group, silently dropping arrays whose names collide with others in the store ([zarr-python#3657](https://github.com/zarr-developers/zarr-python/issues/3657)); this would lose nested data when parsing hierarchical Zarr stores with the `ZarrParser`. The bug is fixed in zarr 3.1.6. The bump also lets the `tiff` and `grib` parsers (which required `zarr>=3.1.2` and `>=3.1.1` respectively) re-join the minimum-versions test environment.
+  By [Tom Nicholas](https://github.com/TomNicholas).
 - Factor the group-recursion logic shared by the `ZarrParser` and `IcechunkParser` into a single `construct_manifest_group_tree` helper in `virtualizarr.parsers.utils`, parameterized by a per-parser callback that builds a `ManifestArray` from an opened zarr array. Removes the duplicated open-group / filter / recurse / assemble code from both parsers.
   By [Tom Nicholas](https://github.com/TomNicholas).
 - Speed up virtual chunk container validation when writing to Icechunk by passing the supported prefixes as a tuple to `str.startswith`, which runs the loop over prefixes in C rather than in a Python generator. The per-reference check is now ~2.6x faster in the common single-container case, which matters when writing manifests with millions of virtual references. The check is still a per-reference Python loop overall (see [icechunk#1167](https://github.com/earth-mover/icechunk/issues/1167) for pushing it down to Icechunk entirely).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "numcodecs>=0.15.1",
     "ujson",
     "packaging",
-    "zarr>=3.1.0",
+    "zarr>=3.1.6",  # earlier versions mis-list nested group contents, silently dropping arrays (zarr-python#3657)
     "obstore>=0.7.0",
     "obspec_utils>=0.9.0",
 ]
@@ -192,7 +192,7 @@ install-upstream-overrides = { cmd = "pip install --upgrade --no-deps -r ci/upst
 xarray = "==2025.6.0"
 numpy = "==2.1.0"
 numcodecs = "==0.15.1"
-zarr = "==3.1.0"
+zarr = "==3.1.6"
 obstore = "==0.7.0"
 icechunk = "==2.0.3"
 
@@ -218,11 +218,7 @@ test-py312 = ["dev", "test", "remote", "hdf", "netcdf3", "fits", "icechunk", "ke
 test-py313 = ["dev", "test", "remote", "hdf", "netcdf3", "fits", "icechunk", "kerchunk", "kerchunk_parquet", "hdf5-lib", "tiff", "grib", "zarr", "py313"] # test against python 3.13
 test-py314 = ["dev", "test", "remote", "hdf", "netcdf3", "fits", "icechunk", "kerchunk", "kerchunk_parquet", "hdf5-lib", "zarr", "py314"] # test against python 3.14
 minio = ["dev", "remote", "hdf", "netcdf3", "fits", "icechunk", "kerchunk", "hdf5-lib", "py314", "zarr", "minio"]
-# tiff (virtual-tiff) is excluded: virtual-tiff 0.5.0 imports zarr's CodecJSON
-# (added in zarr 3.1.2) but only declares a bare `zarr` dependency, so it is
-# incompatible with our minimum pin of zarr==3.1.0.
-# NB grib is intentionally omitted: gribberish declares zarr>=3.1.1, but this env pins zarr==3.1.0.
-minimum-versions = ["dev", "test", "remote", "hdf", "netcdf3", "fits", "icechunk", "kerchunk", "kerchunk_parquet", "hdf5-lib", "zarr","minimum-versions", "py312"]
+minimum-versions = ["dev", "test", "remote", "hdf", "netcdf3", "fits", "tiff", "grib", "icechunk", "kerchunk", "kerchunk_parquet", "hdf5-lib", "zarr","minimum-versions", "py312"]
 upstream = ["dev", "test", "hdf", "hdf5-lib", "netcdf3", "icechunk-dev", "upstream-overlay", "zarr", "py313"]
 all = ["dev", "test", "remote", "hdf", "netcdf3", "fits", "icechunk", "kerchunk", "kerchunk_parquet", "hdf5-lib", "tiff", "grib", "zarr", "all_parsers", "all_writers", "py313"]
 docs = ["docs", "dev", "remote", "hdf", "netcdf3", "fits", "icechunk", "kerchunk", "kerchunk_parquet", "hdf5-lib", "tiff", "grib","zarr", "py313"]

--- a/virtualizarr/tests/test_parsers/test_zarr.py
+++ b/virtualizarr/tests/test_parsers/test_zarr.py
@@ -35,12 +35,6 @@ requires_v2_migration = pytest.mark.skipif(
     reason="V2→V3 metadata migration requires zarr>=3.1.3",
 )
 
-# zarr 3.1.0 cannot list group contents past one level deep (fixed in 3.1.1), so
-# parsing a store with multiple levels of nested groups silently drops the deepest
-# arrays there. The parser recursion itself is correct; this is a zarr listing bug.
-# TODO: remove once the minimum zarr is bumped to >=3.1.1.
-HAS_NESTED_GROUP_LISTING = version.parse(zarr.__version__) >= version.parse("3.1.1")
-
 
 async def _build_manifest(zarr_store: ObjectStore, store_base_uri: str):
     """Helper to open an array from a zarr store and build its chunk manifest."""
@@ -385,11 +379,6 @@ def test_parser_roundtrip_matches_xarray(tmpdir, zarr_format):
             xr.testing.assert_identical(actual, expected)
 
 
-@pytest.mark.xfail(
-    not HAS_NESTED_GROUP_LISTING,
-    reason="zarr 3.1.0 cannot list group contents past one level deep (fixed in 3.1.1)",
-    strict=False,
-)
 @zarr_versions()
 def test_parser_recurses_into_subgroups(tmpdir, zarr_format):
     """ZarrParser should virtualize arrays nested in subgroups, not just the root group.
@@ -399,6 +388,10 @@ def test_parser_recurses_into_subgroups(tmpdir, zarr_format):
     """
     filepath = f"{tmpdir}/hierarchical.zarr"
 
+    # Array names deliberately share the "var" substring across levels: zarr<3.1.6
+    # mis-strips keys when listing a nested group, silently dropping such arrays
+    # (zarr-developers/zarr-python#3657). The `zarr>=3.1.6` floor guards against it;
+    # these names would regress on an older zarr.
     dt = xr.DataTree.from_dict(
         {
             "/": xr.Dataset({"root_var": (("x",), np.arange(4, dtype="float32"))}),


### PR DESCRIPTION
Follow-up to #1023 (merged), fixing the CI failure its `xfail` was papering over.

## The real bug

`#1023` added `test_parser_recurses_into_subgroups` and marked it `xfail` on zarr < 3.1.1, on the theory that zarr 3.1.0 couldn't list nested groups. That was wrong. Investigating the min-versions CI failure showed the actual issue:

zarr **< 3.1.6** mis-strips keys when listing the contents of a nested group — e.g. an array stored at `group_a/nested/deep_var` is reported as a member named `var`, which isn't a real object, so it's silently dropped and `array_keys()` returns empty. It triggers when array names share substrings with others in the store (`root_var`/`a_var`/`deep_var`), the same class of bug as [zarr-python#3657](https://github.com/zarr-developers/zarr-python/issues/3657) that `test_parser_with_nested_store_path` already works around.

Verified across versions (array stored at `group_a/nested/deep_var`):

| zarr | `array_keys()` of `group_a/nested` |
|------|-------------------------------------|
| 3.1.0 – 3.1.5 | ❌ `[]` (array dropped) |
| 3.1.6+ | ✅ `['deep_var']` |

It is **not** version-of-zarr-specific in the depth sense, and it is **not** fixable by choosing tidy test names — real user data can have any names, so on any zarr 3.1.0–3.1.5 a hierarchical store with colliding names silently loses nested arrays. The honest fix is to require the zarr version that fixed it.

## This PR

- Bump `zarr>=3.1.0` → `zarr>=3.1.6` (and the `minimum-versions` pin to `==3.1.6`). 3.1.6 is the exact version that fixed the listing bug.
- Remove the unnecessary `xfail` (and `HAS_NESTED_GROUP_LISTING`) from `test_parser_recurses_into_subgroups`, keeping deliberately colliding array names so the test is a real regression guard. It passes at 3.1.6 and fails at 3.1.5 (confirmed locally).
- Re-include the `tiff` and `grib` parsers in the minimum-versions env — they were excluded only because they require `zarr>=3.1.2` / `>=3.1.1`, both satisfied by the new floor.

## CI watch

The minimum-versions job now resolves `virtual-tiff` and `gribberish` against zarr 3.1.6 — confirm that environment still solves cleanly. If either fails to resolve at the minimum pins, the fallback is to drop it back out with an accurate reason.