### PR TITLE
Add blank unreleased section after v2.7.0

### DIFF
--- a/docs/about/releases.md
+++ b/docs/about/releases.md
@@ -1,5 +1,17 @@
 # Release notes
 
+## v2.7.1 (unreleased)
+
+### New Features
+
+### Breaking changes
+
+### Bug fixes
+
+### Documentation
+
+### Internal changes
+
 ## v2.7.0 (25th June 2026)
 
 Adds a `GribberishParser` for reading GRIB1/GRIB2 files as virtual datasets, a `ManifestArray.with_fill_value_only` constructor, and populates `ds.encoding["source"]` to mirror `xarray.open_dataset`. `ManifestArray` no longer advertises a `.chunks` attribute (a breaking change), which fixes a whole class of cryptic errors when xarray tried to load, compute, or compare virtual arrays. Also fixes the `ZarrParser` and `IcechunkParser` silently dropping arrays nested in subgroups, and bumps the minimum supported `zarr` to `>=3.1.6`. Documentation gains a new ["Validation and Cleaning"](../how_to/validation.md) guide on handling the messy inconsistencies typical of real-world datasets during virtual ingestion, plus a new GOES-16 ingestion example.


### PR DESCRIPTION
Post-release housekeeping following the v2.7.0 release: adds a blank `v2.7.1 (unreleased)` section to the top of the release notes for the next development cycle.