### PR TITLE
Add `nrefs()` method to VirtualiZarrDatasetAccessor

### DIFF
--- a/docs/about/releases.md
+++ b/docs/about/releases.md
@@ -3,6 +3,7 @@
 ## v2.7.1 (unreleased)
 
 ### New Features
+- Added [VirtualiZarrDatasetAccessor.nrefs][virtualizarr.accessor.VirtualiZarrDatasetAccessor.nrefs] — a method that returns the total number of virtual chunk references in the dataset, ignoring non-virtual variables. Closes #573.
 
 ### Breaking changes
 

--- a/docs/api/virtualizarr.md
+++ b/docs/api/virtualizarr.md
@@ -16,6 +16,8 @@ Users can use xarray for every step apart from reading and serializing virtual r
 
 ::: virtualizarr.accessor.VirtualiZarrDatasetAccessor.nbytes
 
+::: virtualizarr.accessor.VirtualiZarrDatasetAccessor.nrefs
+
 ## Renaming paths
 
 ::: virtualizarr.accessor.VirtualiZarrDatasetAccessor.rename_paths

--- a/virtualizarr/accessor.py
+++ b/virtualizarr/accessor.py
@@ -285,7 +285,6 @@ class _VirtualiZarrDatasetAccessor:
             for var in self.ds.variables.values()
         )
 
-
     def nrefs(self) -> int:
         """Count the total number of virtual chunk references in the dataset.
 
@@ -306,6 +305,7 @@ class _VirtualiZarrDatasetAccessor:
             for var in self.ds.variables.values()
             if isinstance(var.data, ManifestArray)
         )
+
 
 @xr.register_dataset_accessor("vz")
 class VirtualiZarrDatasetAccessor(_VirtualiZarrDatasetAccessor):

--- a/virtualizarr/accessor.py
+++ b/virtualizarr/accessor.py
@@ -297,7 +297,7 @@ class _VirtualiZarrDatasetAccessor:
 
         Examples
         --------
-        >>> vds.vz.nrefs
+        >>> vds.vz.nrefs  # doctest: +SKIP
         42
         """
         return sum(

--- a/virtualizarr/accessor.py
+++ b/virtualizarr/accessor.py
@@ -286,6 +286,27 @@ class _VirtualiZarrDatasetAccessor:
         )
 
 
+    def nrefs(self) -> int:
+        """Count the total number of virtual chunk references in the dataset.
+
+        Ignores non-virtual variables (i.e. those not backed by a ManifestArray).
+
+        Returns
+        -------
+        int
+            Total number of virtual references across all virtual variables.
+
+        Examples
+        --------
+        >>> vds.vz.nrefs
+        42
+        """
+        return sum(
+            len(var.data.manifest)
+            for var in self.ds.variables.values()
+            if isinstance(var.data, ManifestArray)
+        )
+
 @xr.register_dataset_accessor("vz")
 class VirtualiZarrDatasetAccessor(_VirtualiZarrDatasetAccessor):
     pass

--- a/virtualizarr/accessor.py
+++ b/virtualizarr/accessor.py
@@ -297,7 +297,7 @@ class _VirtualiZarrDatasetAccessor:
 
         Examples
         --------
-        >>> vds.vz.nrefs  # doctest: +SKIP
+        >>> vds.vz.nrefs()  # doctest: +SKIP
         42
         """
         return sum(

--- a/virtualizarr/tests/test_xarray.py
+++ b/virtualizarr/tests/test_xarray.py
@@ -1174,14 +1174,14 @@ def test_nrefs(simple_netcdf4, local_registry):
         registry=local_registry,
         parser=parser,
     ) as vds:
-        # simple_netcdf4 has one virtual variable 'air' with a single chunk
+        # simple_netcdf4 has one virtual variable 'foo' with a single chunk
         assert vds.vz.nrefs == 1
 
     with open_virtual_dataset(
         url=simple_netcdf4,
         registry=local_registry,
         parser=parser,
-        loadable_variables=["air"],
+        loadable_variables=["foo"],
     ) as vds:
         # when the only variable is loadable (non-virtual), nrefs should be 0
         assert vds.vz.nrefs == 0

--- a/virtualizarr/tests/test_xarray.py
+++ b/virtualizarr/tests/test_xarray.py
@@ -1163,3 +1163,25 @@ class TestIsel:
 
         # every original chunk should have been visited exactly once
         assert sorted(seen_refs) == [0, 100, 200, 300]
+
+
+@requires_hdf5plugin
+@requires_imagecodecs
+def test_nrefs(simple_netcdf4, local_registry):
+    parser = HDFParser()
+    with open_virtual_dataset(
+        url=simple_netcdf4,
+        registry=local_registry,
+        parser=parser,
+    ) as vds:
+        # simple_netcdf4 has one virtual variable 'air' with a single chunk
+        assert vds.vz.nrefs == 1
+
+    with open_virtual_dataset(
+        url=simple_netcdf4,
+        registry=local_registry,
+        parser=parser,
+        loadable_variables=["air"],
+    ) as vds:
+        # when the only variable is loadable (non-virtual), nrefs should be 0
+        assert vds.vz.nrefs == 0

--- a/virtualizarr/tests/test_xarray.py
+++ b/virtualizarr/tests/test_xarray.py
@@ -1184,4 +1184,4 @@ def test_nrefs(simple_netcdf4, local_registry):
         loadable_variables=["foo"],
     ) as vds:
         # when the only variable is loadable (non-virtual), nrefs should be 0
-        assert vds.vz.nrefs == 0
+        assert vds.vz.nrefs() == 0

--- a/virtualizarr/tests/test_xarray.py
+++ b/virtualizarr/tests/test_xarray.py
@@ -1175,7 +1175,7 @@ def test_nrefs(simple_netcdf4, local_registry):
         parser=parser,
     ) as vds:
         # simple_netcdf4 has one virtual variable 'foo' with a single chunk
-        assert vds.vz.nrefs == 1
+        assert vds.vz.nrefs() == 1
 
     with open_virtual_dataset(
         url=simple_netcdf4,


### PR DESCRIPTION
# What I did

Adds a `nrefs()` method to `VirtualiZarrDatasetAccessor` that returns the total number of virtual chunk references in a dataset, ignoring non-virtual (loadable) variables. Useful for knowing how many references you're about to write to Icechunk or Kerchunk before actually doing it.

The implementation follows the same pattern as the existing `.nbytes` property.

Acceptance criteria:

- [x] Closes #573
- [x] Tests added
- [ ] Tests passing
- [ ] No test coverage regression
- [x] Full type hint coverage
- [x] Changes are documented in `docs/about/releases.md`
- [x] New functions/methods are listed in an appropriate `*.md` file under `docs/api`
- [x] New functionality has documentation