### PR TITLE
Add lazy reindexer that can operate on ManifestArrays

### DIFF
--- a/docs/about/releases.md
+++ b/docs/about/releases.md
@@ -4,6 +4,7 @@
 
 ### New Features
 - Added [VirtualiZarrDatasetAccessor.nrefs][virtualizarr.accessor.VirtualiZarrDatasetAccessor.nrefs] — a method that returns the total number of virtual chunk references in the dataset, ignoring non-virtual variables. Closes #573.
+- Added lazy `reindex` and `reindex_like` accessor methods ([VirtualiZarrDatasetAccessor.reindex][virtualizarr.accessor.VirtualiZarrDatasetAccessor.reindex], [VirtualiZarrDatasetAccessor.reindex_like][virtualizarr.accessor.VirtualiZarrDatasetAccessor.reindex_like]) — conform a virtual dataset to new coordinate labels without materializing data, padding absent positions with null-path manifest entries that read back as `fill_value`.
 
 ### Breaking changes
 

--- a/docs/api/virtualizarr.md
+++ b/docs/api/virtualizarr.md
@@ -18,6 +18,12 @@ Users can use xarray for every step apart from reading and serializing virtual r
 
 ::: virtualizarr.accessor.VirtualiZarrDatasetAccessor.nrefs
 
+## Alignment
+
+::: virtualizarr.accessor.VirtualiZarrDatasetAccessor.reindex
+
+::: virtualizarr.accessor.VirtualiZarrDatasetAccessor.reindex_like
+
 ## Renaming paths
 
 ::: virtualizarr.accessor.VirtualiZarrDatasetAccessor.rename_paths

--- a/virtualizarr/accessor.py
+++ b/virtualizarr/accessor.py
@@ -6,6 +6,7 @@ from functools import wraps
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
+    Any,
     Callable,
     Generator,
     Literal,
@@ -20,6 +21,55 @@ from virtualizarr.writers.kerchunk import dataset_to_kerchunk_refs
 
 if TYPE_CHECKING:
     from icechunk import IcechunkStore  # type: ignore[import-not-found]
+
+
+def _reindex_dataset_one_dim(ds: "xr.Dataset", dim: str, target) -> "xr.Dataset":
+    import numpy as np
+    import pandas as pd
+
+    from virtualizarr.manifests.reindex import chunk_index_map
+
+    if dim not in ds.indexes:
+        raise ValueError(
+            f"Cannot reindex dimension {dim!r}: it has no in-memory index. "
+            "Alignment needs real coordinate labels to compare; load the "
+            f"coordinate (e.g. via loadable_variables) before reindexing {dim!r}."
+        )
+
+    source_labels = ds.indexes[dim]
+    target_index = pd.Index(np.asarray(target))
+
+    # variables (data vars or coords) backed by a ManifestArray along this dim
+    virtual_names = [
+        name
+        for name, var in ds.variables.items()
+        if dim in var.dims and isinstance(var.data, ManifestArray)
+    ]
+
+    # record which virtual names are coordinates so we can restore their coord
+    # status after reassignment (assigning result[name] = xr.Variable(...) always
+    # produces a data variable, which would demote aux coords silently).
+    virtual_coord_names = [n for n in virtual_names if n in ds.coords]
+
+    # let xarray reindex everything else (loaded vars + the dim coordinate) — safe,
+    # no ManifestArrays involved — which also produces the new dim coordinate.
+    rest_reindexed = ds.drop_vars(virtual_names).reindex({dim: target_index})
+
+    result = rest_reindexed
+    for name in virtual_names:
+        var = ds[name].variable
+        axis = var.dims.index(dim)
+        chunk_size = var.data.metadata.chunks[axis]
+        cmap = chunk_index_map(source_labels, target_index, chunk_size)
+        new_data = var.data._reindex_axis(axis, cmap, new_size=len(target_index))
+        result[name] = xr.Variable(
+            var.dims, new_data, attrs=var.attrs, encoding=var.encoding
+        )
+
+    if virtual_coord_names:
+        result = result.set_coords(virtual_coord_names)
+
+    return result
 
 
 def warn_if_not_virtual(cls_name: Literal["Dataset", "DataTree"]):
@@ -305,6 +355,39 @@ class _VirtualiZarrDatasetAccessor:
             for var in self.ds.variables.values()
             if isinstance(var.data, ManifestArray)
         )
+
+    def reindex(self, indexers: Mapping[Any, Any] | None = None, **indexers_kwargs):
+        """
+        Conform this virtual dataset to a new set of coordinate labels, lazily.
+
+        Positions absent from the source are padded with null-path chunk entries
+        that read back as the array's ``fill_value`` — no data is materialized.
+        Only whole-chunk appends, inserts, and reorders are supported; a target
+        that would split a chunk raises ``NotImplementedError``.
+
+        Target labels must be comparable to the source index dtype; labels with
+        no match in the source become fill positions (null chunks), mirroring
+        xarray's ``Dataset.reindex`` behaviour.
+        """
+        from xarray.core.utils import either_dict_or_kwargs
+
+        indexers = either_dict_or_kwargs(indexers, indexers_kwargs, "reindex")
+        ds = self.ds
+        for dim, target in indexers.items():
+            ds = _reindex_dataset_one_dim(ds, dim, target)
+        return ds
+
+    def reindex_like(self, other: "xr.Dataset"):
+        """Conform this virtual dataset to the indexes of ``other`` (lazily).
+
+        Conforms by exact label match only; ``method`` and ``tolerance``
+        arguments (supported by xarray's ``reindex_like``) are not available
+        in v1 of this implementation.
+        """
+        indexers = {
+            dim: other.indexes[dim] for dim in other.indexes if dim in self.ds.dims
+        }
+        return self.reindex(indexers)
 
 
 @xr.register_dataset_accessor("vz")

--- a/virtualizarr/manifests/array.py
+++ b/virtualizarr/manifests/array.py
@@ -333,6 +333,71 @@ class ManifestArray:
         )
         return ManifestArray(metadata=new_metadata, chunkmanifest=empty_manifest)
 
+    def _reindex_axis(
+        self, axis: int, chunk_map: list[int | None], new_size: int
+    ) -> "ManifestArray":
+        """
+        Return a new ManifestArray with the chunk grid along ``axis`` remapped.
+
+        Each entry of ``chunk_map`` is the source chunk index to copy into that
+        target chunk slot, or ``None`` for a missing (null-path) chunk that reads
+        back as ``fill_value``. ``new_size`` is the new length of ``axis`` in
+        elements; the chunk size is unchanged.
+        """
+        from virtualizarr.manifests.manifest import (
+            MISSING_CHUNK_PATH,
+            ChunkManifest,
+        )
+        from virtualizarr.manifests.utils import copy_and_replace_metadata
+
+        manifest = self.manifest
+        src_paths = manifest._paths
+        src_offsets = manifest._offsets
+        src_lengths = manifest._lengths
+
+        new_grid_shape = list(src_paths.shape)
+        new_grid_shape[axis] = len(chunk_map)
+
+        new_paths = np.full(
+            new_grid_shape, MISSING_CHUNK_PATH, dtype=np.dtypes.StringDType()
+        )
+        new_offsets = np.zeros(new_grid_shape, dtype=np.uint64)
+        new_lengths = np.zeros(new_grid_shape, dtype=np.uint64)
+
+        new_inlined: dict[tuple[int, ...], bytes] = {}
+        for new_idx, src_chunk in enumerate(chunk_map):
+            if src_chunk is None:
+                continue  # leave this slab as missing/null
+            src_slice: list[Any] = [slice(None)] * src_paths.ndim
+            src_slice[axis] = src_chunk
+            dst_slice: list[Any] = [slice(None)] * src_paths.ndim
+            dst_slice[axis] = new_idx
+            new_paths[tuple(dst_slice)] = src_paths[tuple(src_slice)]
+            new_offsets[tuple(dst_slice)] = src_offsets[tuple(src_slice)]
+            new_lengths[tuple(dst_slice)] = src_lengths[tuple(src_slice)]
+            # re-key any inlined chunks that lived in this source slab
+            for key, data in manifest._inlined.items():
+                if key[axis] == src_chunk:
+                    shifted = list(key)
+                    shifted[axis] = new_idx
+                    new_inlined[tuple(shifted)] = data
+
+        new_manifest = ChunkManifest.from_arrays(
+            paths=new_paths,
+            offsets=new_offsets,
+            lengths=new_lengths,
+            validate_paths=False,
+            inlined=new_inlined if new_inlined else None,
+        )
+
+        new_shape = list(self.shape)
+        new_shape[axis] = new_size
+        new_metadata = copy_and_replace_metadata(
+            old_metadata=self.metadata, new_shape=new_shape
+        )
+
+        return ManifestArray(chunkmanifest=new_manifest, metadata=new_metadata)
+
     def to_virtual_variable(self) -> xr.Variable:
         """
         Create a "virtual" xarray.Variable containing the contents of one zarr array.

--- a/virtualizarr/manifests/reindex.py
+++ b/virtualizarr/manifests/reindex.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+_SPLIT_MSG = (
+    "Cannot reindex lazily: the requested target labels would require splitting "
+    "or sub-chunk reordering of a source chunk, which VirtualiZarr does not do "
+    "(it would require reading chunk bytes). Only whole-chunk appends, inserts, "
+    "and reorders are supported. See https://github.com/zarr-developers/VirtualiZarr/issues/51."
+)
+
+
+def chunk_index_map(
+    source_labels: Any,
+    target_labels: Any,
+    chunk_size: int,
+) -> list[int | None]:
+    """
+    Translate a label-space reindex into a chunk-grid map.
+
+    Returns one entry per target chunk slot: the index of the source chunk to
+    copy into that slot, or ``None`` for an all-missing (null-path) chunk that
+    reads back as the array's ``fill_value``.
+
+    Raises
+    ------
+    NotImplementedError
+        If the reindex cannot be expressed at chunk granularity (would split,
+        partially cover, or sub-chunk-reorder a source chunk).
+    """
+    source_index = pd.Index(source_labels)
+    target_index = pd.Index(target_labels)
+
+    n_source = len(source_index)
+    # -1 where a target label is absent from the source. Raises if source non-unique.
+    pos = source_index.get_indexer(target_index)
+
+    n_target = len(target_index)
+    chunk_map: list[int | None] = []
+    for start in range(0, n_target, chunk_size):
+        block = pos[start : start + chunk_size]
+
+        if np.all(block == -1):
+            chunk_map.append(None)
+            continue
+        if np.any(block == -1):
+            # block mixes present and missing labels -> would split a chunk
+            raise NotImplementedError(_SPLIT_MSG)
+
+        s = int(block[0])
+        # must be a contiguous, ascending, step-1 run (no sub-chunk reorder)
+        if not np.array_equal(block, np.arange(s, s + len(block))):
+            raise NotImplementedError(_SPLIT_MSG)
+        # must start on a source chunk boundary
+        if s % chunk_size != 0:
+            raise NotImplementedError(_SPLIT_MSG)
+        src_chunk = s // chunk_size
+        # block length must match that source chunk's actual size (handles trailing partial)
+        src_chunk_size = min(chunk_size, n_source - src_chunk * chunk_size)
+        if len(block) != src_chunk_size:
+            raise NotImplementedError(_SPLIT_MSG)
+
+        chunk_map.append(src_chunk)
+
+    return chunk_map

--- a/virtualizarr/tests/test_manifests/test_array.py
+++ b/virtualizarr/tests/test_manifests/test_array.py
@@ -808,6 +808,71 @@ class TestWithFillValueOnly:
         assert result.manifest.dict() == {}
 
 
+class TestReindexAxis:
+    def test_pad_with_null_chunk(self, array_v3_metadata):
+        # shape (4,), chunks (2,) -> two source chunks "0","1"
+        manifest = ChunkManifest(
+            entries={
+                "0": {"path": "/a.nc", "offset": 0, "length": 8},
+                "1": {"path": "/b.nc", "offset": 8, "length": 8},
+            }
+        )
+        metadata = array_v3_metadata(shape=(4,), chunks=(2,), dimension_names=["x"])
+        marr = ManifestArray(metadata=metadata, chunkmanifest=manifest)
+
+        # insert a missing chunk between the two real chunks; new length 6 (3 chunks)
+        result = marr._reindex_axis(axis=0, chunk_map=[0, None, 1], new_size=6)
+
+        assert result.shape == (6,)
+        assert result.metadata.chunks == (2,)
+        # missing chunk is simply omitted from the dict
+        assert result.manifest.dict() == {
+            "0": {"path": "file:///a.nc", "offset": 0, "length": 8},
+            "2": {"path": "file:///b.nc", "offset": 8, "length": 8},
+        }
+
+    def test_whole_chunk_reorder(self, array_v3_metadata):
+        manifest = ChunkManifest(
+            entries={
+                "0": {"path": "/a.nc", "offset": 0, "length": 8},
+                "1": {"path": "/b.nc", "offset": 8, "length": 8},
+            }
+        )
+        metadata = array_v3_metadata(shape=(4,), chunks=(2,), dimension_names=["x"])
+        marr = ManifestArray(metadata=metadata, chunkmanifest=manifest)
+
+        result = marr._reindex_axis(axis=0, chunk_map=[1, 0], new_size=4)
+
+        assert result.shape == (4,)
+        assert result.manifest.dict() == {
+            "0": {"path": "file:///b.nc", "offset": 8, "length": 8},
+            "1": {"path": "file:///a.nc", "offset": 0, "length": 8},
+        }
+
+    def test_only_target_axis_remapped_2d(self, array_v3_metadata):
+        # shape (2,4) chunks (2,2) -> chunk grid (1,2): keys "0.0","0.1"
+        manifest = ChunkManifest(
+            entries={
+                "0.0": {"path": "/a.nc", "offset": 0, "length": 16},
+                "0.1": {"path": "/b.nc", "offset": 16, "length": 16},
+            }
+        )
+        metadata = array_v3_metadata(
+            shape=(2, 4), chunks=(2, 2), dimension_names=["y", "x"]
+        )
+        marr = ManifestArray(metadata=metadata, chunkmanifest=manifest)
+
+        # reindex axis 1 (x): keep chunk 0, append a null chunk -> shape (2,6)
+        result = marr._reindex_axis(axis=1, chunk_map=[0, 1, None], new_size=6)
+
+        assert result.shape == (2, 6)
+        assert result.metadata.chunks == (2, 2)
+        assert result.manifest.dict() == {
+            "0.0": {"path": "file:///a.nc", "offset": 0, "length": 16},
+            "0.1": {"path": "file:///b.nc", "offset": 16, "length": 16},
+        }
+
+
 def test_refuse_combine(array_v3_metadata):
     # TODO test refusing to concatenate arrays that have conflicting shapes / chunk sizes
     chunks = (5, 1, 10)

--- a/virtualizarr/tests/test_manifests/test_reindex.py
+++ b/virtualizarr/tests/test_manifests/test_reindex.py
@@ -1,0 +1,59 @@
+import pandas as pd
+import pytest
+
+from virtualizarr.manifests.reindex import chunk_index_map
+
+
+class TestChunkIndexMap:
+    def test_append_chunk_size_1(self):
+        # extend [0,1,2] -> [0,1,2,3,4] with C=1: two new null chunks
+        assert chunk_index_map([0, 1, 2], [0, 1, 2, 3, 4], 1) == [0, 1, 2, None, None]
+
+    def test_chunked_append(self):
+        # source chunks [0,1],[2,3]; target adds a whole new chunk [4,5] (all missing)
+        assert chunk_index_map([0, 1, 2, 3], [0, 1, 2, 3, 4, 5], 2) == [0, 1, None]
+
+    def test_prepend(self):
+        # source [2,3] (C=1); target [0,1,2,3] -> two leading null chunks
+        assert chunk_index_map([2, 3], [0, 1, 2, 3], 1) == [None, None, 0, 1]
+
+    def test_gap_fill_insert_whole_chunk(self):
+        # source chunks [0,1],[4,5]; target [0,1,2,3,4,5] inserts a null chunk in the gap
+        assert chunk_index_map([0, 1, 4, 5], [0, 1, 2, 3, 4, 5], 2) == [0, None, 1]
+
+    def test_whole_chunk_reverse_c1(self):
+        assert chunk_index_map([0, 1, 2], [2, 1, 0], 1) == [2, 1, 0]
+
+    def test_whole_chunk_reverse_c2(self):
+        # source chunks [0,1],[2,3]; target swaps the two chunks
+        assert chunk_index_map([0, 1, 2, 3], [2, 3, 0, 1], 2) == [1, 0]
+
+    def test_sort_c1(self):
+        # unsorted source [3,1,2] sorted to [1,2,3]
+        assert chunk_index_map([3, 1, 2], [1, 2, 3], 1) == [1, 2, 0]
+
+    def test_trailing_partial_source_chunk(self):
+        # source [0,1,2,3,4] C=2 -> chunks of size 2,2,1; selecting just the partial tail
+        assert chunk_index_map([0, 1, 2, 3, 4], [4], 2) == [2]
+
+    def test_raise_mixed_present_and_missing(self):
+        with pytest.raises(NotImplementedError, match="split"):
+            chunk_index_map([0, 1, 2, 3], [0, 1, 2, 5], 2)
+
+    def test_raise_sub_chunk_reorder(self):
+        with pytest.raises(NotImplementedError, match="split"):
+            chunk_index_map([0, 1, 2, 3], [1, 0, 2, 3], 2)
+
+    def test_raise_unaligned_start(self):
+        with pytest.raises(NotImplementedError, match="split"):
+            chunk_index_map([0, 1, 2, 3], [1, 2], 2)
+
+    def test_raise_partial_target_of_full_source(self):
+        # taking only half of source chunk [2,3] would split it
+        with pytest.raises(NotImplementedError, match="split"):
+            chunk_index_map([0, 1, 2, 3], [0, 1, 2], 2)
+
+    def test_raise_non_unique_source(self):
+        # pandas refuses get_indexer on a non-unique index
+        with pytest.raises(pd.errors.InvalidIndexError):
+            chunk_index_map([0, 0, 1], [0, 1], 1)

--- a/virtualizarr/tests/test_xarray.py
+++ b/virtualizarr/tests/test_xarray.py
@@ -17,8 +17,14 @@ from virtualizarr import (
     open_virtual_datatree,
     open_virtual_mfdataset,
 )
-from virtualizarr.manifests import ChunkManifest, ManifestArray
+from virtualizarr.manifests import (
+    ChunkManifest,
+    ManifestArray,
+    ManifestGroup,
+    ManifestStore,
+)
 from virtualizarr.manifests.indexing import SubChunkIndexingError
+from virtualizarr.manifests.utils import create_v3_array_metadata
 from virtualizarr.parsers import HDFParser
 from virtualizarr.tests import (
     requires_dask,
@@ -375,6 +381,298 @@ class TestCombine:
             assert isinstance(combined_vds["time"].data, ManifestArray)
             assert isinstance(combined_vds["lat"].data, ManifestArray)
             assert isinstance(combined_vds["lon"].data, ManifestArray)
+
+
+class TestAlignment:
+    """
+    Outer-style alignment introduces coordinate labels an array doesn't have and
+    fills the new positions with NaN. The NaN fill is *not* fundamentally a
+    materializing operation: a missing chunk in a manifest (``MISSING_CHUNK_PATH``)
+    already reads back as ``fill_value``, so the NaN can live purely as a chunk
+    reference and only be realized when a reader asks for those bytes (see
+    ``test_missing_chunk_reads_back_as_virtual_nan``).
+
+    What actually breaks today is xarray's *reindex machinery*, not the manifest
+    model. xarray implements an outer join by reindexing each object onto the
+    union of labels, and reindex builds an integer indexer with ``-1`` at every
+    missing (would-be-NaN) position - e.g. ``[0, 1, 2, -1, -1]``. ManifestArray
+    refuses that fancy-indexing operation, so alignment raises before any result
+    is produced. The lazy, manifest-level path (padding with missing chunks) is
+    not yet wired into reindex, which is why the outer join fails here.
+    """
+
+    def _manifest_dataarray(self, array_v3_metadata, path, coord):
+        """A 1D ManifestArray wrapped in a DataArray with a dimension coordinate."""
+        n = len(coord)
+        manifest = ChunkManifest(
+            entries={"0": {"path": path, "offset": 0, "length": n * 4}}
+        )
+        metadata = array_v3_metadata(
+            shape=(n,), chunks=(n,), data_type=np.dtype("float32")
+        )
+        marr = ManifestArray(metadata=metadata, chunkmanifest=manifest)
+        return xr.DataArray(marr, dims=["x"], coords={"x": coord}, name="foo")
+
+    def test_align_outer_join_with_unaligned_labels_raises(self, array_v3_metadata):
+        # Partially overlapping labels: the union is x=[0, 1, 2, 3, 4], so each
+        # array gains a would-be-NaN at the labels it personally lacks.
+        da1 = self._manifest_dataarray(array_v3_metadata, "/a.nc", [0, 1, 2])
+        da2 = self._manifest_dataarray(array_v3_metadata, "/b.nc", [2, 3, 4])
+
+        # The outer join reindexes da1 onto [0, 1, 2, 3, 4], producing the
+        # indexer [0, 1, 2, -1, -1]. ManifestArray rejects that fancy index, so
+        # alignment fails inside xarray's reindex - this is a machinery gap, not
+        # proof that the NaN fill must materialize (the manifest could instead be
+        # padded with missing chunks; that path is not yet wired into reindex).
+        with pytest.raises(NotImplementedError, match="fancy indexing"):
+            xr.align(da1, da2, join="outer")
+
+    def test_align_outer_join_already_aligned_stays_lazy(self, array_v3_metadata):
+        # When the labels already match, an outer join needs no reindex (no NaN
+        # fill), so it is a no-op that leaves the data lazy as a ManifestArray.
+        da1 = self._manifest_dataarray(array_v3_metadata, "/a.nc", [0, 1, 2])
+        da2 = self._manifest_dataarray(array_v3_metadata, "/b.nc", [0, 1, 2])
+
+        aligned1, aligned2 = xr.align(da1, da2, join="outer")
+
+        assert isinstance(aligned1.data, ManifestArray)
+        assert isinstance(aligned2.data, ManifestArray)
+
+    def test_reading_manifestarray_values_raises_clear_error(self, array_v3_metadata):
+        # A bare ManifestArray refuses to materialize into numpy, pointing the
+        # user at loadable_variables / writing to a store instead. (To read NaN
+        # fill values lazily you go through a ManifestStore, not __array__ - see
+        # test_missing_chunk_reads_back_as_virtual_nan.)
+        da = self._manifest_dataarray(array_v3_metadata, "/a.nc", [0, 1, 2])
+
+        with pytest.raises(NotImplementedError, match="virtual references"):
+            da.values
+
+    def test_missing_chunk_reads_back_as_virtual_nan(self):
+        # The NaN fill an outer join wants does NOT require materializing a real
+        # array: a MISSING_CHUNK_PATH ("") entry is a virtual NaN that a
+        # ManifestStore serves lazily as fill_value at read time. Here chunk "0"
+        # is a real reference and chunk "1" is missing, so the array reads back as
+        # [1.0, 2.0, nan, nan] without ever materializing a fill array.
+        import obstore as obs
+
+        store = obs.store.MemoryStore()
+        # two little-endian float32 values: 1.0, 2.0
+        obs.put(store, "data.bin", b"\x00\x00\x80\x3f\x00\x00\x00\x40")
+
+        manifest = ChunkManifest(
+            entries={
+                "0": {"path": "memory:///data.bin", "offset": 0, "length": 8},
+                "1": {"path": "", "offset": 0, "length": 0},  # MISSING_CHUNK_PATH
+            }
+        )
+        metadata = create_v3_array_metadata(
+            shape=(4,),
+            chunk_shape=(2,),
+            data_type=np.dtype("float32"),
+            codecs=[{"configuration": {"endian": "little"}, "name": "bytes"}],
+            fill_value=float("nan"),
+            dimension_names=["x"],
+        )
+        marr = ManifestArray(metadata=metadata, chunkmanifest=manifest)
+
+        # the missing chunk is simply absent from the manifest dict
+        assert manifest.dict() == {
+            "0": {"path": "memory:///data.bin", "offset": 0, "length": 8}
+        }
+
+        manifest_store = ManifestStore(
+            group=ManifestGroup(arrays={"foo": marr}),
+            registry=ObjectStoreRegistry({"memory://": store}),
+        )
+        ds = xr.open_zarr(manifest_store, consolidated=False, zarr_format=3)
+
+        values = ds["foo"].values
+        np.testing.assert_array_equal(values[:2], [1.0, 2.0])
+        assert np.isnan(values[2:]).all()
+
+    def _virtual_ds_with_time_index(self, times, path):
+        # one float32 value per timestep, one chunk per timestep (C=1 along time)
+        n = len(times)
+        manifest = ChunkManifest(
+            entries={
+                str(i): {"path": path, "offset": i * 4, "length": 4} for i in range(n)
+            }
+        )
+        metadata = create_v3_array_metadata(
+            shape=(n,),
+            chunk_shape=(1,),
+            data_type=np.dtype("float32"),
+            codecs=[{"configuration": {"endian": "little"}, "name": "bytes"}],
+            fill_value=float("nan"),
+            dimension_names=["time"],
+        )
+        marr = ManifestArray(metadata=metadata, chunkmanifest=manifest)
+        var = xr.Variable(["time"], marr)
+        return xr.Dataset({"foo": var}, coords={"time": list(times)})
+
+    def test_reindex_pads_with_virtual_nan(self):
+        ds = self._virtual_ds_with_time_index([0, 1, 2], "/a.nc")
+        result = ds.vz.reindex(time=[0, 1, 2, 3, 4])
+
+        # still lazy
+        assert isinstance(result["foo"].data, ManifestArray)
+        assert result.sizes["time"] == 5
+        assert list(result["time"].values) == [0, 1, 2, 3, 4]
+        # positions 3 and 4 are null chunks, omitted from the manifest dict
+        assert result["foo"].data.manifest.dict() == {
+            "0": {"path": "file:///a.nc", "offset": 0, "length": 4},
+            "1": {"path": "file:///a.nc", "offset": 4, "length": 4},
+            "2": {"path": "file:///a.nc", "offset": 8, "length": 4},
+        }
+
+    def test_reindex_read_back_fill_value(self):
+        import obstore as obs
+
+        store = obs.store.MemoryStore()
+        # three little-endian float32 values: 1.0, 2.0, 3.0
+        obs.put(
+            store,
+            "data.bin",
+            b"\x00\x00\x80\x3f\x00\x00\x00\x40\x00\x00\x40\x40",
+        )
+        manifest = ChunkManifest(
+            entries={
+                "0": {"path": "memory:///data.bin", "offset": 0, "length": 4},
+                "1": {"path": "memory:///data.bin", "offset": 4, "length": 4},
+                "2": {"path": "memory:///data.bin", "offset": 8, "length": 4},
+            }
+        )
+        metadata = create_v3_array_metadata(
+            shape=(3,),
+            chunk_shape=(1,),
+            data_type=np.dtype("float32"),
+            codecs=[{"configuration": {"endian": "little"}, "name": "bytes"}],
+            fill_value=float("nan"),
+            dimension_names=["time"],
+        )
+        marr = ManifestArray(metadata=metadata, chunkmanifest=manifest)
+        ds = xr.Dataset(
+            {"foo": xr.Variable(["time"], marr)}, coords={"time": [0, 1, 2]}
+        )
+
+        reindexed = ds.vz.reindex(time=[0, 1, 2, 3, 4])
+
+        manifest_store = ManifestStore(
+            group=ManifestGroup(arrays={"foo": reindexed["foo"].data}),
+            registry=ObjectStoreRegistry({"memory://": store}),
+        )
+        roundtripped = xr.open_zarr(manifest_store, consolidated=False, zarr_format=3)
+        values = roundtripped["foo"].values
+        np.testing.assert_array_equal(values[:3], [1.0, 2.0, 3.0])
+        assert np.isnan(values[3:]).all()
+
+    def test_reindex_like(self):
+        ds = self._virtual_ds_with_time_index([0, 1, 2], "/a.nc")
+        other = xr.Dataset(coords={"time": [0, 1, 2, 3]})
+        result = ds.vz.reindex_like(other)
+        assert result.sizes["time"] == 4
+        assert isinstance(result["foo"].data, ManifestArray)
+
+    def test_reindex_without_index_raises(self):
+        # build a dataset whose "time" dim has NO coordinate/index
+        manifest = ChunkManifest(
+            entries={"0": {"path": "/a.nc", "offset": 0, "length": 12}}
+        )
+        metadata = create_v3_array_metadata(
+            shape=(3,),
+            chunk_shape=(3,),
+            data_type=np.dtype("float32"),
+            dimension_names=["time"],
+        )
+        marr = ManifestArray(metadata=metadata, chunkmanifest=manifest)
+        ds = xr.Dataset({"foo": xr.Variable(["time"], marr)})  # no time coord
+
+        with pytest.raises(ValueError, match="index"):
+            ds.vz.reindex(time=[0, 1, 2, 3])
+
+    def test_reindex_non_chunk_aligned_raises(self):
+        # C=2 along time; target inserts a single missing label mid-chunk -> split
+        manifest = ChunkManifest(
+            entries={
+                "0": {"path": "/a.nc", "offset": 0, "length": 8},
+                "1": {"path": "/a.nc", "offset": 8, "length": 8},
+            }
+        )
+        metadata = create_v3_array_metadata(
+            shape=(4,),
+            chunk_shape=(2,),
+            data_type=np.dtype("float32"),
+            fill_value=float("nan"),
+            dimension_names=["time"],
+        )
+        marr = ManifestArray(metadata=metadata, chunkmanifest=manifest)
+        ds = xr.Dataset(
+            {"foo": xr.Variable(["time"], marr)}, coords={"time": [0, 1, 2, 3]}
+        )
+
+        with pytest.raises(NotImplementedError, match="split"):
+            ds.vz.reindex(time=[0, 1, 99, 2, 3])
+
+    def test_reindex_preserves_aux_coord_status(self):
+        # Regression test for FIX 1: a virtual variable declared as a coordinate
+        # (auxiliary coord, not the dimension coord) must stay in result.coords
+        # after reindexing — it must not be demoted to a data variable.
+        n = 3
+        manifest = ChunkManifest(
+            entries={
+                str(i): {"path": "/a.nc", "offset": i * 4, "length": 4}
+                for i in range(n)
+            }
+        )
+        metadata = create_v3_array_metadata(
+            shape=(n,),
+            chunk_shape=(1,),
+            data_type=np.dtype("float32"),
+            codecs=[{"configuration": {"endian": "little"}, "name": "bytes"}],
+            fill_value=float("nan"),
+            dimension_names=["time"],
+        )
+        marr_data = ManifestArray(metadata=metadata, chunkmanifest=manifest)
+
+        # build an aux coord (ref_time) backed by a ManifestArray along the time dim
+        aux_manifest = ChunkManifest(
+            entries={
+                str(i): {"path": "/b.nc", "offset": i * 4, "length": 4}
+                for i in range(n)
+            }
+        )
+        aux_metadata = create_v3_array_metadata(
+            shape=(n,),
+            chunk_shape=(1,),
+            data_type=np.dtype("float32"),
+            codecs=[{"configuration": {"endian": "little"}, "name": "bytes"}],
+            fill_value=float("nan"),
+            dimension_names=["time"],
+        )
+        aux_marr = ManifestArray(metadata=aux_metadata, chunkmanifest=aux_manifest)
+
+        ds = xr.Dataset(
+            {"foo": xr.Variable(["time"], marr_data)},
+            coords={
+                "time": list(range(n)),
+                "ref_time": xr.Variable(["time"], aux_marr),
+            },
+        )
+
+        # ref_time should be a coord before reindexing
+        assert "ref_time" in ds.coords
+        assert isinstance(ds["ref_time"].data, ManifestArray)
+
+        result = ds.vz.reindex(time=[0, 1, 2, 3, 4])
+
+        # ref_time must remain a coord (not demoted to a data var)
+        assert "ref_time" in result.coords, (
+            "aux coord ref_time was demoted to a data variable after reindex"
+        )
+        # and it must still be a ManifestArray
+        assert isinstance(result["ref_time"].data, ManifestArray)
+        assert result.sizes["time"] == 5
 
 
 class TestRenamePaths:


### PR DESCRIPTION
# What I did
Added lazy `reindex` and `reindex_like` accessor methods that align a virtual dataset to new coordinate labels without materializing data, padding missing positions in the new target grid with null-path manifest entries so that the missing chunks are read as `fill_value`.

Acceptance criteria:


- [x] Closes #882 #382 #883 https://github.com/nasa-jpl/its_live_production/discussions/59
- [x] Tests added
- [x] Tests passing
- [x] No test coverage regression
- [x] Full type hint coverage
- [x] Changes are documented in `docs/about/releases.md`
- [x] New functions/methods are listed in an appropriate `*.md` file under `docs/api`
- [x] New functionality has documentation
