### PR TITLE
Fix kerchunk structured-dtype refs (FITS binary tables)

### DIFF
--- a/docs/about/releases.md
+++ b/docs/about/releases.md
@@ -8,6 +8,8 @@
 ### Breaking changes
 
 ### Bug fixes
+- Fix parsing kerchunk references that use a **structured (record) dtype**, as produced for a FITS `BinTableHDU` (e.g. an SDSS spectrum). Such references round-trip the dtype through JSON as a list of `[name, format]` lists and encode the `fill_value` as base64 raw bytes; `from_kerchunk_refs` now coerces the field specs back to tuples before `np.dtype` and decodes the base64 `fill_value` into a structured scalar, instead of raising `TypeError`.
+  By [David Stuebe](https://github.com/emfdavid).
 
 ### Documentation
 

--- a/virtualizarr/parsers/kerchunk/translator.py
+++ b/virtualizarr/parsers/kerchunk/translator.py
@@ -49,13 +49,24 @@ def from_kerchunk_refs(decoded_arr_refs_zarray, zattrs) -> "ArrayV3Metadata":
     ValueError
         If the Zarr format specified in the input dictionary is not 2 or 3.
     """
+    # A structured dtype round-trips through kerchunk's JSON as a list of
+    # ``[name, format]`` (and optionally shape) lists, but ``np.dtype`` requires
+    # each field spec to be a tuple -- coerce the inner lists back to tuples.
+    raw_dtype = decoded_arr_refs_zarray["dtype"]
+    if isinstance(raw_dtype, list):
+        raw_dtype = [tuple(field) for field in raw_dtype]
+    dtype = np.dtype(raw_dtype)
+
     # coerce type of fill_value as kerchunk can be inconsistent with this
-    dtype = np.dtype(decoded_arr_refs_zarray["dtype"])
     fill_value = decoded_arr_refs_zarray["fill_value"]
     if np.issubdtype(dtype, np.floating) and (
         fill_value is None or fill_value == "NaN" or fill_value == "nan"
     ):
         fill_value = np.nan
+    elif dtype.fields is not None and isinstance(fill_value, str):
+        # kerchunk encodes a structured dtype's fill_value as base64-encoded raw
+        # bytes; decode it into a structured scalar that zarr-v3 can cast.
+        fill_value = np.frombuffer(base64.b64decode(fill_value), dtype=dtype)[0]
 
     zarr_format = int(decoded_arr_refs_zarray["zarr_format"])
     if zarr_format not in (2, 3):

--- a/virtualizarr/tests/test_parsers/test_kerchunk.py
+++ b/virtualizarr/tests/test_parsers/test_kerchunk.py
@@ -578,4 +578,33 @@ def test_parse_dict_via_memorystore(array_v3_metadata):
     actual_marr = manifeststore._group._members["a"]
     assert (actual_marr == expected_marr).all()
 
+
+def test_from_kerchunk_refs_structured_dtype():
+    """A FITS BinTableHDU (e.g. an SDSS spectrum) is emitted by kerchunk as a
+    structured dtype: its fields arrive as JSON *lists* (``["flux", ">f4"]``) and
+    its ``fill_value`` as base64-encoded raw bytes. Both need coercing before they
+    reach ``np.dtype`` / zarr-v3, which previously raised ``TypeError``."""
+    import base64
+
+    from virtualizarr.parsers.kerchunk.translator import from_kerchunk_refs
+
+    fields = [["flux", ">f4"], ["mask", ">i4"]]
+    itemsize = np.dtype([tuple(f) for f in fields]).itemsize
+    zarray = {
+        "dtype": fields,
+        "fill_value": base64.b64encode(b"\x00" * itemsize).decode(),
+        "zarr_format": 2,
+        "filters": None,
+        "compressor": None,
+        "chunks": [10],
+        "shape": [10],
+        "dimension_names": ["x"],
+    }
+
+    metadata = from_kerchunk_refs(zarray, {"value": "1"})
+
+    assert metadata.data_type.to_native_dtype().names == ("flux", "mask")
+    # the base64 fill decodes to the structured zero, not the raw string
+    assert metadata.fill_value == np.zeros((), metadata.data_type.to_native_dtype())[()]
+
     # TODO assert that manifeststore.to_kerchunk_refs() roundtrips, once we have that method


### PR DESCRIPTION
# What I did
A FITS BinTableHDU (e.g. an SDSS spectrum) is emitted by kerchunk as a structured/record dtype. Its field specs round-trip through JSON as lists (['flux', '>f4']) rather than tuples, and its fill_value is base64-encoded raw bytes -- both of which made from_kerchunk_refs raise TypeError (first in np.dtype, then in zarr-v3's structured cast_scalar).

Coerce the field specs back to tuples before np.dtype, and decode the base64 fill_value into a structured scalar. Adds a regression test.

Acceptance criteria:

- [x] Tests added
- [x] Tests passing
- [x] No test coverage regression
- [x] Full type hint coverage
- [x] Changes are documented in `docs/about/releases.md`

Not applicable
- [ ] Closes #xxxx
- [ ] New functions/methods are listed in an appropriate `*.md` file under `docs/api`
- [ ] New functionality has documentation
