### PR TITLE
perf: add fast path for local hdf5

### DIFF
--- a/docs/about/releases.md
+++ b/docs/about/releases.md
@@ -9,6 +9,9 @@
 
 ### Bug fixes
 
+- `HDFParser` now walks a local file's chunk index with h5py's native driver instead of routing every index-node read through the object-store block reader. For chunk-dense datasets (e.g. sparse single-cell `.h5ad`) this avoids reading a large fraction of the whole file just to build the manifest — HDF5 reads the index at native granularity. The reader path is unchanged for remote sources and when a custom `reader_factory` is supplied.
+  By [Ian Hunt-Isaak](https://github.com/ianhi).
+
 ### Documentation
 
 ### Internal changes

--- a/docs/api/parsers/hdf5.md
+++ b/docs/api/parsers/hdf5.md
@@ -1,3 +1,32 @@
 # HDF5/NetCDF4
 
+!!! note "Chunk-dense files over the network"
+
+    Local files are walked with HDF5's own index-aware driver, so building a
+    manifest reads only the chunk index. For **remote** chunk-dense files (many
+    small chunks — e.g. sparse single-cell `.h5ad`), the default block reader
+    can instead fetch a large fraction of the whole file just to recover that
+    index.
+
+    The robust fix is to **download the file once and parse it locally**, which
+    takes the native fast path automatically.
+
+    If downloading isn't practical, tune the block size via the `reader_factory`
+    parameter (documented below). The default 1 MiB block over-reads the ~2 KiB
+    chunk-index nodes, so a smaller block cuts the bytes fetched — at the cost
+    of more requests:
+
+    ```python
+    import functools
+    from obspec_utils.readers import BlockStoreReader
+
+    parser = HDFParser(
+        reader_factory=functools.partial(BlockStoreReader, block_size=64 * 1024),
+    )
+    ```
+
+    This only mitigates the over-read: the ideal block size depends on the
+    file's chunk-index layout, so downloading and parsing locally remains the
+    reliable option.
+
 ::: virtualizarr.parsers.HDFParser

--- a/virtualizarr/parsers/hdf/hdf.py
+++ b/virtualizarr/parsers/hdf/hdf.py
@@ -8,7 +8,7 @@ from typing import (
 )
 
 import numpy as np
-from obspec_utils.protocols import ReadableFile
+from obspec_utils.protocols import ReadableFile, ReadableStore
 from obspec_utils.readers import BlockStoreReader
 from obspec_utils.registry import ObjectStoreRegistry
 
@@ -139,15 +139,47 @@ def _chunk_shape(dataset: H5Dataset) -> tuple[int, ...]:
     return dataset.chunks
 
 
+def _resolve_local_path(store: ReadableStore, path_in_store: str) -> str | None:
+    """Return the filesystem path of ``path_in_store`` if ``store`` is local.
+
+    When the resolved store is an obstore ``LocalStore`` the file is a real path
+    on disk, so we can hand it straight to ``h5py.File`` and let HDF5's own
+    index-aware driver walk the chunk index natively - reading each index type
+    at native granularity instead of dragging a full block per ~2 KiB index-node
+    read through the object-store reader. See the module for why block-based
+    reading amplifies the chunk-index walk on chunk-dense files.
+
+    Returns ``None`` for any non-local store, or if the reconstructed path does
+    not point at an existing file (in which case we fall back to the reader).
+    """
+    import obstore.store as obs
+
+    if not isinstance(store, obs.LocalStore):
+        return None
+    # ``LocalStore.prefix`` may be None (no prefix), a str, or a PosixPath. With
+    # no prefix, obstore strips the leading "/" from the path, so the resolved
+    # ``path_in_store`` is relative to the filesystem root - rejoin it there.
+    prefix = getattr(store, "prefix", None)
+    root = str(prefix) if prefix is not None else "/"
+    candidate = Path(root) / path_in_store
+    # Guard against any reconstruction we didn't anticipate: only take the native
+    # path when it actually resolves to a file, otherwise fall back to the reader.
+    return str(candidate) if candidate.is_file() else None
+
+
 def _construct_manifest_group(
     filepath: str,
-    reader: ReadableFile,
+    reader: ReadableFile | str,
     *,
     group: str | None = None,
     drop_variables: Iterable[str] | None = None,
 ) -> ManifestGroup:
     """
     Construct a virtual Group from a HDF dataset.
+
+    ``reader`` is either a file-like reader over the object store or, for local
+    files, a filesystem path string that ``h5py.File`` opens with its native
+    driver.
     """
     import h5py
 
@@ -198,17 +230,29 @@ class HDFParser:
         A callable that creates a file-like reader from a store and path.
         Must return an object implementing the
         [ReadableFile][obspec_utils.protocols.ReadableFile] protocol.
-        Default is [BlockStoreReader][obspec_utils.readers.BlockStoreReader].
+        Defaults to `None`, which uses
+        [BlockStoreReader][obspec_utils.readers.BlockStoreReader] for remote
+        sources and the native fast path (below) for local files.
+
+        When the source is a local file and ``reader_factory`` is left as
+        `None`, the parser bypasses the reader entirely and opens the file with
+        h5py's native driver. HDF5 then walks the chunk index at native
+        granularity, which for chunk-dense datasets reads orders of magnitude
+        fewer bytes than serving each ~2 KiB index-node read through a
+        fixed-block reader. Passing an explicit ``reader_factory`` opts back into
+        the reader path for local files too.
     """
 
     def __init__(
         self,
         group: str | None = None,
         drop_variables: Iterable[str] | None = None,
-        reader_factory: ReaderFactory = BlockStoreReader,
+        reader_factory: ReaderFactory | None = None,
     ):
         self.group = group
         self.drop_variables = drop_variables
+        # ``None`` means "take the local native fast path when possible, else fall
+        # back to BlockStoreReader"; an explicit factory is always honoured.
         self.reader_factory = reader_factory
 
     def __call__(
@@ -233,7 +277,15 @@ class HDFParser:
             A [ManifestStore][virtualizarr.manifests.ManifestStore] which provides a Zarr representation of the parsed file.
         """
         store, path_in_store = registry.resolve(url)
-        reader = self.reader_factory(store, path_in_store)
+        # With no explicit reader_factory, a local file takes the native fast path
+        # (h5py opens it directly); everything else goes through the block reader.
+        reader: ReadableFile | str
+        if self.reader_factory is None:
+            reader = _resolve_local_path(store, path_in_store) or BlockStoreReader(
+                store, path_in_store
+            )
+        else:
+            reader = self.reader_factory(store, path_in_store)
         manifest_group = _construct_manifest_group(
             filepath=url,
             reader=reader,

--- a/virtualizarr/tests/test_parsers/conftest.py
+++ b/virtualizarr/tests/test_parsers/conftest.py
@@ -95,6 +95,22 @@ def chunked_hdf5_url(tmpdir):
 
 
 @pytest.fixture
+def chunk_dense_hdf5_url(tmpdir):
+    # A chunk-dense dataset written in the "expensive" layout: an unlimited
+    # (extendable) dimension + libver="earliest" forces a scattered v1 B-tree
+    # chunk index, and gzip makes chunks variable-length (so a real index is
+    # required). Building a manifest through a fixed-block reader over-reads this
+    # index by ~1-2 orders of magnitude; the local native fast path avoids it.
+    filepath = f"{tmpdir}/chunk_dense.h5"
+    with h5py.File(filepath, "w", libver="earliest") as f:
+        data = (np.random.default_rng(0).standard_normal(400_000) * 100).astype("int64")
+        f.create_dataset(
+            "x", data=data, chunks=(1_000,), maxshape=(None,), compression="gzip"
+        )
+    return f"file://{filepath}"
+
+
+@pytest.fixture
 def single_dimension_scale_hdf5_url(tmpdir):
     filepath = f"{tmpdir}/single_dimension_scale.nc"
     f = h5py.File(filepath, "w")

--- a/virtualizarr/tests/test_parsers/test_hdf/test_hdf.py
+++ b/virtualizarr/tests/test_parsers/test_hdf/test_hdf.py
@@ -1,3 +1,5 @@
+import functools
+import os
 import warnings
 
 import h5py  # type: ignore
@@ -5,11 +7,13 @@ import numpy as np
 import pytest
 import xarray as xr
 import zarr
+from obspec_utils.readers import BlockStoreReader
 from obspec_utils.registry import ObjectStoreRegistry
-from obstore.store import from_url
+from obstore.store import LocalStore, from_url
 
 from virtualizarr import open_virtual_dataset
 from virtualizarr.parsers import HDFParser
+from virtualizarr.parsers.hdf import hdf as hdf_parser_module
 from virtualizarr.tests import (
     requires_hdf5plugin,
     requires_imagecodecs,
@@ -271,3 +275,109 @@ def test_netcdf_over_https():
     ):
         np.testing.assert_allclose(ds["z"].min().to_numpy(), -6)
         np.testing.assert_allclose(ds["z"].max().to_numpy(), 817)
+
+
+class _ByteTallyStore:
+    """Wrap an obstore store to count bytes served at the store layer.
+
+    Used to demonstrate the read amplification of the block-reader path. Note it
+    is deliberately *not* a ``LocalStore`` subclass (that type can't be
+    subclassed), so it does not trigger the local native fast path - which is
+    exactly what we want when forcing the reader path with an explicit
+    ``reader_factory``.
+    """
+
+    def __init__(self, inner):
+        self._inner = inner
+        self.bytes = 0
+
+    def get_ranges(self, path, starts, lengths):
+        self.bytes += sum(int(x) for x in lengths)
+        return self._inner.get_ranges(path, starts=starts, lengths=lengths)
+
+    def get_range(self, path, *, start, length):
+        self.bytes += int(length)
+        return self._inner.get_range(path, start=start, length=length)
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+
+@requires_hdf5plugin
+@requires_imagecodecs
+class TestLocalNativeFastPath:
+    """A local file is walked with h5py's native driver rather than through the
+    object-store reader, so building a manifest of a chunk-dense dataset does not
+    read the whole file. See ``_resolve_local_path`` in the HDF parser.
+    """
+
+    def _spy_on_reader(self, monkeypatch):
+        # Capture the ``reader`` argument handed to _construct_manifest_group on
+        # the first (top-level) call. A ``str`` means the native path (h5py opens
+        # the file directly and the object store is never touched).
+        captured = {}
+        original = hdf_parser_module._construct_manifest_group
+
+        def spy(*args, **kwargs):
+            captured.setdefault("reader", kwargs.get("reader"))
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(hdf_parser_module, "_construct_manifest_group", spy)
+        return captured
+
+    def test_local_default_bypasses_reader(
+        self, chunk_dense_hdf5_url, local_registry, monkeypatch
+    ):
+        captured = self._spy_on_reader(monkeypatch)
+        HDFParser()(url=chunk_dense_hdf5_url, registry=local_registry)
+        assert isinstance(captured["reader"], str), (
+            "default HDFParser should hand h5py a local path, bypassing the reader"
+        )
+
+    def test_explicit_reader_opts_out_of_fast_path(
+        self, chunk_dense_hdf5_url, local_registry, monkeypatch
+    ):
+        captured = self._spy_on_reader(monkeypatch)
+        HDFParser(reader_factory=BlockStoreReader)(
+            url=chunk_dense_hdf5_url, registry=local_registry
+        )
+        assert not isinstance(captured["reader"], str), (
+            "an explicit reader_factory should route local files through the reader"
+        )
+
+    def test_native_manifest_identical_to_reader_and_reader_amplifies(
+        self, chunk_dense_hdf5_url
+    ):
+        path = chunk_dense_hdf5_url.removeprefix("file://")
+        directory = os.path.dirname(path)
+        file_size = os.path.getsize(path)
+
+        # Default parser -> local native fast path.
+        native_registry = ObjectStoreRegistry(
+            {f"file://{directory}": LocalStore(prefix=directory)}
+        )
+        native = HDFParser()(url=chunk_dense_hdf5_url, registry=native_registry)
+        native_arr = native._group.arrays["x"]
+
+        # Explicit block reader -> reader path, with a tally to observe over-read.
+        tally = _ByteTallyStore(LocalStore(prefix=directory))
+        reader_registry = ObjectStoreRegistry({f"file://{directory}": tally})
+        reader = HDFParser(
+            reader_factory=functools.partial(BlockStoreReader, block_size=64 * 1024)
+        )(url=chunk_dense_hdf5_url, registry=reader_registry)
+        reader_arr = reader._group.arrays["x"]
+
+        # The reader path over-reads: building the manifest needs only the chunk
+        # index (~16 bytes of offset+length per chunk), yet the block reader
+        # fetches a large fraction of the whole file (observed ~57%) - orders of
+        # magnitude more than needed. The native path avoids this entirely (it
+        # never touches the store). Assert against the index size it actually
+        # needed rather than a raw file fraction, so the test stays meaningful if
+        # the fixture or block layout shifts.
+        n_chunks = int(np.prod(native_arr.manifest.shape_chunk_grid))
+        assert tally.bytes > 20 * n_chunks * 16
+        assert tally.bytes < file_size  # sanity: it doesn't read past the file
+
+        # ... yet both produce a byte-identical ManifestArray.
+        assert native_arr.metadata == reader_arr.metadata
+        assert native_arr.manifest.dict() == reader_arr.manifest.dict()


### PR DESCRIPTION
# What I did
Added a fast path for parsing HDF files that are local. For these the Blockreader can cause massive perforamnce hits. Especially for a larger files (40 GB), you can actually end up reading more data than the file size! especially for b-trees where you end up revisting nodes.

draft for now - this is AI code I have not yet personally carefully reviewd.

attn @ilan-gold  curious if this helps with the performance issues here: https://annbatch.readthedocs.io/en/stable/preshuffling.html

Acceptance criteria:
<!-- Feel free to remove check-list items that aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] No test coverage regression
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/about/releases.md`
- [ ] New functions/methods are listed in an appropriate `*.md` file under `docs/api`
- [ ] New functionality has documentation
