### PR TITLE
Fix ZarrParser crash on uninitialized scalar chunk (e.g. CRS variables)

### DIFF
--- a/docs/about/releases.md
+++ b/docs/about/releases.md
@@ -9,6 +9,9 @@
 
 ### Bug fixes
 
+- Fix `ZarrParser` raising `ValueError: need a chunk grid shape if no chunks given` when a scalar array's chunk is uninitialized. Scalar variables that carry only attributes and hold no data — such as CF grid-mapping / CRS variables — have no chunk written to storage, so the `HEAD` request 404s. The empty manifest built for this case now passes its (empty) chunk grid shape, matching the non-scalar path.
+  By [Tom Nicholas](https://github.com/TomNicholas).
+
 ### Documentation
 
 ### Internal changes

--- a/virtualizarr/parsers/zarr.py
+++ b/virtualizarr/parsers/zarr.py
@@ -364,8 +364,10 @@ async def build_chunk_manifest(
         try:
             head = await obstore.head_async(obs_store, store_key)
         except (FileNotFoundError, obstore.exceptions.NotFoundError):
-            # technically I think the zarr spec allows for the possibility that the scalar chunk is uninitialized
-            return ChunkManifest({})
+            # The zarr spec allows the scalar chunk to be uninitialized (e.g. CF
+            # grid-mapping / CRS variables carry only attributes). An empty
+            # manifest still needs its (empty) chunk grid shape.
+            return ChunkManifest({}, shape=chunk_grid_shape)
 
         size = head["size"]
         full_path = join_url(store_base_uri, store_key)

--- a/virtualizarr/tests/test_parsers/test_zarr.py
+++ b/virtualizarr/tests/test_parsers/test_zarr.py
@@ -176,6 +176,25 @@ def test_scalar_chunk_mapping(tmpdir, zarr_format):
     assert chunk_dict[""]["length"] > 0
 
 
+@zarr_versions()
+def test_uninitialized_scalar_chunk_mapping(tmpdir, zarr_format):
+    """Test chunk mapping for a scalar array whose chunk was never written.
+
+    This is common for CF grid-mapping / CRS variables, which are scalar arrays
+    that carry only attributes and hold no data, so their single chunk is
+    uninitialized. The parser must produce an empty (all-fill) manifest rather
+    than raising.
+    """
+
+    filepath = f"{tmpdir}/uninitialized_scalar.zarr"
+    zarr.create(shape=(), dtype="int8", store=filepath, zarr_format=zarr_format)
+
+    zarr_store = ObjectStore(store=LocalStore(prefix=filepath))
+    manifest = asyncio.run(_build_manifest(zarr_store, filepath))
+    assert manifest.dict() == {}
+    assert manifest.shape_chunk_grid == ()
+
+
 def test_join_url_empty_base():
     """Test join_url with empty base."""
 


### PR DESCRIPTION
### Summary

`ZarrParser` raised `ValueError: need a chunk grid shape if no chunks given` when parsing a Zarr store containing a **scalar array whose single chunk was never written**. This is extremely common: CF grid-mapping / CRS variables (`projection`, `spatial_ref`, `crs`, …) are scalar arrays that carry only attributes and hold no data, so no chunk object exists in storage.

The scalar branch of `build_chunk_manifest` `HEAD`s the single chunk key (`c` in Zarr V3). When that 404s, the array is uninitialized — the code correctly caught the `FileNotFoundError` but then built `ChunkManifest({})` **without a shape**, which `ChunkManifest.__init__` rejects for an empty entries dict. The non-scalar branch a few lines below already handles this correctly by passing `shape=chunk_grid_shape`; this change makes the scalar branch do the same (the grid shape is `()` for a scalar).

### Reproducer / test

Added `test_uninitialized_scalar_chunk_mapping`, parametrized over Zarr V2 and V3, which creates a scalar array without writing any data and asserts the parser returns an empty manifest with `shape_chunk_grid == ()`. It fails on `main` with the exact `ValueError` above and passes with the fix.

### Traceback this fixes

```
File ".../virtualizarr/parsers/zarr.py", line 368, in build_chunk_manifest
    return ChunkManifest({})
File ".../virtualizarr/manifests/manifest.py", line 226, in __init__
    raise ValueError("need a chunk grid shape if no chunks given")
ValueError: need a chunk grid shape if no chunks given
```

[This is Claude Code on behalf of Tom Nicholas]