### PR TITLE
Fix grib tests against gribberish >=1.3.0 nested group layout

### DIFF
--- a/docs/about/releases.md
+++ b/docs/about/releases.md
@@ -13,6 +13,9 @@
 
 ### Internal changes
 
+- Bump the minimum supported `gribberish` to `>=1.3.0`. From that release the `GribberishParser` groups GRIB messages by level-type and step-type (like cfgrib), nesting variables under subgroups such as `/depth_bls/instant` rather than at the store root. The grib tests now open the source as a `DataTree` via `open_virtual_datatree` and assert against that grouped layout.
+  By [Tom Nicholas](https://github.com/TomNicholas).
+
 ## v2.7.0 (25th June 2026)
 
 Adds a `GribberishParser` for reading GRIB1/GRIB2 files as virtual datasets, a `ManifestArray.with_fill_value_only` constructor, and populates `ds.encoding["source"]` to mirror `xarray.open_dataset`. `ManifestArray` no longer advertises a `.chunks` attribute (a breaking change), which fixes a whole class of cryptic errors when xarray tried to load, compute, or compare virtual arrays. Also fixes the `ZarrParser` and `IcechunkParser` silently dropping arrays nested in subgroups, and bumps the minimum supported `zarr` to `>=3.1.6`. Documentation gains a new ["Validation and Cleaning"](../how_to/validation.md) guide on handling the messy inconsistencies typical of real-world datasets during virtual ingestion, plus a new GOES-16 ingestion example.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ tiff = [
 ]
 # GRIB1/GRIB2 parser, provided by the (Rust-backed) gribberish package.
 grib = [
-    "gribberish>=1.0.0",
+    "gribberish>=1.3.0",
 ]
 kerchunk_parquet = [
    "virtualizarr[remote]",

--- a/virtualizarr/tests/test_parsers/test_grib.py
+++ b/virtualizarr/tests/test_parsers/test_grib.py
@@ -5,19 +5,27 @@ import pytest
 import zarr
 from obspec_utils.registry import ObjectStoreRegistry
 from obstore.store import LocalStore
-from xarray import Dataset
+from xarray import DataTree
 
-from virtualizarr import open_virtual_dataset
+from virtualizarr import open_virtual_datatree
 from virtualizarr.tests import requires_grib
 
 # The GribberishParser (and its zarr codec) are new in gribberish 1.0.0.
-pytest.importorskip("gribberish", minversion="1.0.0")
+# From gribberish >=1.3.0 the parser groups messages by level-type and step-type
+# (like cfgrib), so the soil variables live in a nested "/depth_bls/instant"
+# group rather than at the store root. We open the whole hierarchy as a
+# DataTree and assert against that layout.
+pytest.importorskip("gribberish", minversion="1.3.0")
 
 from gribberish.virtualizarr import GribberishParser  # noqa: E402
 
 # A 1 KB GRIB1 file with 8 ECMWF soil variables on a 4x4 grid. Vendored from the
 # gribberish test suite so this stays a hermetic, offline test.
 FIXTURE = Path(__file__).resolve().parents[1] / "data" / "ecmwf_soil_8vars_tiny.grib1"
+
+# The variables are soil layers (depth below land surface) at a single instant,
+# so gribberish nests them under this group path.
+SOIL_GROUP = "/depth_bls/instant"
 
 # 4 soil-temperature layers + 4 soil-moisture layers.
 EXPECTED_VARS = {"stl1", "stl2", "stl3", "stl4", "swvl1", "swvl2", "swvl3", "swvl4"}
@@ -29,15 +37,16 @@ def _registry_and_url() -> tuple[ObjectStoreRegistry, str]:
 
 
 @requires_grib
-def test_grib_virtual_dataset() -> None:
+def test_grib_virtual_datatree() -> None:
     registry, url = _registry_and_url()
     parser = GribberishParser()
-    with open_virtual_dataset(url=url, parser=parser, registry=registry) as vds:
-        assert isinstance(vds, Dataset)
-        assert set(vds.data_vars) == EXPECTED_VARS
-        assert {"latitude", "longitude"}.issubset(set(vds.coords))
+    with open_virtual_datatree(url=url, parser=parser, registry=registry) as vdt:
+        assert isinstance(vdt, DataTree)
+        ds = vdt[SOIL_GROUP].ds
+        assert set(ds.data_vars) == EXPECTED_VARS
+        assert {"latitude", "longitude"}.issubset(set(ds.coords))
         for name in EXPECTED_VARS:
-            var = vds[name]
+            var = ds[name]
             assert var.dims == ("time", "latitude", "longitude")
             assert var.sizes == {"time": 1, "latitude": 4, "longitude": 4}
 
@@ -46,8 +55,8 @@ def test_grib_virtual_dataset() -> None:
 def test_grib_only_variables() -> None:
     registry, url = _registry_and_url()
     parser = GribberishParser(only_variables=["stl1"])
-    with open_virtual_dataset(url=url, parser=parser, registry=registry) as vds:
-        assert set(vds.data_vars) == {"stl1"}
+    with open_virtual_datatree(url=url, parser=parser, registry=registry) as vdt:
+        assert set(vdt[SOIL_GROUP].ds.data_vars) == {"stl1"}
 
 
 @requires_grib
@@ -58,7 +67,7 @@ def test_grib_chunk_decodes_via_codec() -> None:
     catch a codec that returns garbage rather than just something finite."""
     registry, url = _registry_and_url()
     store = GribberishParser()(url, registry)
-    arr = zarr.open_array(store, path="stl1", mode="r")
+    arr = zarr.open_array(store, path=f"{SOIL_GROUP}/stl1", mode="r")
 
     chunk = np.asarray(arr[0])  # (time0) -> (latitude, longitude)
     np.testing.assert_array_equal(chunk, np.arange(16, dtype=chunk.dtype).reshape(4, 4))


### PR DESCRIPTION
## What

The grib tests are failing on `main` (see the [CI](https://github.com/zarr-developers/VirtualiZarr/actions), which resolves `gribberish==1.5.0`).

## Why

From `gribberish >=1.3.0` the `GribberishParser` groups GRIB messages by level-type and step-type (like cfgrib), nesting variables under subgroups such as `/depth_bls/instant` rather than placing them at the store root. The tests used `open_virtual_dataset` and expected the variables at the root, so they came back empty:

```
assert set() == {'stl1', 'stl2', ...}
```

and the codec test hit `NodeTypeValidationError: ... Got 'group'` opening `stl1` (now a group path) as an array.

## Changes

- Bump the minimum `gribberish` to `>=1.3.0` (the first release producing the nested layout).
- Update the tests to open the source as a `DataTree` via `open_virtual_datatree` and assert against gribberish's current grouped layout, rather than working around the breaking change.
- Changelog entry under *Internal changes*.

Verified all three tests pass against both the new minimum (1.3.0) and latest (1.5.0).