### PR TITLE
Fix IcechunkParser producing wrong-shaped manifest for scalar arrays

### DIFF
--- a/docs/about/releases.md
+++ b/docs/about/releases.md
@@ -11,6 +11,8 @@
 
 - Fix `ZarrParser` raising `ValueError: need a chunk grid shape if no chunks given` when a scalar array's chunk is uninitialized. Scalar variables that carry only attributes and hold no data — such as CF grid-mapping / CRS variables — have no chunk written to storage, so the `HEAD` request 404s. The empty manifest built for this case now passes its (empty) chunk grid shape, matching the non-scalar path.
   By [Tom Nicholas](https://github.com/TomNicholas).
+- Fix `IcechunkParser` building a 1-d `(1,)` chunk manifest (keyed `"0"`) for scalar arrays instead of a 0-d manifest (keyed `""`) matching the array's `()` shape. The `grid_shape or (1,)` fallback coerced the empty (falsy) scalar grid shape to `(1,)`; reshaping to `grid_shape` directly produces the correct 0-d manifest, so scalar values (e.g. a data-bearing scalar, or a CF grid-mapping / CRS variable) round-trip correctly.
+  By [Tom Nicholas](https://github.com/TomNicholas).
 
 ### Documentation
 

--- a/virtualizarr/parsers/icechunk/parser.py
+++ b/virtualizarr/parsers/icechunk/parser.py
@@ -307,10 +307,13 @@ async def _construct_manifest_array(
             coord = tuple(int(x) for x in b_coords[batch_i])
             inlined[coord] = data
 
+    # Reshape the flat buffers to the chunk grid. For a scalar array grid_shape
+    # is () and the single-element buffers reshape to a 0-d manifest (keyed "")
+    # matching the array metadata — not a 1-d (1,) grid.
     chunk_manifest = ChunkManifest.from_arrays(
-        paths=paths.reshape(grid_shape or (1,)),
-        offsets=offsets.reshape(grid_shape or (1,)),
-        lengths=lengths.reshape(grid_shape or (1,)),
+        paths=paths.reshape(grid_shape),
+        offsets=offsets.reshape(grid_shape),
+        lengths=lengths.reshape(grid_shape),
         validate_paths=False,
         inlined=inlined or None,
     )

--- a/virtualizarr/tests/test_parsers/test_icechunk/test_icechunk.py
+++ b/virtualizarr/tests/test_parsers/test_icechunk/test_icechunk.py
@@ -298,7 +298,8 @@ class TestParseSession:
         with_data = ms._group.arrays["with_data"]
         assert with_data.shape == ()
         assert with_data._manifest.shape_chunk_grid == ()
-        assert with_data._manifest.dict()[""]["length"] == 4
+        # 0-d manifest: the single chunk is indexed with an empty tuple, not [0]
+        assert int(with_data._manifest._lengths[()]) == 4
 
         crs_like = ms._group.arrays["crs_like"]
         assert crs_like.shape == ()

--- a/virtualizarr/tests/test_parsers/test_icechunk/test_icechunk.py
+++ b/virtualizarr/tests/test_parsers/test_icechunk/test_icechunk.py
@@ -132,6 +132,20 @@ def nested_icechunk_repo() -> icechunk.Repository:
     return repo
 
 
+@pytest.fixture
+def scalar_icechunk_repo() -> icechunk.Repository:
+    """In-memory icechunk repo with a scalar array holding data and an
+    uninitialized scalar array (as CF grid-mapping / CRS variables are)."""
+    repo = _make_repo(icechunk.in_memory_storage())
+    session = repo.writable_session("main")
+    group = zarr.group(store=session.store, overwrite=True)
+    with_data = group.create_array("with_data", shape=(), dtype="i4", compressors=None)
+    with_data[()] = 42
+    group.create_array("crs_like", shape=(), dtype="i4", compressors=None)
+    session.commit("init scalars")
+    return repo
+
+
 # ----------------------------------------------------------------------
 # parse_session: escape-hatch path
 # ----------------------------------------------------------------------
@@ -263,6 +277,33 @@ class TestParseSession:
             IcechunkParser().parse_session(  # type: ignore[call-arg]
                 session, registry=ObjectStoreRegistry({})
             )
+
+    def test_scalar_array_manifest_shape(
+        self, scalar_icechunk_repo: icechunk.Repository
+    ) -> None:
+        """Scalar arrays must produce a 0-d manifest matching their metadata.
+
+        A scalar has ``metadata.shape == ()`` and a single chunk keyed ``""``.
+        The chunk grid shape is ``()`` (falsy), so the manifest must not be
+        coerced to a 1-d ``(1,)`` grid keyed ``"0"``. Covers both a scalar with
+        data written and an uninitialized scalar (e.g. a CRS variable).
+        """
+        session = scalar_icechunk_repo.readonly_session(branch="main")
+        ms = IcechunkParser().parse_session(
+            session,
+            registry=ObjectStoreRegistry({}),
+            native_chunks_prefix="s3://bucket/repo/chunks",
+        )
+
+        with_data = ms._group.arrays["with_data"]
+        assert with_data.shape == ()
+        assert with_data._manifest.shape_chunk_grid == ()
+        assert with_data._manifest.dict()[""]["length"] == 4
+
+        crs_like = ms._group.arrays["crs_like"]
+        assert crs_like.shape == ()
+        assert crs_like._manifest.shape_chunk_grid == ()
+        assert crs_like._manifest.dict() == {}
 
     def test_round_trip_to_icechunk_writes_valid_chunk_keys(
         self, mixed_icechunk_repo: icechunk.Repository


### PR DESCRIPTION
### Summary

`IcechunkParser` built a **1-d `(1,)` chunk manifest keyed `"0"`** for scalar arrays, instead of a **0-d manifest keyed `""`** matching the array's `()` shape. A scalar's chunk grid shape is `()`, which is falsy, so the `grid_shape or (1,)` fallback in the manifest reshape (`virtualizarr/parsers/icechunk/parser.py`) coerced it to `(1,)`. Reshaping the single-element buffers to `grid_shape` directly yields the correct 0-d manifest.

This produced a manifest inconsistent both with the array metadata and with what `ZarrParser` produces for the same scalar. It did not raise at parse time because `ManifestArray.__init__` does not yet validate manifest-vs-metadata shape consistency (see the `# TODO` in `manifests/array.py`).

### Impact

Scalar variables — including data-bearing scalars and CF grid-mapping / CRS variables (`projection`, `spatial_ref`, `crs`, …) — were mis-indexed. Verified end-to-end: with the fix, a scalar written as `42` reads back as `42` through the resulting `ManifestStore` (and an uninitialized scalar correctly reads its fill value); the manifest now reports `shape_chunk_grid == ()`.

### Test

Added `TestParseSession::test_scalar_array_manifest_shape`, covering both a data-bearing scalar and an uninitialized scalar. It asserts `metadata.shape == ()`, `manifest.shape_chunk_grid == ()`, and the correct chunk keys. Fails on `main` (`assert (1,) == ()`) and passes with the fix.

### Related

Sibling to #1039, which fixes an analogous scalar-handling bug in `ZarrParser` (a crash on uninitialized scalar chunks). This PR is independent and can be reviewed on its own.

[This is Claude Code on behalf of Tom Nicholas]