### PR TITLE
Add virtual GRIB NBM blog post to articles lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ If you see other opportunities then we would love to hear your ideas!
 
 ### Articles
 
+- 2026/07/13 - Earthmover blog - Tom Nicholas and Matt Iannucci - [Virtually Gribberish - Bringing Icechunk clarity to GRIB archives](https://www.earthmover.io/blog/virtual-grib-nbm)
 - 2026/06/02 - Earthmover blog - Tom Nicholas - [Old format, no problem!: Cloud-optimizing the GOES-16 archive as Virtual Zarr](https://www.earthmover.io/blog/virtual-zarr)
 
 ### Talks and Presentations

--- a/docs/index.md
+++ b/docs/index.md
@@ -134,6 +134,7 @@ See the [Usage docs page](how_to/usage.md) for more details.
 
 ## Articles
 
+- 2026/07/13 - Earthmover blog - Tom Nicholas and Matt Iannucci - [Virtually Gribberish - Bringing Icechunk clarity to GRIB archives](https://www.earthmover.io/blog/virtual-grib-nbm)
 - 2026/06/02 - Earthmover blog - Tom Nicholas - [Old format, no problem!: Cloud-optimizing the GOES-16 archive as Virtual Zarr](https://www.earthmover.io/blog/virtual-zarr)
 
 ## Talks and Presentations


### PR DESCRIPTION
Adds a link to the [_Virtually Gribberish - Bringing Icechunk clarity to GRIB archives_](https://www.earthmover.io/blog/virtual-grib-nbm) blog post to the Articles sections of the README and the docs landing page.