### PR TITLE
Propagate drop_variables into HDFParser subgroup recursion

### DIFF
--- a/docs/about/releases.md
+++ b/docs/about/releases.md
@@ -8,6 +8,11 @@
     [ManifestStore.nbytes_virtual][virtualizarr.manifests.ManifestStore.nbytes_virtual] — mirroring `ds.vz.nbytes`. Closes
     [#798](https://github.com/zarr-developers/VirtualiZarr/issues/798).
 
+  ### Bug fixes
+
+  - `HDFParser`'s `drop_variables` is now propagated into subgroup recursion, so a listed name is dropped wherever it appears in the walked group hierarchy instead of only at the level the parser was called on. This allows parsing files whose nested groups contain datasets with dtypes zarr cannot represent (e.g. the compound-dtype `legend` tables in ODIM_H5 weather-radar volumes) by dropping them. Closes [#1057](https://github.com/zarr-developers/VirtualiZarr/issues/1057).
+    By [Alfonso Ladino](https://github.com/aladinor).
+
 
 ## v2.7.1 (15th July 2026)
 

--- a/virtualizarr/parsers/hdf/hdf.py
+++ b/virtualizarr/parsers/hdf/hdf.py
@@ -160,13 +160,14 @@ def _construct_manifest_group(
         # yet supported in zarr-python v3.  We'll drop these variables for the
         # moment until big endian support is included upstream.
 
-        non_coordinate_dimension_vars = _find_non_coord_dimension_vars(group=g)
-        drop_variables = set(drop_variables or ()) | set(non_coordinate_dimension_vars)
+        non_coordinate_dimension_vars = set(_find_non_coord_dimension_vars(group=g))
+        drop_variables = frozenset(drop_variables or ())
         group_name = str(g.name)  # NOTE: this will always include leading "/"
         arrays = {
             key: _construct_manifest_array(filepath, dataset, group_name)
             for key in g.keys()
             if key not in drop_variables
+            if key not in non_coordinate_dimension_vars
             if isinstance(dataset := g[key], h5py.Dataset)
         }
         groups = {
@@ -174,6 +175,7 @@ def _construct_manifest_group(
                 filepath,
                 reader,
                 group=str(Path(group) / key) if group is not None else key,
+                drop_variables=drop_variables,
             )
             for key in g.keys()
             if key not in drop_variables
@@ -192,7 +194,8 @@ class HDFParser:
     group
         Name of the group within the HDF5 file to virtualize.
     drop_variables
-        Variables in the file that will be ignored when creating the ManifestStore
+        Variables in the file that will be ignored when creating the ManifestStore,
+        wherever they appear in the walked group hierarchy
         (default: `None`, do not ignore any variables).
     reader_factory
         A callable that creates a file-like reader from a store and path.

--- a/virtualizarr/tests/test_parsers/conftest.py
+++ b/virtualizarr/tests/test_parsers/conftest.py
@@ -191,6 +191,21 @@ def nested_group_hdf5_url(tmp_path: Path) -> str:
 
 
 @pytest.fixture
+def nested_compound_dtype_hdf5_url(tmp_path: Path) -> str:
+    # "legend" has a dtype zarr cannot represent (compound with a vlen-string
+    # field) and is nested below the root group (GH issue #1057)
+    filepath = str(tmp_path / "nested_compound_dtype.h5")
+
+    with h5py.File(filepath, "w") as f:
+        g = f.create_group("dataset1/quality1")
+        dt = np.dtype([("code", "<i8"), ("class", h5py.string_dtype())])
+        g.create_dataset("legend", data=np.array([(1, "rain")], dtype=dt))
+        f.create_dataset("dataset1/data", data=np.zeros((4, 5)))
+
+    return f"file://{filepath}"
+
+
+@pytest.fixture
 def multiple_datasets_hdf5_url(tmp_path: Path) -> str:
     filepath = str(tmp_path / "multiple_datasets.nc")
 

--- a/virtualizarr/tests/test_parsers/test_hdf/test_hdf.py
+++ b/virtualizarr/tests/test_parsers/test_hdf/test_hdf.py
@@ -201,6 +201,44 @@ class TestManifestGroupFromHDF:
         manifest_store = parser(url=multiple_datasets_hdf5_url, registry=local_registry)
         assert "data2" not in manifest_store._group.arrays.keys()
 
+    def test_drop_variables_in_nested_groups(self, nested_compound_dtype_hdf5_url):
+        # regression test for GH issue #1057: drop_variables must reach nested groups
+        with pytest.raises(ValueError, match="data type"):
+            manifest_store_from_hdf_url(nested_compound_dtype_hdf5_url)
+
+        manifest_store = manifest_store_from_hdf_url(
+            nested_compound_dtype_hdf5_url, drop_variables=["legend"]
+        )
+        assert "legend" not in manifest_store._group["dataset1"]["quality1"].arrays
+        assert "data" in manifest_store._group["dataset1"].arrays
+
+    def test_drop_variables_applies_at_every_depth(self, nested_group_hdf5_url):
+        manifest_store = manifest_store_from_hdf_url(
+            nested_group_hdf5_url, drop_variables=["data"]
+        )
+        assert "data" not in manifest_store._group["group"].arrays
+        assert "data" not in manifest_store._group["group"]["nested_group"].arrays
+
+    def test_drop_variables_group_name_skips_subtree(self, nested_group_hdf5_url):
+        manifest_store = manifest_store_from_hdf_url(
+            nested_group_hdf5_url, drop_variables=["nested_group"]
+        )
+        assert "nested_group" not in manifest_store._group["group"].groups
+        assert "data" in manifest_store._group["group"].arrays
+
+    def test_dimension_var_drops_stay_group_local(self, tmp_path):
+        # an auto-dropped non-coordinate dimension var in one group must not
+        # drop an identically named variable in a sibling group
+        filepath = str(tmp_path / "sibling_dimension_vars.h5")
+        with h5py.File(filepath, "w") as f:
+            dim = f.create_group("a").create_dataset("n", shape=(5,), dtype="<i4")
+            dim.attrs["_Netcdf4Dimid"] = 0
+            f.create_group("b").create_dataset("n", data=np.arange(3))
+
+        manifest_store = manifest_store_from_hdf_url(f"file://{filepath}")
+        assert "n" not in manifest_store._group["a"].arrays
+        assert "n" in manifest_store._group["b"].arrays
+
     def test_dataset_in_group(self, group_hdf5_url):
         manifest_store = manifest_store_from_hdf_url(group_hdf5_url, group="group")
         assert len(manifest_store._group.arrays) == 1

--- a/virtualizarr/tests/utils.py
+++ b/virtualizarr/tests/utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import tempfile
+from collections.abc import Iterable
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -40,8 +41,10 @@ def obstore_http(url: str) -> ObjectStore:
     return store
 
 
-def manifest_store_from_hdf_url(url, group: str | None = None):
+def manifest_store_from_hdf_url(
+    url, group: str | None = None, drop_variables: Iterable[str] | None = None
+):
     registry: ObjectStoreRegistry = ObjectStoreRegistry()
     registry.register(url, obstore_local(url=url))
-    parser = HDFParser(group=group)
+    parser = HDFParser(group=group, drop_variables=drop_variables)
     return parser(url=url, registry=registry)


### PR DESCRIPTION
Closes #1057

## Problem

`HDFParser(drop_variables=[...])` filtered variables only at the group the parser was called on. `_construct_manifest_group`'s recursive call for child groups omitted the parameter, so it reset to `None` at every level of descent — a dropped name nested one group deeper was still parsed. If that nested dataset has a dtype zarr cannot represent (e.g. a compound dtype with a vlen-string field), the whole parse failed even though the user explicitly excluded it. Real-world case: ODIM_H5 weather-radar volumes (FMI's open archive, files from 2026 on) carry compound-dtype `quality*/legend` tables under every sweep group, making any root-group parse impossible.

## Fix

The user-supplied `drop_variables` set now propagates into the subgroup recursion, so a listed name is dropped **wherever it appears in the walked hierarchy** — the semantics the parameter's docstring already implied, and the same behaviour as the Zarr/Icechunk parsers' recursive walks (`construct_manifest_group_tree` applies `skip_variables` at every level).

One subtlety: the per-group auto-detected `non_coordinate_dimension_vars` (the big-endian workaround set) are deliberately **not** propagated — they are level-specific, and leaking them into sibling subtrees could silently drop an identically named, perfectly valid variable. They are now applied only to the current group's datasets comprehension, where they could previously never match a child group's name anyway (they are always dataset names, and HDF5 group namespaces are unique).

## Tests

- `test_drop_variables_in_nested_groups` — the regression: parsing the nested compound-dtype file fails without the drop, succeeds with it (new `nested_compound_dtype_hdf5_url` fixture mirroring the issue MRE)
- `test_drop_variables_applies_at_every_depth` — a name present at two depths is dropped at both
- `test_drop_variables_group_name_skips_subtree` — a group name in `drop_variables` skips the whole subtree
- `test_dimension_var_drops_stay_group_local` — an auto-dropped dimension var in one group does not drop an identically named variable in a sibling group

`manifest_store_from_hdf_url` (test helper) gained a `drop_variables` passthrough so the new tests follow the module's existing pattern.