### PR TITLE
fix: restore compatibility with zarr 3.3.0

### DIFF
--- a/docs/about/releases.md
+++ b/docs/about/releases.md
@@ -8,6 +8,18 @@
     [ManifestStore.nbytes_virtual][virtualizarr.manifests.ManifestStore.nbytes_virtual] — mirroring `ds.vz.nbytes`. Closes
     [#798](https://github.com/zarr-developers/VirtualiZarr/issues/798).
 
+  ### Bug fixes
+
+  - Fix `AttributeError: 'str' object has no attribute 'value'` when writing Kerchunk references with
+    zarr >= 3.3.0. Zarr 3.3.0 deprecated its string-valued codec enums, so `BytesCodec.endian` is now a
+    plain string rather than an `Endian` member; `convert_v3_to_v2_metadata` now handles both forms.
+  - Fix `HDF4Parser` raising `ValueError: Chunk size must be positive, got 0` with zarr >= 3.3.0 on files
+    containing a zero-length variable — e.g. a MODIS fire-mask granule that detected no fires, whose
+    `FP_*` fire-pixel variables all have shape `(0,)`. `kerchunk.hdf4` uses such a variable's dimensions
+    as its chunk shape, and zarr now (correctly) requires chunk edges to be positive, so the parser
+    coerces a zero-length chunk edge to 1 — matching what the Kerchunk reference translator already does
+    when reading those references back.
+
 
 ## v2.7.1 (15th July 2026)
 

--- a/virtualizarr/parsers/hdf4.py
+++ b/virtualizarr/parsers/hdf4.py
@@ -1,11 +1,52 @@
-from collections.abc import Iterable
+import threading
+from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
 from pathlib import Path
+from typing import Any
 
 from obspec_utils.registry import ObjectStoreRegistry
 
 from virtualizarr.manifests import ManifestStore
 from virtualizarr.parsers.kerchunk.translator import manifestgroup_from_kerchunk_refs
 from virtualizarr.types.kerchunk import KerchunkStoreRefs
+
+# Serializes the monkeypatch in _positive_chunk_edges, which mutates zarr.Group
+# for the duration of a single kerchunk translation.
+_patch_lock = threading.Lock()
+
+
+@contextmanager
+def _positive_chunk_edges() -> Iterator[None]:
+    """
+    Clamp zero-sized chunk edges requested by `kerchunk.hdf4` to 1.
+
+    HDF4 granules routinely hold zero-length variables — a MODIS fire-mask granule
+    that detected no fires stores every one of its 27 `FP_*` fire-pixel variables
+    with shape `(0,)`. `HDF4ToZarr.translate` passes those zero-length dimensions
+    through as the chunk shape (`chunks=v.get("chunks", v["dims"])`), which zarr
+    rejects from 3.3.0 onwards because a chunk edge must be positive. A zero-length
+    array holds no chunks whatever its chunk shape, so coercing the edge to 1 is
+    lossless, and it matches what `from_kerchunk_refs` already does when reading
+    such references back.
+
+    TODO: Remove once kerchunk clamps the chunk shape itself.
+    """
+    import zarr
+
+    with _patch_lock:
+        original = zarr.Group.require_array
+
+        def require_array(self: zarr.Group, name: str, **kwargs: Any) -> Any:
+            chunks = kwargs.get("chunks")
+            if isinstance(chunks, Iterable):
+                kwargs["chunks"] = tuple(edge or 1 for edge in chunks)
+            return original(self, name, **kwargs)
+
+        zarr.Group.require_array = require_array  # type: ignore[method-assign]
+        try:
+            yield
+        finally:
+            zarr.Group.require_array = original  # type: ignore[method-assign]
 
 
 class HDF4Parser:
@@ -55,9 +96,10 @@ class HDF4Parser:
         from kerchunk.hdf4 import HDF4ToZarr
 
         # handle inconsistency in kerchunk, see GH issue https://github.com/zarr-developers/VirtualiZarr/issues/160
-        refs = KerchunkStoreRefs(
-            {"refs": HDF4ToZarr(url, **self.reader_options).translate()}
-        )
+        with _positive_chunk_edges():
+            refs = KerchunkStoreRefs(
+                {"refs": HDF4ToZarr(url, **self.reader_options).translate()}
+            )
 
         manifestgroup = manifestgroup_from_kerchunk_refs(
             refs,

--- a/virtualizarr/tests/test_parsers/test_hdf4.py
+++ b/virtualizarr/tests/test_parsers/test_hdf4.py
@@ -42,6 +42,19 @@ def test_hdf4_skip_variables() -> None:
 
 
 @requires_kerchunk
+def test_hdf4_zero_length_variables() -> None:
+    """This granule detected no fires, so every `FP_*` fire-pixel variable has
+    shape (0,). Kerchunk reports a chunk edge of 0 for them, which Zarr rejects,
+    so the parser coerces the edge to 1 without altering the (empty) shape."""
+    registry, url = _registry_and_url()
+    store = HDF4Parser()(url, registry)
+    marr = store._group.arrays["FP_line"]
+    assert marr.shape == (0,)
+    assert marr.metadata.chunks == (1,)
+    assert marr.manifest.shape_chunk_grid == (0,)
+
+
+@requires_kerchunk
 def test_hdf4_chunk_decodes_via_codec() -> None:
     """Read the "fire mask" array back through its byte references and zlib
     codec, asserting the exact max value the kerchunk test suite checks for."""

--- a/virtualizarr/utils.py
+++ b/virtualizarr/utils.py
@@ -96,6 +96,17 @@ def determine_chunk_grid_shape(
     return tuple(ceildiv(length, chunksize) for length, chunksize in zip(shape, chunks))
 
 
+def _codec_endianness(codec: ArrayBytesCodec) -> str | None:
+    """
+    Return a codec's endianness as ``"little"``, ``"big"``, or ``None``.
+
+    zarr < 3.3 types ``BytesCodec.endian`` as an ``Endian`` enum, whereas
+    zarr >= 3.3 types it as a plain string, so unwrap the enum when present.
+    """
+    endian = getattr(codec, "endian", None)
+    return getattr(endian, "value", endian)
+
+
 def convert_v3_to_v2_metadata(
     v3_metadata: ArrayV3Metadata, fill_value: Any = None
 ) -> ArrayV2Metadata:
@@ -125,9 +136,7 @@ def convert_v3_to_v2_metadata(
     # This logic is based on the (default) Bytes codec's endian property,
     # but other codec pipelines could store endianness elsewhere.
     big_endian = any(
-        isinstance(codec, ArrayBytesCodec)
-        and getattr(codec, "endian", None) is not None
-        and codec.endian.value == "big"  # type: ignore[attr-defined]
+        isinstance(codec, ArrayBytesCodec) and _codec_endianness(codec) == "big"
         for codec in v3_metadata.codecs
     )
     if big_endian:


### PR DESCRIPTION
This should close out #1060, sorry for the breakage!

🤖 AI text below 🤖

Two independent breakages under zarr 3.3.0 (566 passing -> 43 failures):

1. zarr 3.3.0 deprecated its string-valued codec enums, so `BytesCodec.endian` is now a plain string rather than an `Endian` member. `convert_v3_to_v2_metadata` did `codec.endian.value`, raising `AttributeError: 'str' object has no attribute 'value'` on every Kerchunk write path (40 failures). Unwrap the enum only when present so both forms work across the supported `zarr>=3.1.6` range.

2. zarr 3.3.0 requires chunk edges to be positive. `kerchunk.hdf4` uses a variable's dimensions as its chunk shape, so a zero-length variable -- e.g. the `FP_*` fire-pixel variables of a MODIS granule that detected no fires -- asks zarr for `chunks=[0]` and raises `ValueError: Chunk size must be positive, got 0` (3 failures). Coerce such an edge to 1 for the duration of the translation, matching what `from_kerchunk_refs` already does when reading those references back.

Verified green against zarr 3.3.0, 3.2.1, and 3.1.6.

Assisted-by: ClaudeCode:claude-opus-5

# What I did
<!-- Please describe what you did and why -->

Acceptance criteria:
<!-- Feel free to remove check-list items that aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] No test coverage regression
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/about/releases.md`
- [ ] New functions/methods are listed in an appropriate `*.md` file under `docs/api`
- [ ] New functionality has documentation
