### PR TITLE
fix: return empty dict from ChunkManifest.dict() for zero-length arrays

### DIFF
--- a/docs/about/releases.md
+++ b/docs/about/releases.md
@@ -8,6 +8,13 @@
     [ManifestStore.nbytes_virtual][virtualizarr.manifests.ManifestStore.nbytes_virtual] — mirroring `ds.vz.nbytes`. Closes
     [#798](https://github.com/zarr-developers/VirtualiZarr/issues/798).
 
+  ### Bug fixes
+
+  - Fix `ChunkManifest.dict()` raising `ValueError: Iteration of zero-sized operands is not enabled` for a zero-length
+    array (a chunk grid shape containing a `0`), which also broke `.keys()`/`.values()`/`.items()` and writing such a
+    variable to Kerchunk references. A zero-length array legitimately has no chunks, so `dict()` now returns `{}`;
+    `iter_refs()` had the same `np.nditer` problem and now yields nothing.
+
 
 ## v2.7.1 (15th July 2026)
 

--- a/virtualizarr/manifests/manifest.py
+++ b/virtualizarr/manifests/manifest.py
@@ -453,6 +453,10 @@ class ChunkManifest:
         Entries whose path is ``MISSING_CHUNK_PATH`` will be interpreted as missing chunks and omitted from the dictionary.
         Entries whose path is ``INLINED_CHUNK_PATH`` have their data stored in memory and are included.
         """
+        if self._paths.size == 0:
+            # a zero-length array has no chunks, and np.nditer refuses zero-sized operands
+            return cast(ChunkDict, {})
+
         coord_vectors = np.mgrid[
             tuple(slice(None, length) for length in self.shape_chunk_grid)
         ]
@@ -520,6 +524,10 @@ class ChunkManifest:
 
     def iter_refs(self) -> Iterator[tuple[tuple[int, ...], ChunkEntry]]:
         """Yield (grid_indices, chunk_entry) for every non-missing chunk."""
+        if self._paths.size == 0:
+            # a zero-length array has no chunks, and np.nditer refuses zero-sized operands
+            return
+
         coord_vectors = np.mgrid[
             tuple(slice(None, length) for length in self.shape_chunk_grid)
         ]

--- a/virtualizarr/tests/test_manifests/test_manifest.py
+++ b/virtualizarr/tests/test_manifests/test_manifest.py
@@ -196,6 +196,18 @@ class TestCreateManifest:
         with pytest.raises(ValueError, match="Invalid format for chunk key"):
             ChunkManifest(entries=chunks)
 
+    @pytest.mark.parametrize("shape", [(0,), (0, 0), (2, 0), (0, 2)])
+    def test_zero_sized_chunk_grid(self, shape):
+        """A zero-length array has no chunks, so the manifest should be empty rather than raise."""
+        manifest = ChunkManifest(entries={}, shape=shape)
+        assert len(manifest) == 0
+        assert manifest.dict() == {}
+        assert list(manifest.keys()) == []
+        assert list(manifest.values()) == []
+        assert list(manifest.items()) == []
+        assert list(manifest.iter_refs()) == []
+        assert list(manifest.iter_nonempty_paths()) == []
+
     def test_remove_chunks_with_empty_paths(self):
         chunks = {
             "0.0.0": {"path": "", "offset": 0, "length": 100},


### PR DESCRIPTION
This fixes a bug I observed when working on #1061 

"🤖 AI text below 🤖"

A chunk grid shape containing a 0 made np.nditer raise "ValueError: Iteration of zero-sized operands is not enabled", which also broke keys()/values()/items() and writing such a variable to Kerchunk references. A zero-length array legitimately has no chunks, so dict() now short-circuits to {}. iter_refs() had the same problem and now yields nothing.

Assisted-by: ClaudeCode:claude-opus-5

# What I did
<!-- Please describe what you did and why -->

Acceptance criteria:
<!-- Feel free to remove check-list items that aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] No test coverage regression
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/about/releases.md`
- [ ] New functions/methods are listed in an appropriate `*.md` file under `docs/api`
- [ ] New functionality has documentation
