### PR TITLE
Only treat chunk-key-shaped keys as chunks in ZarrParser

### DIFF
--- a/docs/about/releases.md
+++ b/docs/about/releases.md
@@ -10,6 +10,15 @@
 
   ### Bug fixes
 
+  - Fix `ZarrParser` raising `ValueError: invalid literal for int()` when a store contains zero-byte
+    "directory marker" objects, which are common on S3 (created by e.g. `aws s3 sync`, `s3fs`, or
+    `boto3.put_object(Key=prefix + "/")`). `obstore` strips the trailing slash from such a key before it
+    reaches the parser, so it could not be filtered out by its trailing slash and was instead parsed as a
+    chunk coordinate. Rather than matching markers by name, only keys shaped like a genuine chunk key — a
+    literal descendant of the array's chunks prefix with exactly one coordinate component per dimension —
+    are now treated as chunks, which also covers markers for *nested* chunk subdirectories (e.g. `air/c/0/`
+    alongside the chunk `air/c/0/0`).
+    By [Sanjay Santhanam](https://github.com/Sanjays2402) and [Tom Nicholas](https://github.com/TomNicholas).
   - Fix `ZarrParser` raising `ValueError: invalid literal for int()` for Zarr V2 stores written with
     `dimension_separator="/"` (chunk keys like `data/0/0`). The on-disk separator was hardcoded to
     `"."` for V2 instead of reading the array's `dimension_separator`.

--- a/virtualizarr/parsers/zarr.py
+++ b/virtualizarr/parsers/zarr.py
@@ -386,7 +386,12 @@ async def build_chunk_manifest(
         array_path, on_disk_zarr_format.chunks_dir_prefix
     )
     stripped_keys, full_paths, all_lengths = await build_1d_chunk_mapping(
-        obs_store, store_base_uri, nonscalar_chunks_prefix, on_disk_zarr_format
+        obs_store,
+        store_base_uri,
+        nonscalar_chunks_prefix,
+        on_disk_zarr_format,
+        on_disk_separator,
+        len(metadata.shape),
     )
 
     if len(stripped_keys) == 0:
@@ -421,6 +426,8 @@ async def build_1d_chunk_mapping(
     store_base_uri: str,
     array_chunks_prefix: str,
     zarr_format: ZarrFormat,
+    chunk_key_separator: str,
+    ndim: int,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """
     Build chunk mapping by listing the object store with obstore.
@@ -438,6 +445,11 @@ async def build_1d_chunk_mapping(
         Store-relative prefix to list and strip from chunk keys (e.g. "air/c/").
     zarr_format
         The zarr format version.
+    chunk_key_separator
+        The chunk key separator used on disk (e.g. ``"."`` or ``"/"``).
+    ndim
+        Number of dimensions of the array, i.e. how many coordinate components a
+        genuine chunk key has.
 
     Returns
     -------
@@ -454,14 +466,26 @@ async def build_1d_chunk_mapping(
         sizes_np = batch.column("size").to_numpy()
 
         # filter out metadata and directory keys, leaving only valid chunk keys
-        # (assumes that there are no other objects inside this directory)
         is_metadata = np.zeros(len(paths_np), dtype=bool)
         for suffix in zarr_format.metadata_key_names:
             is_metadata |= np.strings.endswith(paths_np, suffix)
-        is_directory = np.strings.endswith(paths_np, "/") | (
-            (sizes_np == 0) & (paths_np == array_chunks_prefix.rstrip("/"))
-        )
-        chunk_keys_mask = ~(is_metadata | is_directory)
+        is_directory = np.strings.endswith(paths_np, "/")
+
+        # Zero-byte "directory marker" objects (created by e.g. `aws s3 sync`, `s3fs`,
+        # or `boto3.put_object(Key=prefix + "/")`) are keyed with a trailing slash, but
+        # obstore's client-side path parsing strips that slash before the listed path
+        # reaches here, so `is_directory` above can never catch them. Rather than
+        # matching markers by name, keep only keys shaped like a genuine chunk key:
+        # a literal descendant of the prefix with exactly one coordinate component per
+        # dimension. A marker for the chunks directory itself ends up one character
+        # shorter than the prefix, and a marker for a nested chunk subdirectory (only
+        # possible when the separator is "/") ends up short a component, so both fail.
+        is_descendant = np.strings.startswith(paths_np, array_chunks_prefix)
+        relative_keys = np.strings.replace(paths_np, array_chunks_prefix, "", 1)
+        n_components = np.strings.count(relative_keys, chunk_key_separator) + 1
+        has_chunk_key_shape = is_descendant & (n_components == ndim)
+
+        chunk_keys_mask = ~(is_metadata | is_directory) & has_chunk_key_shape
 
         path_batches.append(paths_np[chunk_keys_mask])
         size_batches.append(sizes_np[chunk_keys_mask])

--- a/virtualizarr/tests/test_parsers/test_zarr.py
+++ b/virtualizarr/tests/test_parsers/test_zarr.py
@@ -369,6 +369,84 @@ def test_build_chunk_manifest_skips_normalized_directory_marker():
     assert next(iter(chunk_dict.values()))["length"] == 32
 
 
+@pytest.mark.parametrize(
+    "zarr_format,separator,listed_keys,expected_key",
+    [
+        # marker for a chunk subdirectory, which only exists when chunk keys are
+        # themselves nested (V2 dimension_separator="/", or any V3 array)
+        pytest.param(
+            ZarrFormat.V2,
+            "/",
+            {"x/0/0": 4, "x/0": 0, "x": 0},
+            "0.0",
+            id="v2-nested-marker",
+        ),
+        pytest.param(
+            ZarrFormat.V3,
+            "/",
+            {"x/c/0/0": 4, "x/c/0": 0, "x/c": 0},
+            "0.0",
+            id="v3-nested-marker",
+        ),
+        # an object keyed at the chunks prefix itself that isn't zero-byte, so
+        # isn't recognisable as a directory marker by its size
+        pytest.param(
+            ZarrFormat.V2,
+            "/",
+            {"x/0/0": 4, "x": 7},
+            "0.0",
+            id="v2-nonempty-object-at-prefix",
+        ),
+    ],
+)
+def test_build_chunk_manifest_skips_nested_directory_markers(
+    zarr_format, separator, listed_keys, expected_key
+):
+    """Only keys shaped like a genuine chunk key (one coordinate component per
+    dimension, nested under the chunks prefix) are treated as chunks.
+
+    obstore strips the trailing slash from a listed directory marker's key, so a
+    marker for a *nested* chunk subdirectory (e.g. ``x/0/`` alongside the chunk
+    ``x/0/0``) arrives looking like a chunk key one component short. Regression
+    test for the nested case left open by #1054.
+    """
+    # arro3 is an optional dependency, so it can't be imported at module scope
+    from arro3.core import Array, RecordBatch
+
+    class FabricatedListingStore:
+        async def list_async(self, *, prefix, return_arrow):
+            paths = Array.from_numpy(np.array(list(listed_keys), dtype="U16"))
+            sizes = Array.from_numpy(
+                np.array(list(listed_keys.values()), dtype=np.uint64)
+            )
+            yield RecordBatch.from_arrays([paths, sizes], names=["path", "size"])
+
+    metadata_store = ObjectStore(store=ObsMemoryStore())
+    zarr_array = zarr.create(
+        shape=(10, 10),
+        chunks=(5, 5),
+        dtype="int8",
+        store=metadata_store,
+        zarr_format=zarr_format.value,
+    )
+    metadata = metadata_as_v3(zarr_array.metadata)
+
+    manifest = asyncio.run(
+        build_chunk_manifest(
+            obs_store=FabricatedListingStore(),
+            array_path="x",
+            store_base_uri="memory://bucket/store.zarr",
+            metadata=metadata,
+            on_disk_zarr_format=zarr_format,
+            on_disk_separator=separator,
+        )
+    )
+
+    chunk_dict = manifest.dict()
+    assert set(chunk_dict) == {expected_key}
+    assert chunk_dict[expected_key]["length"] == 4
+
+
 @zarr_versions()
 def test_sparse_array_with_missing_chunks(tmpdir, zarr_format):
     """Test that arrays with some missing chunks (sparse arrays) are handled correctly."""


### PR DESCRIPTION
Follow-up to #1054 (which fixed #1052). Supersedes #1055, now closed.

## Why

#1054 identifies a directory marker by name: a zero-byte object whose key equals the array's chunks prefix with its trailing slash stripped. Since `obstore`'s client-side path parsing strips the trailing slash from *any* listed marker key, that leaves two related cases still crashing with `ValueError: invalid literal for int()`:

- **Nested markers.** A marker for a chunk *subdirectory* — e.g. `air/c/0/` sitting alongside the chunk `air/c/0/0` — arrives as `air/c/0`, which does start with the prefix and so passes #1054's check, but is one coordinate component short. This affects any V3 array with more than one dimension, and V2 stores with `dimension_separator="/"` (support for which just landed in #1066). `aws s3 sync` and `s3fs` create a marker per directory level, so a store that has the top-level marker generally has these too.
- **A non-zero-byte object keyed at the chunks prefix itself**, which isn't identifiable as a marker by its size.

## Fix

Filter on the invariant rather than on the marker's spelling: a genuine chunk key is a literal descendant of `array_chunks_prefix` with exactly one coordinate component per dimension.

```python
is_descendant = np.strings.startswith(paths_np, array_chunks_prefix)
relative_keys = np.strings.replace(paths_np, array_chunks_prefix, "", 1)
n_components = np.strings.count(relative_keys, chunk_key_separator) + 1
has_chunk_key_shape = is_descendant & (n_components == ndim)
```

A marker for the chunks directory itself ends up one character *shorter* than the prefix, and a nested marker ends up short a component, so both fail regardless of whether the trailing slash survived. This also protects the `np.strings.replace(all_paths, array_chunks_prefix, "", 1)` below it, which would otherwise pass a non-descendant key through unstripped.

`build_1d_chunk_mapping` now takes the on-disk separator and `ndim` to do the component count. The separator it uses is the same `on_disk_separator` already used to split the keys back into coordinates, so the two stay consistent by construction.

## Test plan

- Added `test_build_chunk_manifest_skips_nested_directory_markers`, parametrized over the V2 nested marker, the V3 nested marker, and a non-zero-byte object at the prefix. All three fail on `main` with the reported `ValueError` and pass here; #1054's existing regression test still passes.
- As in #1054, no in-memory or local `obstore` backend reproduces the S3-specific slash-stripping (writes and lists are normalized the same way there), so the tests fabricate the listing shape a real S3 store returns and feed it through `build_chunk_manifest`.
- `pytest virtualizarr/tests` passes locally (541 passed, 25 skipped); `ruff check`/`ruff format` clean; `mypy` reports only the pre-existing `icechunk/parser.py` error.

Also adds the release note that #1054 didn't include, crediting @Sanjays2402 for the original fix.

## Known remaining gap (not addressed here)

A V3 array whose `chunk_key_encoding` separator is `"."` (keys like `air/c.0.0`) still won't be read at all, because `ZarrFormat.chunks_dir_prefix` hardcodes `"c/"` and so lists a prefix that matches nothing. That's a pre-existing limitation unrelated to directory markers — happy to open a separate issue for it.