### PR TITLE
Fix ZarrParser and ZippedZarrParser silently dropping all chunks for a V3 array with a "." chunk key separator

### DIFF
--- a/docs/about/releases.md
+++ b/docs/about/releases.md
@@ -19,6 +19,14 @@
 
   ### Bug fixes
 
+  - Fix `ZarrParser` and `ZippedZarrParser` silently returning an **empty chunk manifest** for a Zarr V3 array
+    whose `chunk_key_encoding` separator is `"."` (chunk keys like `air/c.0.0` rather than `air/c/0/0`), which
+    made such an array read back as entirely fill-value with no error raised. The chunk key prefix was
+    hardcoded to `air/c/`, which matches no such key. It is now derived from the array's separator, and
+    `ZarrParser` lists the array's own directory rather than that prefix, since `obstore` matches a list prefix
+    one whole path component at a time and so would match nothing at all for a prefix ending mid-component
+    (`air/c.`). Closes [#1069](https://github.com/zarr-developers/VirtualiZarr/issues/1069).
+    By [Tom Nicholas](https://github.com/TomNicholas).
   - Fix `ZarrParser` raising `ValueError: invalid literal for int()` when a store contains zero-byte
     "directory marker" objects, which are common on S3 (created by e.g. `aws s3 sync`, `s3fs`, or
     `boto3.put_object(Key=prefix + "/")`). `obstore` strips the trailing slash from such a key before it

--- a/virtualizarr/parsers/zarr/common.py
+++ b/virtualizarr/parsers/zarr/common.py
@@ -79,13 +79,21 @@ class ZarrFormat(Enum):
             case ZarrFormat.V3:
                 return "c"
 
-    @property
-    def chunks_dir_prefix(self) -> str:
+    def chunks_prefix(self, separator: ChunkKeySeparator) -> str:
+        """
+        Prefix that every non-scalar chunk key of an array shares, relative to the
+        array's own path.
+
+        V3 keys are prefixed with ``"c"`` joined to the coordinates by the array's chunk
+        key separator, so this is a directory only when that separator is ``"/"``
+        (e.g. ``"c/"`` for ``air/c/0/0``, but ``"c."`` for ``air/c.0.0``). V2 keys carry
+        no prefix at all.
+        """
         match self:
             case ZarrFormat.V2:
                 return ""
             case ZarrFormat.V3:
-                return "c/"
+                return f"c{separator}"
 
 
 def join_url(base: str, key: str) -> str:

--- a/virtualizarr/parsers/zarr/zarr.py
+++ b/virtualizarr/parsers/zarr/zarr.py
@@ -236,14 +236,15 @@ async def build_chunk_manifest(
             }
         )
 
-    # Build 1d array of all initialized chunk paths and their lengths
-    nonscalar_chunks_prefix = join_url(
-        array_path, on_disk_zarr_format.chunks_dir_prefix
-    )
+    # Build 1d array of all initialized chunk paths and their lengths.
+    # Listing the array's own directory (rather than the chunk key prefix) keeps this
+    # correct when that prefix isn't a whole path component, e.g. "air/c." for a V3
+    # array whose chunk key separator is "." — see chunks_prefix.
     stripped_keys, full_paths, all_lengths = await build_1d_chunk_mapping(
         obs_store,
         store_base_uri,
-        nonscalar_chunks_prefix,
+        join_url(array_path, ""),
+        join_url(array_path, on_disk_zarr_format.chunks_prefix(on_disk_separator)),
         on_disk_zarr_format,
         on_disk_separator,
         len(metadata.shape),
@@ -262,6 +263,7 @@ async def build_chunk_manifest(
 async def build_1d_chunk_mapping(
     obs_store: ObstoreStore,
     store_base_uri: str,
+    list_prefix: str,
     array_chunks_prefix: str,
     zarr_format: ZarrFormat,
     chunk_key_separator: str,
@@ -279,8 +281,13 @@ async def build_1d_chunk_mapping(
         The obstore ObjectStore to list.
     store_base_uri
         The base URI of the store (e.g. "s3://bucket/store.zarr"), used to construct full chunk paths.
+    list_prefix
+        Store-relative path prefix to list (e.g. "air/"). obstore matches a list prefix
+        one whole path component at a time, so this must end at a "/" boundary even when
+        ``array_chunks_prefix`` doesn't.
     array_chunks_prefix
-        Store-relative prefix to list and strip from chunk keys (e.g. "air/c/").
+        Store-relative prefix that every chunk key starts with, and which is stripped to
+        get the chunk's coordinates (e.g. "air/c/", "air/c.", or "air/").
     zarr_format
         The zarr format version.
     chunk_key_separator
@@ -295,7 +302,7 @@ async def build_1d_chunk_mapping(
     """
     path_batches: list[np.ndarray] = []
     size_batches: list[np.ndarray] = []
-    stream = obs_store.list_async(prefix=array_chunks_prefix, return_arrow=True)
+    stream = obs_store.list_async(prefix=list_prefix, return_arrow=True)
     async for batch in stream:
         # Immediately convert to numpy arrays - we can still do efficient manipulations, and don't need any extra arrow dependencies.
         # Note: The .astype is only needed because .to_numpy converts to a numpy object array of python `str` objects, which is inefficient.

--- a/virtualizarr/parsers/zarr/zip.py
+++ b/virtualizarr/parsers/zarr/zip.py
@@ -365,9 +365,7 @@ async def _construct_manifest_array(
             )
         return ManifestArray(metadata=metadata, chunkmanifest=chunk_manifest)
 
-    chunks_prefix = join_url(array_path, on_disk_format.chunks_dir_prefix)
-    if not chunks_prefix.endswith("/"):
-        chunks_prefix += "/"
+    chunks_prefix = join_url(array_path, on_disk_format.chunks_prefix(separator))
 
     chunk_keys: list[str] = []
     offsets: list[int] = []

--- a/virtualizarr/tests/test_parsers/test_zarr.py
+++ b/virtualizarr/tests/test_parsers/test_zarr.py
@@ -786,3 +786,41 @@ def test_v2_slash_dimension_separator(tmp_path, local_registry):
         loadable_variables=["data"],
     ) as vds:
         np.testing.assert_array_equal(vds["data"].values, expected)
+
+
+@pytest.mark.parametrize("group_path", ["", "nested"], ids=["root", "in-group"])
+def test_v3_dot_chunk_key_separator(tmp_path, local_registry, group_path):
+    """Zarr V3 arrays may use a "." chunk key separator, giving chunk keys like
+    "data/c.0.0" rather than "data/c/0/0". Regression test for #1069."""
+    store_path = tmp_path / "dot_sep.zarr"
+    root = zarr.create_group(str(store_path), zarr_format=3)
+    group = root.create_group(group_path) if group_path else root
+    arr = group.create_array(
+        "data",
+        shape=(4, 6),
+        chunks=(2, 3),
+        dtype="float64",
+        chunk_key_encoding={"name": "default", "separator": "."},
+        dimension_names=["x", "y"],
+    )
+    expected = np.arange(24, dtype="float64").reshape(4, 6)
+    arr[:] = expected
+
+    with open_virtual_dataset(
+        url=f"file://{store_path}",
+        registry=local_registry,
+        parser=ZarrParser(group=group_path or None),
+        loadable_variables=[],
+    ) as vds:
+        manifest = vds["data"].data.manifest.dict()
+        assert set(manifest.keys()) == {"0.0", "0.1", "1.0", "1.1"}
+        # the manifest must point at the real (dot-separated) chunk keys
+        assert manifest["0.0"]["path"].endswith(f"{group_path}/data/c.0.0".lstrip("/"))
+
+    with open_virtual_dataset(
+        url=f"file://{store_path}",
+        registry=local_registry,
+        parser=ZarrParser(group=group_path or None),
+        loadable_variables=["data"],
+    ) as vds:
+        np.testing.assert_array_equal(vds["data"].values, expected)

--- a/virtualizarr/tests/test_parsers/test_zip.py
+++ b/virtualizarr/tests/test_parsers/test_zip.py
@@ -217,3 +217,47 @@ def test_scalar_array(tmp_path, local_registry):
         loadable_variables=["scalar"],
     ) as vds:
         xr.testing.assert_identical(vds, ds)
+
+
+def test_v3_dot_chunk_key_separator(tmp_path, local_registry):
+    """Zarr V3 arrays may use a "." chunk key separator, giving members like
+    "air/c.0.0" rather than "air/c/0/0". Regression test for #1069."""
+    ds = _test_dataset()
+    zip_path = tmp_path / "dot_sep.zarr.zip"
+    store = ZipStore(zip_path, mode="w")
+    try:
+        ds.to_zarr(
+            store,
+            zarr_format=3,
+            consolidated=False,
+            encoding={
+                "air": {
+                    "chunks": (2, 3, 2),
+                    "chunk_key_encoding": {
+                        "name": "default",
+                        "configuration": {"separator": "."},
+                    },
+                }
+            },
+        )
+    finally:
+        store.close()
+
+    with zipfile.ZipFile(zip_path) as zf:
+        assert "air/c.0.0.0" in zf.namelist()
+
+    with open_virtual_dataset(
+        url=f"file://{zip_path}",
+        registry=local_registry,
+        parser=ZippedZarrParser(),
+        loadable_variables=[],
+    ) as vds:
+        assert set(vds["air"].data.manifest.dict()) == {"0.0.0", "1.0.0"}
+
+    with open_virtual_dataset(
+        url=f"file://{zip_path}",
+        registry=local_registry,
+        parser=ZippedZarrParser(),
+        loadable_variables=list(ds.variables),
+    ) as vds:
+        xr.testing.assert_identical(vds, ds)


### PR DESCRIPTION
Closes #1069. Rebased onto current `main`, which now includes the `ZippedZarrParser` from #1065 — that parser has the same bug on its own code path, so this fixes both.

## The bug

A Zarr V3 array whose `chunk_key_encoding` separator is `"."` stores its chunks as `air/c.0.0`, not `air/c/0/0`. `ZarrFormat.chunks_dir_prefix` hardcoded `"c/"`, which matches no such key, so **neither parser found any chunks at all**. The empty result then took the "no initialized chunks found" path, so the array came back with an empty manifest and **no error raised** — i.e. it read as entirely fill-value. Silent wrong data rather than a crash, which is why this is worth fixing rather than just erroring.

Confirmed for both parsers: manifest `[]` before, `['0.0', '0.1', '1.0', '1.1']` after.

## The fix

`chunks_dir_prefix` becomes `chunks_prefix(separator)`, returning `f"c{separator}"` for V3 and `""` for V2.

For `ZippedZarrParser` that's the whole fix — it filters an in-memory index of archive members by that prefix, so a plain string prefix is exactly right. Its `if not chunks_prefix.endswith("/")` fixup goes away, since it would have corrupted `air/c.` into `air/c./`.

For `ZarrParser` it isn't sufficient on its own, which is the part I had wrong in my note on #1068: **obstore matches a list prefix one whole path component at a time**, so a prefix ending mid-component matches nothing either.

```
'air/c.' -> []
'air/c'  -> []
'air/'   -> ['air/c.0.0', 'air/c.0.1', 'air/c.1.0', 'air/c.1.1', 'air/zarr.json']
```

So the prefix was quietly doing two different jobs there — the thing to LIST, and the thing that identifies and gets stripped from chunk keys — which only coincide when the separator is `"/"`. This splits them:

- `list_prefix` — the array's own directory (`air/`), always a whole path component.
- `array_chunks_prefix` — what a chunk key starts with and what's stripped to get its coordinates (`air/c/`, `air/c.`, or `air/` for V2).

The existing `startswith`/component-count filter from #1068 then does the rest of the work unchanged — the extra `zarr.json` that listing the array directory now surfaces was already filtered as metadata.

## Test plan

- `test_v3_dot_chunk_key_separator` in `test_zarr.py`, parametrized over a root-level and an in-group array, mirroring `test_v2_slash_dimension_separator`. Checks the manifest keys, that the manifest paths point at the real dot-separated chunk keys, and that the values load back correctly.
- `test_v3_dot_chunk_key_separator` in `test_zip.py`, asserting the archive really does contain `air/c.0.0.0`, then checking the manifest keys and a full `assert_identical` round-trip.
- All of these fail on `main` with an empty manifest and pass here.
- Manually verified all eight combinations of {V2, V3} x {`.`, `/`} x {root, nested group} produce the right manifest keys and chunk paths.
- `pytest virtualizarr/tests` passes locally (615 passed, 27 skipped); `ruff check` clean over `virtualizarr/`; `mypy` reports only the pre-existing `icechunk/parser.py` error.