### PR TITLE
Fix sharded arrays losing their shard config on axis changes

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -126,6 +126,21 @@ BLOSC_CODEC = {
 ZLIB_CODEC = {"name": "numcodecs.zlib", "configuration": {"level": 1}}
 
 
+def sharding_codec(
+    inner_chunk_shape: tuple[int, ...], inner_codecs: list[dict] | None = None
+) -> dict:
+    """A `sharding_indexed` codec config splitting each shard into `inner_chunk_shape` chunks."""
+    return {
+        "name": "sharding_indexed",
+        "configuration": {
+            "chunk_shape": inner_chunk_shape,
+            "codecs": inner_codecs or [ARRAYBYTES_CODEC],
+            "index_codecs": [ARRAYBYTES_CODEC, {"name": "crc32c"}],
+            "index_location": "end",
+        },
+    }
+
+
 # Helper functions
 def _generate_chunk_entries(
     shape: tuple[int, ...],

--- a/docs/about/releases.md
+++ b/docs/about/releases.md
@@ -8,9 +8,25 @@
 
 ### Bug fixes
 
+- Concatenating, stacking, broadcasting or indexing virtual arrays that use the `sharding_indexed` codec
+  now works. Operations that add or remove a length-1 axis realign the shard's inner `chunk_shape` to
+  match the array's new dimensionality, instead of leaving a stale config that zarr rejects with
+  *"The shard's `chunk_shape` and array's `shape` need to have the same number of dimensions."*
+  Relatedly, operations on a sharded array now consistently treat a *shard* as the unit that a chunk
+  manifest entry locates — previously they used `ArrayV3Metadata.chunks`, which zarr defines as the
+  *inner* chunk shape when sharding is in play, so e.g. a stacked sharded array came out with an inner
+  chunk shape as its outer chunk grid. Closes
+  [#1076](https://github.com/zarr-developers/VirtualiZarr/issues/1076).
+  By [Tom Nicholas](https://github.com/TomNicholas).
+
 ### Documentation
 
 ### Internal changes
+
+- Added `virtualizarr.manifests.utils.manifest_chunk_shape`, the shape of the region that one chunk
+  manifest entry locates (a shard, for sharded arrays), and used it in place of `ArrayV3Metadata.chunks`
+  wherever that meaning was intended.
+  By [Tom Nicholas](https://github.com/TomNicholas).
 
 
 ## v2.7.2 (5th August 2026)

--- a/virtualizarr/manifests/array.py
+++ b/virtualizarr/manifests/array.py
@@ -332,7 +332,9 @@ class ManifestArray:
         new_metadata = dataclasses.replace(self.metadata, fill_value=fill_value)
         empty_manifest = ChunkManifest(
             entries={},
-            shape=determine_chunk_grid_shape(self.shape, self.metadata.chunks),
+            shape=determine_chunk_grid_shape(
+                self.shape, utils.manifest_chunk_shape(self.metadata)
+            ),
         )
         return ManifestArray(metadata=new_metadata, chunkmanifest=empty_manifest)
 

--- a/virtualizarr/manifests/array_api.py
+++ b/virtualizarr/manifests/array_api.py
@@ -13,6 +13,7 @@ from .utils import (
     check_same_shapes,
     check_same_shapes_except_on_concat_axis,
     copy_and_replace_metadata,
+    manifest_chunk_shape,
 )
 
 if TYPE_CHECKING:
@@ -99,7 +100,7 @@ def where(condition, x, y, /):
 def _missing_element_mask(marr: "ManifestArray") -> np.ndarray:
     """Boolean element-mask (shape == marr.shape), True at missing (null) chunks."""
     mask = marr.manifest._paths == MISSING_CHUNK_PATH
-    for axis, chunk_size in enumerate(marr.metadata.chunks):
+    for axis, chunk_size in enumerate(manifest_chunk_shape(marr.metadata)):
         mask = np.repeat(mask, chunk_size, axis=axis)
     return mask[tuple(slice(0, length) for length in marr.shape)]
 
@@ -137,7 +138,7 @@ def concatenate(
         axis = axis % first_arr.ndim
 
     arr_shapes = [arr.shape for arr in arrays]
-    arr_chunks = [arr.metadata.chunks for arr in arrays]
+    arr_chunks = [manifest_chunk_shape(arr.metadata) for arr in arrays]
     check_same_shapes_except_on_concat_axis(arr_shapes, axis)
     check_no_partial_chunks_on_concat_axis(arr_shapes, arr_chunks, axis)
 
@@ -199,7 +200,7 @@ def stack(
     stacked_manifest = _stack_manifests([arr.manifest for arr in arrays], axis=axis)
 
     # chunk shape has changed because a length-1 axis has been inserted
-    old_chunks = first_arr.metadata.chunks
+    old_chunks = manifest_chunk_shape(first_arr.metadata)
     new_chunks = list(old_chunks)
     new_chunks.insert(axis, 1)
 
@@ -237,7 +238,7 @@ def broadcast_to(x: "ManifestArray", /, shape: tuple[int, ...]) -> "ManifestArra
 
     # new chunk_shape is old chunk_shape with singleton dimensions prepended
     # (chunk shape can never change by more than adding length-1 axes because each chunk represents a fixed number of array elements)
-    old_chunk_shape = x.metadata.chunks
+    old_chunk_shape = manifest_chunk_shape(x.metadata)
     new_chunk_shape = _prepend_singleton_dimensions(
         old_chunk_shape, ndim=len(new_shape)
     )

--- a/virtualizarr/manifests/indexing.py
+++ b/virtualizarr/manifests/indexing.py
@@ -8,7 +8,10 @@ from zarr.core.metadata.v3 import ArrayV3Metadata
 from virtualizarr.manifests.array_api import expand_dims
 from virtualizarr.manifests.manifest import ChunkManifest
 from virtualizarr.manifests.reindex import chunk_map_from_indexer, reindex_axis
-from virtualizarr.manifests.utils import copy_and_replace_metadata
+from virtualizarr.manifests.utils import (
+    copy_and_replace_metadata,
+    manifest_chunk_shape,
+)
 
 # indexer with only basic selectors, no new axes or ellipsis
 T_BasicIndexer_1d: TypeAlias = int | slice | np.ndarray
@@ -199,7 +202,7 @@ def _apply_reindex(
     for axis, raw_indexer_1d in enumerate(indexers):
         indexer_1d = _collapse_outer_indexer(raw_indexer_1d, axis)
         if _is_reindex_indexer(indexer_1d):
-            chunk_size = result.metadata.chunks[axis]
+            chunk_size = manifest_chunk_shape(result.metadata)[axis]
             try:
                 chunk_map = chunk_map_from_indexer(
                     np.asarray(indexer_1d), chunk_size, result.shape[axis]
@@ -276,7 +279,12 @@ def apply_selection(
     # The byte adjustment is uniform across every surviving chunk, since chunks share layout.
     sub_chunk_byte_adjust: tuple[int, int] | None = None
     for axis, (axis_length, chunk_size, indexer_1d) in enumerate(
-        zip(marr.shape, marr.metadata.chunks, narrowed_indexers, strict=True)
+        zip(
+            marr.shape,
+            manifest_chunk_shape(marr.metadata),
+            narrowed_indexers,
+            strict=True,
+        )
     ):
         chunk_grid_selector: int | slice
         if axis == sub_chunk_axis and _is_sub_chunk_slice(
@@ -288,7 +296,9 @@ def apply_selection(
                     axis_length=axis_length,
                     chunk_size=chunk_size,
                     other_axis_chunks=tuple(
-                        c for i, c in enumerate(marr.metadata.chunks) if i != axis
+                        c
+                        for i, c in enumerate(manifest_chunk_shape(marr.metadata))
+                        if i != axis
                     ),
                     itemsize=marr.dtype.itemsize,
                 )

--- a/virtualizarr/manifests/store.py
+++ b/virtualizarr/manifests/store.py
@@ -19,7 +19,7 @@ from zarr.core.common import BytesLike
 
 from virtualizarr.manifests.array import ManifestArray
 from virtualizarr.manifests.group import ManifestGroup
-from virtualizarr.manifests.utils import parse_manifest_index
+from virtualizarr.manifests.utils import manifest_chunk_shape, parse_manifest_index
 
 if TYPE_CHECKING:
     from obstore.store import (
@@ -408,7 +408,10 @@ def _warn_about_oversized_virtual_chunks(vds: "xr.Dataset") -> None:
         name
         for name, var in vds.variables.items()
         if isinstance(var.data, ManifestArray)
-        and any(c > s for c, s in zip(var.data.metadata.chunks, var.data.shape))
+        and any(
+            c > s
+            for c, s in zip(manifest_chunk_shape(var.data.metadata), var.data.shape)
+        )
     ]
     if oversized:
         warnings.warn(

--- a/virtualizarr/manifests/utils.py
+++ b/virtualizarr/manifests/utils.py
@@ -364,6 +364,18 @@ def manifest_chunk_shape(
     For a sharded array this is the *shard* shape, because each manifest entry points at
     a whole shard. Note this is deliberately not ``ArrayV3Metadata.chunks``, which zarr
     defines as the shape of an *inner* chunk when a sharding codec is present.
+
+    Parameters
+    ----------
+    metadata
+        Metadata of the array whose manifest unit is wanted. Zarr V2 metadata is accepted
+        because [check_combinable_zarr_arrays][virtualizarr.manifests.utils.check_combinable_zarr_arrays]
+        may be handed a V2 `zarr.Array` alongside `ManifestArray`s.
+
+    Returns
+    -------
+    The shape covered by one manifest entry: the shard shape if `metadata` has a sharding
+    codec, else the chunk shape.
     """
     if not isinstance(metadata, ArrayV3Metadata):
         # Zarr V2 has no sharding, so a chunk is the manifest's unit
@@ -391,6 +403,28 @@ def _realign_inner_chunk_shape(
     so: an ambiguous position holds a 1 in the outer shape, so the inner shape must hold
     a 1 there too (it divides the outer), and inserting or dropping a 1 on either side of
     an existing 1 gives the same result.
+
+    Parameters
+    ----------
+    old_chunks
+        The outer chunk shape before the change of axes, i.e. one shard.
+    new_chunks
+        The outer chunk shape after the change of axes. Must be `old_chunks` with length-1
+        axes added and/or removed.
+    old_inner_chunks
+        The shard's inner chunk shape, on `old_chunks`' axes. Same length as `old_chunks`,
+        and divides it element-wise.
+
+    Returns
+    -------
+    `old_inner_chunks` mapped onto `new_chunks`' axes, with a 1 at each added axis and the
+    entry at each dropped axis removed. Same length as `new_chunks`.
+
+    Raises
+    ------
+    ValueError
+        If `new_chunks` is not `old_chunks` with length-1 axes added or removed, so no
+        alignment exists.
     """
     new_inner_chunks: list[int] = []
     old_axis = new_axis = 0
@@ -426,6 +460,24 @@ def _realign_sharding_codecs(
 
     Zarr requires a shard's inner chunk shape to have the same number of dimensions as
     the array, so changing an array's axes means changing the shard config to match.
+
+    Parameters
+    ----------
+    codecs
+        A codec pipeline, as plain dicts (i.e. straight out of `ArrayV3Metadata.to_dict`).
+        Codecs other than `sharding_indexed` are passed through untouched.
+    old_chunks
+        The chunk shape these codecs currently encode, on the old axes. For a top-level
+        pipeline this is the array's outer chunk shape; when recursing into a nested shard
+        it is the enclosing shard's inner chunk shape.
+    new_chunks
+        The same shape on the new axes, as `old_chunks` with length-1 axes added and/or
+        removed.
+
+    Returns
+    -------
+    A new codec list. Sharding codecs are deep-copied with their inner `chunk_shape`
+    realigned, so the input dicts are never mutated.
     """
     updated = []
     for codec in codecs:
@@ -459,8 +511,35 @@ def copy_and_replace_metadata(
     """
     Update metadata to reflect a new shape and/or chunk shape.
 
-    ``new_chunks`` is the outer chunk shape, i.e. the shard shape for a sharded array -
-    see [manifest_chunk_shape][virtualizarr.manifests.utils.manifest_chunk_shape].
+    Parameters
+    ----------
+    old_metadata
+        Metadata to copy from. Never mutated.
+    new_shape
+        Replacement array shape, or None to keep the existing one.
+    new_chunks
+        Replacement *outer* chunk shape - the shard shape for a sharded array, see
+        [manifest_chunk_shape][virtualizarr.manifests.utils.manifest_chunk_shape] - or None
+        to keep the existing one. If this changes the number of axes, any sharding codec's
+        inner `chunk_shape` is realigned onto the new axes to match; the change must then
+        be length-1 axes added and/or removed, since a chunk covers a fixed number of
+        elements.
+    new_dimension_names
+        Replacement dimension names, or None to clear them. Defaults to the sentinel
+        `"default"`, meaning leave them as they are - None cannot serve as that sentinel
+        because it is itself a valid value for zarr's `dimension_names`.
+    new_attributes
+        Replacement attributes dict, or None to keep the existing one.
+
+    Returns
+    -------
+    New metadata with the requested replacements applied.
+
+    Raises
+    ------
+    ValueError
+        If `new_chunks` changes the number of axes by anything other than adding or
+        removing length-1 axes, leaving a sharding codec's inner chunk shape unalignable.
     """
     # TODO this should really be upstreamed into zarr-python
 

--- a/virtualizarr/manifests/utils.py
+++ b/virtualizarr/manifests/utils.py
@@ -1,11 +1,13 @@
+import copy
 import functools
 import re
 import typing
-from typing import TYPE_CHECKING, Any, Dict, Iterable, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterable, Literal, Optional, Union, cast
 
 import numpy as np
 from zarr import Array
 from zarr.core.chunk_key_encodings import ChunkKeyEncodingLike
+from zarr.core.metadata.v2 import ArrayV2Metadata
 from zarr.core.metadata.v3 import (
     ArrayV3Metadata,
     parse_dimension_names,
@@ -16,7 +18,16 @@ from zarr.dtype import parse_data_type
 from virtualizarr.codecs import convert_to_codec_pipeline, get_codecs
 
 if TYPE_CHECKING:
+    from zarr.core.metadata.v3 import RegularChunkGridMetadata
+
     from .array import ManifestArray
+else:
+    try:
+        from zarr.core.metadata.v3 import RegularChunkGridMetadata  # zarr-python>3.1.6
+    except ImportError:
+        from zarr.core.metadata.v3 import (
+            RegularChunkGrid as RegularChunkGridMetadata,  # zarr-python<=3.1.6
+        )
 
 ChunkKeySeparator = Literal[".", "/"]
 # Tuple of literal values specified in the Literal type above
@@ -332,7 +343,7 @@ def check_combinable_zarr_arrays(
     check_same_codecs([get_codecs(arr) for arr in arrays])
 
     # Would require variable-length chunks ZEP
-    check_same_chunk_shapes([arr.metadata.chunks for arr in arrays])
+    check_same_chunk_shapes([manifest_chunk_shape(arr.metadata) for arr in arrays])
 
 
 def check_compatible_arrays(
@@ -344,6 +355,100 @@ def check_compatible_arrays(
     check_same_shapes_except_on_concat_axis(arr_shapes, append_axis)
 
 
+def manifest_chunk_shape(
+    metadata: Union[ArrayV3Metadata, "ArrayV2Metadata"],
+) -> tuple[int, ...]:
+    """
+    The shape of the region of the array that one chunk manifest entry locates.
+
+    For a sharded array this is the *shard* shape, because each manifest entry points at
+    a whole shard. Note this is deliberately not ``ArrayV3Metadata.chunks``, which zarr
+    defines as the shape of an *inner* chunk when a sharding codec is present.
+    """
+    if not isinstance(metadata, ArrayV3Metadata):
+        # Zarr V2 has no sharding, so a chunk is the manifest's unit
+        return tuple(metadata.chunks)
+    return tuple(cast("RegularChunkGridMetadata", metadata.chunk_grid).chunk_shape)
+
+
+def _realign_inner_chunk_shape(
+    old_chunks: tuple[int, ...],
+    new_chunks: tuple[int, ...],
+    old_inner_chunks: tuple[int, ...],
+) -> tuple[int, ...]:
+    """
+    Carry a shard's inner chunk shape across a change of axes in the outer chunk shape.
+
+    An outer chunk shape can only ever change by adding or removing length-1 axes - a
+    chunk covers a fixed number of array elements, so any other change would describe
+    different chunks. Adding an axis (`stack`, `expand_dims`, `broadcast_to`) gives the
+    inner shape a 1 in the same place; removing one (integer indexing, which is only
+    legal where the chunk length is already 1) drops the corresponding inner axis. Both
+    leave the inner chunk grid, the C-order shard index layout, and every inner chunk's
+    bytes untouched, so the encoded shard stays byte-for-byte valid.
+
+    Where ``old_chunks`` already contains 1s the alignment is ambiguous, but harmlessly
+    so: an ambiguous position holds a 1 in the outer shape, so the inner shape must hold
+    a 1 there too (it divides the outer), and inserting or dropping a 1 on either side of
+    an existing 1 gives the same result.
+    """
+    new_inner_chunks: list[int] = []
+    old_axis = new_axis = 0
+    while old_axis < len(old_chunks) or new_axis < len(new_chunks):
+        if (
+            old_axis < len(old_chunks)
+            and new_axis < len(new_chunks)
+            and old_chunks[old_axis] == new_chunks[new_axis]
+        ):
+            new_inner_chunks.append(old_inner_chunks[old_axis])
+            old_axis += 1
+            new_axis += 1
+        elif new_axis < len(new_chunks) and new_chunks[new_axis] == 1:
+            new_inner_chunks.append(1)  # axis added
+            new_axis += 1
+        elif old_axis < len(old_chunks) and old_chunks[old_axis] == 1:
+            old_axis += 1  # axis dropped
+        else:
+            raise ValueError(
+                f"chunk shape {new_chunks} is not {old_chunks} with length-1 axes added "
+                "or removed, so it cannot describe the same chunks"
+            )
+    return tuple(new_inner_chunks)
+
+
+def _realign_sharding_codecs(
+    codecs: Iterable[dict[str, Any]],
+    old_chunks: tuple[int, ...],
+    new_chunks: tuple[int, ...],
+) -> list[dict[str, Any]]:
+    """
+    Realign the inner ``chunk_shape`` of any ``sharding_indexed`` codec onto new axes.
+
+    Zarr requires a shard's inner chunk shape to have the same number of dimensions as
+    the array, so changing an array's axes means changing the shard config to match.
+    """
+    updated = []
+    for codec in codecs:
+        if codec.get("name") != "sharding_indexed":
+            updated.append(codec)
+            continue
+
+        codec = copy.deepcopy(codec)
+        configuration = codec["configuration"]
+        old_inner_chunks = tuple(configuration["chunk_shape"])
+        new_inner_chunks = _realign_inner_chunk_shape(
+            old_chunks, new_chunks, old_inner_chunks
+        )
+        configuration["chunk_shape"] = new_inner_chunks
+        # shards may themselves contain shards, for which this shard's inner chunk shape
+        # is in turn the outer one
+        configuration["codecs"] = _realign_sharding_codecs(
+            configuration["codecs"], old_inner_chunks, new_inner_chunks
+        )
+        updated.append(codec)
+    return updated
+
+
 def copy_and_replace_metadata(
     old_metadata: ArrayV3Metadata,
     new_shape: list[int] | None = None,
@@ -353,6 +458,9 @@ def copy_and_replace_metadata(
 ) -> ArrayV3Metadata:
     """
     Update metadata to reflect a new shape and/or chunk shape.
+
+    ``new_chunks`` is the outer chunk shape, i.e. the shard shape for a sharded array -
+    see [manifest_chunk_shape][virtualizarr.manifests.utils.manifest_chunk_shape].
     """
     # TODO this should really be upstreamed into zarr-python
 
@@ -361,10 +469,20 @@ def copy_and_replace_metadata(
     if new_shape is not None:
         metadata_copy["shape"] = parse_shapelike(new_shape)  # type: ignore[assignment]
     if new_chunks is not None:
+        old_chunks = manifest_chunk_shape(old_metadata)
+        new_chunks = list(new_chunks)
         metadata_copy["chunk_grid"] = {
             "name": "regular",
             "configuration": {"chunk_shape": tuple(new_chunks)},
         }
+        if len(new_chunks) != len(old_chunks):
+            # a sharding codec's inner chunk_shape must match the array's ndim, so it has
+            # to gain or lose the same length-1 axes the outer chunk shape just did
+            metadata_copy["codecs"] = _realign_sharding_codecs(
+                cast(list[dict[str, Any]], metadata_copy["codecs"]),
+                old_chunks,
+                tuple(new_chunks),
+            )
     if new_dimension_names != "default":
         # need the option to use the literal string "default" as a sentinel value because None is a valid choice for zarr dimension_names
         metadata_copy["dimension_names"] = parse_dimension_names(new_dimension_names)

--- a/virtualizarr/tests/test_manifests/test_array.py
+++ b/virtualizarr/tests/test_manifests/test_array.py
@@ -5,6 +5,7 @@ from zarr.core.metadata.v3 import ArrayV3Metadata
 from conftest import (
     ARRAYBYTES_CODEC,
     ZLIB_CODEC,
+    sharding_codec,
 )
 from virtualizarr.manifests import ChunkManifest, ManifestArray
 from virtualizarr.manifests.indexing import SubChunkIndexingError
@@ -638,6 +639,118 @@ class TestStack:
         codec_dict = result.metadata.codecs[1].to_dict()
         assert codec_dict["name"] == "numcodecs.zlib"
         assert result.metadata.fill_value == metadata.fill_value
+
+
+class TestSharded:
+    """
+    Adding a length-1 axis to a sharded array must add it to the shard config too,
+    otherwise zarr rejects the metadata for having a 2D shard on an N-D array.
+    """
+
+    @pytest.fixture
+    def sharded_marr(self, array_v3_metadata):
+        metadata = array_v3_metadata(
+            shape=(90, 180),
+            chunks=(90, 180),
+            data_type=np.dtype("float32"),
+            codecs=[sharding_codec((45, 45))],
+        )
+        manifest = ChunkManifest(
+            entries={"0.0": {"path": "/foo.zarr", "offset": 0, "length": 1000}}
+        )
+        return ManifestArray(metadata=metadata, chunkmanifest=manifest)
+
+    def test_expand_dims(self, sharded_marr):
+        result = np.expand_dims(sharded_marr, axis=0)
+
+        assert result.shape == (1, 90, 180)
+        assert result.metadata.shards == (1, 90, 180)
+        assert result.metadata.chunks == (1, 45, 45)
+        assert result.manifest.dict() == {
+            "0.0.0": {"path": "file:///foo.zarr", "offset": 0, "length": 1000}
+        }
+
+    def test_expand_dims_trailing_axis(self, sharded_marr):
+        result = np.expand_dims(sharded_marr, axis=2)
+
+        assert result.shape == (90, 180, 1)
+        assert result.metadata.chunks == (45, 45, 1)
+
+    def test_stack(self, sharded_marr):
+        result = np.stack([sharded_marr, sharded_marr], axis=0)
+
+        assert result.shape == (2, 90, 180)
+        assert result.metadata.shards == (1, 90, 180)
+        assert result.metadata.chunks == (1, 45, 45)
+
+    def test_broadcast_to_new_axis(self, sharded_marr):
+        result = np.broadcast_to(sharded_marr, shape=(3, 90, 180))
+
+        assert result.shape == (3, 90, 180)
+        assert result.metadata.shards == (1, 90, 180)
+        assert result.metadata.chunks == (1, 45, 45)
+
+    def test_concatenate_leaves_shard_config_alone(self, sharded_marr):
+        result = np.concatenate([sharded_marr, sharded_marr], axis=0)
+
+        assert result.shape == (180, 180)
+        assert result.metadata.chunks == (45, 45)
+
+    def test_full_slice_is_a_noop(self, sharded_marr):
+        # the manifest's unit is the shard, so a full slice selects the whole (1, 1)
+        # chunk grid and must short-circuit rather than subset it as if it were the
+        # 2x4 grid of inner chunks
+        result = sharded_marr[:, :]
+
+        assert result is sharded_marr
+
+    def test_integer_index_drops_axis(self, array_v3_metadata):
+        metadata = array_v3_metadata(
+            shape=(2, 90, 180),
+            chunks=(1, 90, 180),
+            data_type=np.dtype("float32"),
+            codecs=[sharding_codec((1, 45, 45))],
+        )
+        manifest = ChunkManifest(
+            entries={
+                "0.0.0": {"path": "/foo.zarr", "offset": 0, "length": 1000},
+                "1.0.0": {"path": "/foo.zarr", "offset": 1000, "length": 1000},
+            }
+        )
+        marr = ManifestArray(metadata=metadata, chunkmanifest=manifest)
+
+        result = marr[1, :, :]
+
+        assert result.shape == (90, 180)
+        assert result.metadata.shards == (90, 180)
+        assert result.metadata.chunks == (45, 45)
+        assert result.manifest.dict() == {
+            "0.0": {"path": "file:///foo.zarr", "offset": 1000, "length": 1000}
+        }
+
+    def test_shard_aligned_slice(self, array_v3_metadata):
+        metadata = array_v3_metadata(
+            shape=(180, 180),
+            chunks=(90, 180),
+            data_type=np.dtype("float32"),
+            codecs=[sharding_codec((45, 45))],
+        )
+        manifest = ChunkManifest(
+            entries={
+                "0.0": {"path": "/foo.zarr", "offset": 0, "length": 1000},
+                "1.0": {"path": "/foo.zarr", "offset": 1000, "length": 1000},
+            }
+        )
+        marr = ManifestArray(metadata=metadata, chunkmanifest=manifest)
+
+        result = marr[90:180, :]
+
+        assert result.shape == (90, 180)
+        assert result.metadata.shards == (90, 180)
+        assert result.metadata.chunks == (45, 45)
+        assert result.manifest.dict() == {
+            "0.0": {"path": "file:///foo.zarr", "offset": 1000, "length": 1000}
+        }
 
 
 class TestStackInlined:

--- a/virtualizarr/tests/test_manifests/test_array.py
+++ b/virtualizarr/tests/test_manifests/test_array.py
@@ -660,21 +660,77 @@ class TestSharded:
         )
         return ManifestArray(metadata=metadata, chunkmanifest=manifest)
 
-    def test_expand_dims(self, sharded_marr):
+    def test_expand_dims_keeps_pointing_at_the_same_shard(self, sharded_marr):
         result = np.expand_dims(sharded_marr, axis=0)
 
         assert result.shape == (1, 90, 180)
-        assert result.metadata.shards == (1, 90, 180)
-        assert result.metadata.chunks == (1, 45, 45)
         assert result.manifest.dict() == {
             "0.0.0": {"path": "file:///foo.zarr", "offset": 0, "length": 1000}
         }
 
-    def test_expand_dims_trailing_axis(self, sharded_marr):
-        result = np.expand_dims(sharded_marr, axis=2)
+    @pytest.mark.parametrize(
+        "axis, expected_shards, expected_chunks",
+        [
+            (0, (1, 90, 180), (1, 45, 45)),
+            (1, (90, 1, 180), (45, 1, 45)),
+            (2, (90, 180, 1), (45, 45, 1)),
+        ],
+    )
+    def test_expand_dims_at_every_position(
+        self, sharded_marr, axis, expected_shards, expected_chunks
+    ):
+        result = np.expand_dims(sharded_marr, axis=axis)
 
-        assert result.shape == (90, 180, 1)
-        assert result.metadata.chunks == (45, 45, 1)
+        assert result.metadata.shards == expected_shards
+        assert result.metadata.chunks == expected_chunks
+
+    def test_expand_dims_when_shard_shape_already_contains_ones(
+        self, array_v3_metadata
+    ):
+        # aligning (1, 45) onto (1, 1, 45) is ambiguous - the new axis could be read as
+        # either of the leading two - but both readings put a 1 next to an existing 1,
+        # so the inner chunk shape comes out the same either way
+        metadata = array_v3_metadata(
+            shape=(1, 180),
+            chunks=(1, 180),
+            data_type=np.dtype("float32"),
+            codecs=[sharding_codec((1, 45))],
+        )
+        marr = ManifestArray(
+            metadata=metadata,
+            chunkmanifest=ChunkManifest(
+                entries={"0.0": {"path": "/foo.zarr", "offset": 0, "length": 1000}}
+            ),
+        )
+
+        result = np.expand_dims(marr, axis=0)
+
+        assert result.metadata.shards == (1, 1, 180)
+        assert result.metadata.chunks == (1, 1, 45)
+
+    def test_expand_dims_nested_shards(self, array_v3_metadata):
+        # a shard's inner chunks may themselves be shards, so every level has to gain
+        # the new axis
+        metadata = array_v3_metadata(
+            shape=(90, 180),
+            chunks=(90, 180),
+            data_type=np.dtype("float32"),
+            codecs=[sharding_codec((45, 90), inner_codecs=[sharding_codec((45, 45))])],
+        )
+        marr = ManifestArray(
+            metadata=metadata,
+            chunkmanifest=ChunkManifest(
+                entries={"0.0": {"path": "/foo.zarr", "offset": 0, "length": 1000}}
+            ),
+        )
+
+        result = np.expand_dims(marr, axis=0)
+
+        assert result.metadata.shards == (1, 90, 180)
+        assert result.metadata.chunks == (1, 45, 90)
+        (outer_shard,) = result.metadata.codecs
+        (inner_shard,) = outer_shard.codecs
+        assert inner_shard.chunk_shape == (1, 45, 45)
 
     def test_stack(self, sharded_marr):
         result = np.stack([sharded_marr, sharded_marr], axis=0)
@@ -689,6 +745,13 @@ class TestSharded:
         assert result.shape == (3, 90, 180)
         assert result.metadata.shards == (1, 90, 180)
         assert result.metadata.chunks == (1, 45, 45)
+
+    def test_broadcast_to_multiple_new_axes(self, sharded_marr):
+        result = np.broadcast_to(sharded_marr, shape=(2, 3, 90, 180))
+
+        assert result.shape == (2, 3, 90, 180)
+        assert result.metadata.shards == (1, 1, 90, 180)
+        assert result.metadata.chunks == (1, 1, 45, 45)
 
     def test_concatenate_leaves_shard_config_alone(self, sharded_marr):
         result = np.concatenate([sharded_marr, sharded_marr], axis=0)

--- a/virtualizarr/tests/test_utils.py
+++ b/virtualizarr/tests/test_utils.py
@@ -35,131 +35,22 @@ def test_copy_and_replace_metadata(array_v3_metadata):
     assert updated_metadata.fill_value == old_metadata.fill_value
 
 
-class TestCopyAndReplaceMetadataSharding:
+def test_copy_and_replace_metadata_rejects_non_axis_change(array_v3_metadata):
     """
-    A sharding codec's inner chunk_shape must have the same ndim as the array, so adding
-    length-1 axes to the outer chunk shape has to add them to the shard config too.
+    Guard on an internal invariant: an outer chunk shape can only change by adding or
+    removing length-1 axes, so a sharding codec's inner chunk shape can always be
+    realigned onto the new axes. No array operation can currently violate this - this
+    tests the defensive branch directly, so a future caller gets a clear error rather
+    than a silently mismatched shard config.
     """
+    old_metadata = array_v3_metadata(
+        shape=(90, 180),
+        chunks=(90, 180),
+        data_type=np.dtype("float32"),
+        codecs=[_sharding_codec((45, 45))],
+    )
 
-    def test_prepended_axis(self, array_v3_metadata):
-        old_metadata = array_v3_metadata(
-            shape=(90, 180),
-            chunks=(90, 180),
-            data_type=np.dtype("float32"),
-            codecs=[_sharding_codec((45, 45))],
+    with pytest.raises(ValueError, match="length-1 axes added or removed"):
+        copy_and_replace_metadata(
+            old_metadata, new_shape=(2, 90, 180), new_chunks=(2, 90, 180)
         )
-
-        updated_metadata = copy_and_replace_metadata(
-            old_metadata, new_shape=(1, 90, 180), new_chunks=(1, 90, 180)
-        )
-
-        assert updated_metadata.shards == (1, 90, 180)
-        assert updated_metadata.chunks == (1, 45, 45)
-
-    def test_axis_inserted_in_middle(self, array_v3_metadata):
-        old_metadata = array_v3_metadata(
-            shape=(90, 180),
-            chunks=(90, 180),
-            data_type=np.dtype("float32"),
-            codecs=[_sharding_codec((45, 45))],
-        )
-
-        updated_metadata = copy_and_replace_metadata(
-            old_metadata, new_shape=(90, 1, 180), new_chunks=(90, 1, 180)
-        )
-
-        assert updated_metadata.chunks == (45, 1, 45)
-
-    def test_multiple_prepended_axes(self, array_v3_metadata):
-        old_metadata = array_v3_metadata(
-            shape=(90, 180),
-            chunks=(90, 180),
-            data_type=np.dtype("float32"),
-            codecs=[_sharding_codec((45, 45))],
-        )
-
-        updated_metadata = copy_and_replace_metadata(
-            old_metadata, new_shape=(1, 1, 90, 180), new_chunks=(1, 1, 90, 180)
-        )
-
-        assert updated_metadata.chunks == (1, 1, 45, 45)
-
-    def test_nested_shards(self, array_v3_metadata):
-        old_metadata = array_v3_metadata(
-            shape=(90, 180),
-            chunks=(90, 180),
-            data_type=np.dtype("float32"),
-            codecs=[
-                _sharding_codec((45, 90), inner_codecs=[_sharding_codec((45, 45))])
-            ],
-        )
-
-        updated_metadata = copy_and_replace_metadata(
-            old_metadata, new_shape=(1, 90, 180), new_chunks=(1, 90, 180)
-        )
-
-        (outer_shard,) = updated_metadata.codecs
-        assert outer_shard.chunk_shape == (1, 45, 90)
-        (inner_shard,) = outer_shard.codecs
-        assert inner_shard.chunk_shape == (1, 45, 45)
-
-    def test_ambiguous_alignment_when_old_chunks_contain_ones(self, array_v3_metadata):
-        # (1, 45) could align with either the first or second axis of (1, 1, 45), but
-        # both readings insert a 1 next to an existing 1, so the result is the same
-        old_metadata = array_v3_metadata(
-            shape=(1, 180),
-            chunks=(1, 180),
-            data_type=np.dtype("float32"),
-            codecs=[_sharding_codec((1, 45))],
-        )
-
-        updated_metadata = copy_and_replace_metadata(
-            old_metadata, new_shape=(1, 1, 180), new_chunks=(1, 1, 180)
-        )
-
-        assert updated_metadata.chunks == (1, 1, 45)
-
-    def test_dropped_axis(self, array_v3_metadata):
-        # integer indexing drops an axis, which is only legal where the chunk length is
-        # already 1 - so the inner chunk shape holds a 1 there and can drop it too
-        old_metadata = array_v3_metadata(
-            shape=(4, 90, 180),
-            chunks=(1, 90, 180),
-            data_type=np.dtype("float32"),
-            codecs=[_sharding_codec((1, 45, 45))],
-        )
-
-        updated_metadata = copy_and_replace_metadata(
-            old_metadata, new_shape=(90, 180), new_chunks=(90, 180)
-        )
-
-        assert updated_metadata.shards == (90, 180)
-        assert updated_metadata.chunks == (45, 45)
-
-    def test_unsharded_codecs_untouched(self, array_v3_metadata):
-        old_metadata = array_v3_metadata(
-            shape=(90, 180),
-            chunks=(90, 180),
-            data_type=np.dtype("float32"),
-        )
-
-        updated_metadata = copy_and_replace_metadata(
-            old_metadata, new_shape=(1, 90, 180), new_chunks=(1, 90, 180)
-        )
-
-        assert [codec.to_dict() for codec in updated_metadata.codecs] == [
-            codec.to_dict() for codec in old_metadata.codecs
-        ]
-
-    def test_rejects_chunk_shape_that_is_not_an_axis_change(self, array_v3_metadata):
-        old_metadata = array_v3_metadata(
-            shape=(90, 180),
-            chunks=(90, 180),
-            data_type=np.dtype("float32"),
-            codecs=[_sharding_codec((45, 45))],
-        )
-
-        with pytest.raises(ValueError, match="length-1 axes added or removed"):
-            copy_and_replace_metadata(
-                old_metadata, new_shape=(2, 90, 180), new_chunks=(2, 90, 180)
-            )

--- a/virtualizarr/tests/test_utils.py
+++ b/virtualizarr/tests/test_utils.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
+from conftest import sharding_codec as _sharding_codec
 from virtualizarr.manifests.utils import copy_and_replace_metadata
 
 
@@ -32,3 +33,133 @@ def test_copy_and_replace_metadata(array_v3_metadata):
     # Test other values are still the same
     assert updated_metadata.data_type == old_metadata.data_type
     assert updated_metadata.fill_value == old_metadata.fill_value
+
+
+class TestCopyAndReplaceMetadataSharding:
+    """
+    A sharding codec's inner chunk_shape must have the same ndim as the array, so adding
+    length-1 axes to the outer chunk shape has to add them to the shard config too.
+    """
+
+    def test_prepended_axis(self, array_v3_metadata):
+        old_metadata = array_v3_metadata(
+            shape=(90, 180),
+            chunks=(90, 180),
+            data_type=np.dtype("float32"),
+            codecs=[_sharding_codec((45, 45))],
+        )
+
+        updated_metadata = copy_and_replace_metadata(
+            old_metadata, new_shape=(1, 90, 180), new_chunks=(1, 90, 180)
+        )
+
+        assert updated_metadata.shards == (1, 90, 180)
+        assert updated_metadata.chunks == (1, 45, 45)
+
+    def test_axis_inserted_in_middle(self, array_v3_metadata):
+        old_metadata = array_v3_metadata(
+            shape=(90, 180),
+            chunks=(90, 180),
+            data_type=np.dtype("float32"),
+            codecs=[_sharding_codec((45, 45))],
+        )
+
+        updated_metadata = copy_and_replace_metadata(
+            old_metadata, new_shape=(90, 1, 180), new_chunks=(90, 1, 180)
+        )
+
+        assert updated_metadata.chunks == (45, 1, 45)
+
+    def test_multiple_prepended_axes(self, array_v3_metadata):
+        old_metadata = array_v3_metadata(
+            shape=(90, 180),
+            chunks=(90, 180),
+            data_type=np.dtype("float32"),
+            codecs=[_sharding_codec((45, 45))],
+        )
+
+        updated_metadata = copy_and_replace_metadata(
+            old_metadata, new_shape=(1, 1, 90, 180), new_chunks=(1, 1, 90, 180)
+        )
+
+        assert updated_metadata.chunks == (1, 1, 45, 45)
+
+    def test_nested_shards(self, array_v3_metadata):
+        old_metadata = array_v3_metadata(
+            shape=(90, 180),
+            chunks=(90, 180),
+            data_type=np.dtype("float32"),
+            codecs=[
+                _sharding_codec((45, 90), inner_codecs=[_sharding_codec((45, 45))])
+            ],
+        )
+
+        updated_metadata = copy_and_replace_metadata(
+            old_metadata, new_shape=(1, 90, 180), new_chunks=(1, 90, 180)
+        )
+
+        (outer_shard,) = updated_metadata.codecs
+        assert outer_shard.chunk_shape == (1, 45, 90)
+        (inner_shard,) = outer_shard.codecs
+        assert inner_shard.chunk_shape == (1, 45, 45)
+
+    def test_ambiguous_alignment_when_old_chunks_contain_ones(self, array_v3_metadata):
+        # (1, 45) could align with either the first or second axis of (1, 1, 45), but
+        # both readings insert a 1 next to an existing 1, so the result is the same
+        old_metadata = array_v3_metadata(
+            shape=(1, 180),
+            chunks=(1, 180),
+            data_type=np.dtype("float32"),
+            codecs=[_sharding_codec((1, 45))],
+        )
+
+        updated_metadata = copy_and_replace_metadata(
+            old_metadata, new_shape=(1, 1, 180), new_chunks=(1, 1, 180)
+        )
+
+        assert updated_metadata.chunks == (1, 1, 45)
+
+    def test_dropped_axis(self, array_v3_metadata):
+        # integer indexing drops an axis, which is only legal where the chunk length is
+        # already 1 - so the inner chunk shape holds a 1 there and can drop it too
+        old_metadata = array_v3_metadata(
+            shape=(4, 90, 180),
+            chunks=(1, 90, 180),
+            data_type=np.dtype("float32"),
+            codecs=[_sharding_codec((1, 45, 45))],
+        )
+
+        updated_metadata = copy_and_replace_metadata(
+            old_metadata, new_shape=(90, 180), new_chunks=(90, 180)
+        )
+
+        assert updated_metadata.shards == (90, 180)
+        assert updated_metadata.chunks == (45, 45)
+
+    def test_unsharded_codecs_untouched(self, array_v3_metadata):
+        old_metadata = array_v3_metadata(
+            shape=(90, 180),
+            chunks=(90, 180),
+            data_type=np.dtype("float32"),
+        )
+
+        updated_metadata = copy_and_replace_metadata(
+            old_metadata, new_shape=(1, 90, 180), new_chunks=(1, 90, 180)
+        )
+
+        assert [codec.to_dict() for codec in updated_metadata.codecs] == [
+            codec.to_dict() for codec in old_metadata.codecs
+        ]
+
+    def test_rejects_chunk_shape_that_is_not_an_axis_change(self, array_v3_metadata):
+        old_metadata = array_v3_metadata(
+            shape=(90, 180),
+            chunks=(90, 180),
+            data_type=np.dtype("float32"),
+            codecs=[_sharding_codec((45, 45))],
+        )
+
+        with pytest.raises(ValueError, match="length-1 axes added or removed"):
+            copy_and_replace_metadata(
+                old_metadata, new_shape=(2, 90, 180), new_chunks=(2, 90, 180)
+            )

--- a/virtualizarr/tests/test_writers/test_icechunk.py
+++ b/virtualizarr/tests/test_writers/test_icechunk.py
@@ -1218,3 +1218,55 @@ def test_sharded_array_roundtrip_icechunk(icechunk_repo, tmp_path):
     # Verify data values match
     ic_ds = xr.open_zarr(ro_session.store, zarr_format=3, consolidated=False)
     npt.assert_array_equal(ic_ds["data"].values, data)
+
+
+def test_concat_sharded_arrays_along_new_dim_roundtrip_icechunk(
+    icechunk_repo, tmp_path
+):
+    """
+    Concatenating sharded virtual arrays along a *new* dimension must produce readable
+    data: the shard's inner chunk_shape has to gain the same length-1 axis, and doing so
+    leaves the shard's inner chunk grid, index layout and chunk bytes untouched.
+
+    Regression test for https://github.com/zarr-developers/VirtualiZarr/issues/1076.
+    """
+    datasets, vdss = [], []
+    for i in range(2):
+        filepath = str(tmp_path / f"step_{i}.zarr")
+        data = np.arange(i * 144, (i + 1) * 144, dtype="float32").reshape(12, 12)
+        ds = xr.Dataset({"data": (("x", "y"), data)})
+        ds.to_zarr(
+            filepath,
+            encoding={"data": {"chunks": (3, 3), "shards": (12, 12)}},
+            consolidated=False,
+            zarr_format=3,
+        )
+        datasets.append(ds)
+
+        registry = ObjectStoreRegistry(
+            {f"file://{filepath}": LocalStore(prefix=filepath)}
+        )
+        vdss.append(
+            open_virtual_dataset(url=filepath, registry=registry, parser=ZarrParser())
+        )
+
+    # this is what used to raise: "The shard's `chunk_shape` and array's `shape` need to
+    # have the same number of dimensions."
+    concatenated = xr.concat(vdss, dim="time")
+
+    assert concatenated["data"].shape == (2, 12, 12)
+    assert concatenated["data"].data.metadata.shards == (1, 12, 12)
+    assert concatenated["data"].data.metadata.chunks == (1, 3, 3)
+
+    session = icechunk_repo.writable_session("main")
+    concatenated.vz.to_icechunk(session.store, validate_containers=False)
+    session.commit("concat sharded arrays along a new dim")
+
+    ro_session = icechunk_repo.readonly_session("main")
+    roundtrip = xr.open_zarr(ro_session.store, zarr_format=3, consolidated=False)
+
+    assert roundtrip["data"].shape == (2, 12, 12)
+    # the payoff: every inner chunk of both shards decodes to its original values
+    npt.assert_array_equal(
+        roundtrip["data"].values, xr.concat(datasets, dim="time")["data"].values
+    )


### PR DESCRIPTION
Closes #1076.

A chunk manifest entry locates a whole **shard**, but several operations in `manifests/` read `ArrayV3Metadata.chunks` for that shape — which zarr defines as the *inner* chunk shape when a sharding codec is present (the outer chunk grid is `.shards`). The parsers and the icechunk writer already get this right; the array-op layer did not.

The visible symptom was that concatenating sharded virtual arrays along a new dimension raised:

```
ValueError: The shard's `chunk_shape` and array's `shape` need to have the same number of dimensions.
```

because `stack` grew the array's ndim without touching the shard config. But the same conflation had quieter consequences: `stack`/`broadcast_to` wrote an inner chunk shape back as the *outer* chunk grid, and a no-op slice of a sharded array failed to short-circuit because it compared a chunk-grid selector derived from inner chunks against the shard-shaped manifest grid.

## What's in here

- `manifest_chunk_shape(metadata)` — one accessor for "the region one manifest entry locates", used in `stack`, `broadcast_to`, `concatenate`'s partial-chunk check, `_missing_element_mask`, `apply_selection`, the reindex path, `check_combinable_zarr_arrays`, `ManifestArray.empty_like`, and the oversized-chunk warning.
- `copy_and_replace_metadata` realigns any `sharding_indexed` codec's inner `chunk_shape` when the outer chunk shape gains or loses length-1 axes. Both directions matter: `stack`/`expand_dims`/`broadcast_to` add an axis, integer indexing drops one (only legal where the chunk length is already 1). Nested shards recurse.

Realigning length-1 axes is byte-safe — it leaves the inner chunk grid, the C-order shard index layout, and every inner chunk's bytes untouched — so existing references stay valid rather than needing a rewrite.

## Tests

Written first, all red before the fix:

- `TestCopyAndReplaceMetadataSharding` — prepended/middle/multiple added axes, dropped axis, nested shards, the ambiguous-alignment case where `old_chunks` already contains 1s, unsharded codecs left alone, and rejection of a chunk shape that isn't an axis change.
- `TestSharded` in `test_manifests/test_array.py` — `expand_dims`, `stack`, `broadcast_to`, `concatenate`, plus the indexing paths (no-op full slice, integer index dropping an axis, shard-aligned slice).
- `test_concat_sharded_arrays_along_new_dim_roundtrip_icechunk` — the end-to-end payoff: two sharded Zarr stores, virtualized, concatenated along a new dim, written to Icechunk, and read back element-for-element equal to `xr.concat` of the originals. That's what makes the byte-safety claim concrete rather than asserted.

Full suite: 642 passed, no new mypy errors.

## Why it came up

Building an Icechunk datacube from an archive of per-forecast-hour `.zarr.zip` files (via the new `ZippedZarrParser`), where every variable is a single `(720, 1440)` shard of `(45, 45)` chunks — so every variable tripped this the moment the files were concatenated along `init_time`/`forecast_hour`.