### PR TITLE
Demote Zipped Native Zarr entry in format tiers diagram

### DIFF
--- a/docs/_diagrams/format_tiers.md
+++ b/docs/_diagrams/format_tiers.md
@@ -14,5 +14,5 @@
 | GeoTIFF                |                         | x             | x                            |                            |                       |                              |
 | COG                    |                         | x             | x                            | x                          |                       |                              |
 | Native Zarr (v2 or v3) |                         | x             | x                            | x                          | x                     |                              |
-| Zipped Native Zarr     |                         | x             | x                            | x                          |                       |                              |
+| Zipped Native Zarr     |                         | x             |                              |                            |                       |                              |
 | Icechunk               |                         | x             | x                            | x                          | x                     | x                            |


### PR DESCRIPTION
Updated Zipped Native Zarr entry to demote it to merely "virtualizable"