### PR TITLE
Add summary and release date for v2.7.3

### DIFF
--- a/docs/about/releases.md
+++ b/docs/about/releases.md
@@ -1,6 +1,8 @@
 # Release notes
 
-## v2.7.3 (unreleased)
+## v2.7.3 (7th August 2026)
+
+Makes virtualizing `.zarr.zip` archives dramatically cheaper — building a zipped store's member index now takes a single request instead of one per member, a 6.8x throughput improvement when virtualizing many archives — and fixes sharded virtual arrays losing their shard configuration when concatenated, stacked, broadcast or indexed.
 
 ### New Features
 


### PR DESCRIPTION
Step 2 of the release process for v2.7.3: sets the heading to today's date and adds a high-level summary of the changes since v2.7.2 (the zipped-Zarr member-index request reduction, and the sharded-array shard-config fix).

No blank template for the next release yet — that follows after the release is published, per the contributing guide.