### PR TITLE
Add empty release notes for v2.7.4

### DIFF
--- a/docs/about/releases.md
+++ b/docs/about/releases.md
@@ -1,5 +1,17 @@
 # Release notes
 
+## v2.7.4 (unreleased)
+
+### New Features
+
+### Breaking changes
+
+### Bug fixes
+
+### Documentation
+
+### Internal changes
+
 ## v2.7.3 (7th August 2026)
 
 Makes virtualizing `.zarr.zip` archives dramatically cheaper — building a zipped store's member index now takes a single request instead of one per member, a 6.8x throughput improvement when virtualizing many archives — and fixes sharded virtual arrays losing their shard configuration when concatenated, stacked, broadcast or indexed.


### PR DESCRIPTION
Add a section for upcoming release v2.7.4 with placeholders for new features, breaking changes, bug fixes, documentation, and internal changes.
